### PR TITLE
Serialise CI builds: fix the deps.json write race the v2.4.2 bump exposed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,16 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Build (plugin + tests)
-        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release
+        # -m:1 serialises MSBuild project scheduling. Not for speed obviously, but for correctness:
+        # the test project pins StaticWebAssetsEnabled=false on its ProjectReferences, which makes the
+        # btcpayserver closure build a second time under different global properties than the solution's
+        # own entries -- two builds of the same project, one output directory. On the v2.4.1 graph the
+        # two never collided; the v2.4.2 graph re-timed them and every job on the bump PR failed with
+        # "GenerateDepsFile ... deps.json ... being used by another process". The same class of race is
+        # documented for local fresh-worktree builds. Serialising the scheduler removes the collision at
+        # the cost of wall-clock; if that cost ever matters, the real fix is unifying the global
+        # properties, not removing this flag and hoping the timing holds.
+        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release -m:1
 
       # The Postgres and live-regtest suites skip themselves when their environment variables are
       # unset, so this run covers the in-process tests only. The other two jobs cover the rest.
@@ -109,7 +118,16 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Build (plugin + tests)
-        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release
+        # -m:1 serialises MSBuild project scheduling. Not for speed obviously, but for correctness:
+        # the test project pins StaticWebAssetsEnabled=false on its ProjectReferences, which makes the
+        # btcpayserver closure build a second time under different global properties than the solution's
+        # own entries -- two builds of the same project, one output directory. On the v2.4.1 graph the
+        # two never collided; the v2.4.2 graph re-timed them and every job on the bump PR failed with
+        # "GenerateDepsFile ... deps.json ... being used by another process". The same class of race is
+        # documented for local fresh-worktree builds. Serialising the scheduler removes the collision at
+        # the cost of wall-clock; if that cost ever matters, the real fix is unifying the global
+        # properties, not removing this flag and hoping the timing holds.
+        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release -m:1
 
       - name: Store contract & concurrency tests
         env:
@@ -163,7 +181,16 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Build (plugin + tests)
-        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release
+        # -m:1 serialises MSBuild project scheduling. Not for speed obviously, but for correctness:
+        # the test project pins StaticWebAssetsEnabled=false on its ProjectReferences, which makes the
+        # btcpayserver closure build a second time under different global properties than the solution's
+        # own entries -- two builds of the same project, one output directory. On the v2.4.1 graph the
+        # two never collided; the v2.4.2 graph re-timed them and every job on the bump PR failed with
+        # "GenerateDepsFile ... deps.json ... being used by another process". The same class of race is
+        # documented for local fresh-worktree builds. Serialising the scheduler removes the collision at
+        # the cost of wall-clock; if that cost ever matters, the real fix is unifying the global
+        # properties, not removing this flag and hoping the timing holds.
+        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release -m:1
 
       # No API key needed: regtest accepts a null one (see docs/testing.md). This talks to the real
       # Lightspark-hosted regtest SSP over the network and loads the SDK's native library.
@@ -230,7 +257,16 @@ jobs:
 
       - name: Build (plugin + tests)
         if: steps.gate.outputs.funded == 'true'
-        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release
+        # -m:1 serialises MSBuild project scheduling. Not for speed obviously, but for correctness:
+        # the test project pins StaticWebAssetsEnabled=false on its ProjectReferences, which makes the
+        # btcpayserver closure build a second time under different global properties than the solution's
+        # own entries -- two builds of the same project, one output directory. On the v2.4.1 graph the
+        # two never collided; the v2.4.2 graph re-timed them and every job on the bump PR failed with
+        # "GenerateDepsFile ... deps.json ... being used by another process". The same class of race is
+        # documented for local fresh-worktree builds. Serialising the scheduler removes the collision at
+        # the cost of wall-clock; if that cost ever matters, the real fix is unifying the global
+        # properties, not removing this flag and hoping the timing holds.
+        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release -m:1
 
       # One wallet, three tests that each move its money: the suite's collection is declared with
       # DisableParallelization, and the balance lags settlement by ~20 s, so this must not be sped up.

--- a/.github/workflows/spark-regtest-wallet.yml
+++ b/.github/workflows/spark-regtest-wallet.yml
@@ -71,7 +71,16 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Build (plugin + tests)
-        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release
+        # -m:1 serialises MSBuild project scheduling. Not for speed obviously, but for correctness:
+        # the test project pins StaticWebAssetsEnabled=false on its ProjectReferences, which makes the
+        # btcpayserver closure build a second time under different global properties than the solution's
+        # own entries -- two builds of the same project, one output directory. On the v2.4.1 graph the
+        # two never collided; the v2.4.2 graph re-timed them and every job on the bump PR failed with
+        # "GenerateDepsFile ... deps.json ... being used by another process". The same class of race is
+        # documented for local fresh-worktree builds. Serialising the scheduler removes the collision at
+        # the cost of wall-clock; if that cost ever matters, the real fix is unifying the global
+        # properties, not removing this flag and hoping the timing holds.
+        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release -m:1
 
       # No API key: regtest accepts a null one. The tool prints the identity pubkey, the balance and the static
       # deposit address to the job log and to the run summary, and asserts the mnemonic is in neither.


### PR DESCRIPTION
Every job on the auto-generated v2.4.2 bump PR (#2) failed at the build step with `GenerateDepsFile ... deps.json ... being used by another process`. Not an incompatibility: the test project pins `StaticWebAssetsEnabled=false` on its ProjectReferences, forking the btcpayserver closure into a second global-property tree that builds concurrently with the solution's own entries into the same output directory. The v2.4.1 graph never happened to collide; v2.4.2 re-timed it and all three build jobs collided simultaneously.

`-m:1` on the solution builds serialises MSBuild scheduling, removing the collision. Same race class as the documented local fresh-worktree gotcha. If wall-clock ever matters, the proper fix is unifying global properties across the graph.