### PR TITLE
Release 0.1.1

### DIFF
--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -45,7 +45,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>0.1.0</Version>
+    <Version>0.1.1</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/BTCPayServer.Plugins.Flint/Constants.cs
+++ b/BTCPayServer.Plugins.Flint/Constants.cs
@@ -80,8 +80,9 @@ public static class Constants
     /// <remarks>
     /// Informational — nothing at runtime reads it. It exists so the update automation has a version to bump that
     /// is not the support floor, and so a reader can see at a glance which release the assembly was built against.
-    /// It currently equals <see cref="MinBTCPayServerVersion"/>, which is the safe state, not a redundancy: the two
-    /// stay separate constants so a submodule bump can move this one without silently moving the floor.
+    /// It is currently one patch release ahead of <see cref="MinBTCPayServerVersion"/>: the v2.4.2 submodule bump
+    /// moved this constant and left the floor alone, which is exactly what the two being separate constants is
+    /// for — a bump here must never silently drop every host below it.
     /// </remarks>
     public const string BuiltAgainstBTCPayServerVersion = "2.4.2";
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
+## [0.1.1] — 2026-08-14
+
+A dependency-only release. No plugin source changed between 0.1.0 and this; the packaged artifact
+differs from 0.1.0 only in the Spark SDK's bundled native libraries. Upgrading is an ordinary plugin
+update — the identifier, the settings key, the Postgres schema, the SDK storage directory and the
+data-protection purpose are all untouched, so **no recovery phrase needs re-importing** and no
+balance has to be swept out first. The 0.1.0 migration warning applies to arriving from the
+predecessor plugin, not to this step.
+
+### Changed
+
+- **The Spark SDK is now 0.22.0**, up from the 0.19.2 that 0.1.0 shipped. Breez published no release
+  notes across that range, so the bump was reviewed by reading the diff of the surface instead: it is
+  additive — batch sends, CPFP, prepared unilateral exit, passkeys, none of which this plugin calls —
+  with one breaking change that reached us. `SdkException.InsufficientFunds` stopped being a
+  payload-free variant and now carries the identifier of whichever balance was short, which broke two
+  test call sites and no production code. `SparkErrors.IsInsufficientFunds` classifies a token
+  shortfall the same as a sat shortfall, because the plugin only ever spends sats and would otherwise
+  report a token error as "state unknown" — the classification that makes a sweep unsafe to retry.
+  The reason to ship a bump with no known fix in it is that the SDK is pre-1.0 and releases roughly
+  monthly: staying near the tip keeps each upgrade a small step that can be read in an afternoon,
+  rather than a large one taken later under pressure.
+- **The plugin is built against BTCPay Server 2.4.2**, up from 2.4.1. This is the release it is
+  compiled and tested against, not a new requirement: the declared support floor is unchanged at
+  2.4.1, so every host that can run 0.1.0 can run this.
+
 ## [0.1.0] — 2026-08-08
 
 The first release under the name **Flint**, and the first from this repository.


### PR DESCRIPTION
Cuts 0.1.1. The shipped delta from 0.1.0 is one dependency: **Breez.Sdk.Spark 0.19.2 → 0.22.0**. No plugin source changed between the two releases — the `.btcpay` differs only in the SDK's bundled native libraries.

- `<Version>` → 0.1.1, with the matching CHANGELOG heading `PluginVersionTests` asserts against.
- The changelog entry states plainly that this is a dependency-only release, that Breez published no release notes across the range, and that the bump was reviewed by reading the surface instead.
- Upgrade path is an ordinary plugin update: identifier, settings key, Postgres schema, SDK storage directory and data-protection purpose are all untouched, so no recovery phrase re-import and no pre-emptive sweep.
- Support floor stays at 2.4.1; only `BuiltAgainstBTCPayServerVersion` moved to 2.4.2. The Constants.cs remark claiming the two are equal went stale with that bump and is corrected here.

**Not to be tagged until it has been installed and exercised on `oldman` and `btcpay-stg`.** The point of testing a dependency-only release is precisely the thing the unit suite cannot see: the new native libraries loading, and payments moving through them on a real host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)