### PR TITLE
Move the tests to Microsoft.Testing.Platform, and take xunit.v3 4.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,8 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  # Test-project NuGet packages (xunit, Microsoft.NET.Test.Sdk, ...). Separate entry because
+  # Test-project NuGet packages -- xunit.v3, and since the move to Microsoft.Testing.Platform that is the
+  # whole list; the VSTest host and adapter it used to name here are gone. Separate entry because
   # Dependabot's nuget updater scans one project directory per entry.
   - package-ecosystem: "nuget"
     directory: "/BTCPayServer.Plugins.Flint.Tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,12 @@ jobs:
 
       # One wallet, three tests that each move its money: the suite's collection is declared with
       # DisableParallelization, and the balance lags settlement by ~20 s, so this must not be sped up.
+      #
+      # --output Detailed is Microsoft.Testing.Platform's equivalent of the VSTest
+      # `--logger "console;verbosity=detailed"` this used before the test project moved to MTP (see the
+      # test .csproj). Worth knowing if it is ever edited back: MTP does not reject the old flag, it takes
+      # it as a filter, matches nothing, and exits 5 with "Zero tests ran" -- red, but red for a reason
+      # that reads nothing like a bad command line.
       - name: Funded regtest suite
         if: steps.gate.outputs.funded == 'true'
         env:
@@ -289,7 +295,7 @@ jobs:
         run: >
           dotnet test BTCPayServer.Plugins.Flint.Tests/BTCPayServer.Plugins.Flint.Tests.csproj
           --configuration Release --no-build --filter "Category=FundedRegtest"
-          --logger "console;verbosity=detailed"
+          --output Detailed
 
       # always(), because a failed run is exactly when the captured log is worth reading. The fixture writes
       # the artefact from DisposeAsync, so it exists even when an assertion failed — and the preimage assertion

--- a/.github/workflows/spark-regtest-wallet.yml
+++ b/.github/workflows/spark-regtest-wallet.yml
@@ -51,7 +51,7 @@ jobs:
             echo "::error::The repository secret SPARK_REGTEST_SEED is not set, so there is no wallet to look up."
             echo "Generate a seed on your own machine first — never here, the generator refuses to run in CI:"
             echo "  SPARK_REGTEST_WALLET_GENERATE=1 dotnet test \\"
-            echo "    --filter 'FullyQualifiedName~Generate_a_wallet_mnemonic' -l 'console;verbosity=detailed'"
+            echo "    --filter 'FullyQualifiedName~Generate_a_wallet_mnemonic' --output Detailed"
             echo "Then store it as SPARK_REGTEST_SEED under Settings > Secrets and variables > Actions,"
             echo "and run this workflow again. Full runbook: docs/testing.md, 'A funded regtest wallet for CI'."
             exit 1
@@ -84,6 +84,12 @@ jobs:
 
       # No API key: regtest accepts a null one. The tool prints the identity pubkey, the balance and the static
       # deposit address to the job log and to the run summary, and asserts the mnemonic is in neither.
+      #
+      # --output Detailed is load-bearing here in a way it is not elsewhere: this job exists to *read* what the
+      # tool printed, and the default verbosity does not show a passing test's output. It is Microsoft.Testing.
+      # Platform's replacement for the VSTest `--logger "console;verbosity=detailed"` this used before the test
+      # project moved to MTP (see the test .csproj). MTP does not reject the old flag -- it takes it as a
+      # filter, matches nothing, and exits 5 with "Zero tests ran".
       - name: Look up the deposit address
         env:
           SPARK_REGTEST_SEED: ${{ secrets.SPARK_REGTEST_SEED }}
@@ -91,4 +97,4 @@ jobs:
           dotnet test BTCPayServer.Plugins.Flint.Tests/BTCPayServer.Plugins.Flint.Tests.csproj
           --configuration Release --no-build
           --filter "FullyQualifiedName~Print_the_funding_details"
-          --logger "console;verbosity=detailed"
+          --output Detailed

--- a/BTCPayServer.Plugins.Flint.Tests/BTCPayServer.Plugins.Flint.Tests.csproj
+++ b/BTCPayServer.Plugins.Flint.Tests/BTCPayServer.Plugins.Flint.Tests.csproj
@@ -13,15 +13,38 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <!--
+      An xunit.v3 test project is a real executable: the runner is a Main in the test assembly, not an
+      external host loading it. This was previously implicit, set for us by Microsoft.NET.Test.Sdk, and
+      dropping that package (see below) is what made it need saying. Without it the build fails outright
+      with "xUnit.net v3 test projects must be executable", so there is no silent-misconfiguration risk here.
+    -->
+    <OutputType>Exe</OutputType>
+    <!--
+      Run the tests through Microsoft.Testing.Platform rather than xunit's own console runner. Not a
+      preference: xunit.v3 4.0.0 carries MTP 2.3.3, which dropped the VSTest bridge on the .NET 10 SDK, so
+      the VSTest path this project used through 3.2.2 now fails at `dotnet test` with "Testing with VSTest
+      target is no longer supported". The other half of the switch is the repository-root global.json, which
+      tells `dotnet test` to speak MTP; both are required, and setting only one leaves the same error.
+
+      Nothing in the test *code* changes — MTP is a host, not an assertion library — and the VSTest
+      `filter "Category=…"` syntax the CI jobs and docs/testing.md use still works, because xunit's MTP
+      runner accepts it verbatim. The one casualty is the VSTest console logger option; its replacement is
+      `output Detailed`. See docs/testing.md, which spells both out with their leading dashes (XML comments
+      cannot carry a double hyphen, which is why this one does not).
+    -->
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
 
+  <!--
+    Microsoft.NET.Test.Sdk and xunit.runner.visualstudio are both deliberately absent: the first is the VSTest
+    host and the second is its xunit adapter, and under MTP neither is on the path that runs a test. Keeping
+    them builds and passes, so their absence is easy to "fix" by mistake; they were removed because a
+    VSTest adapter sitting in an MTP project is a standing invitation to debug the wrong runner, and because
+    Dependabot would otherwise keep opening bumps for packages this project no longer executes.
+  -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 
   <!--

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,6 +19,14 @@ spending again, and a `Payment` whose amount is already net of the fee under `Fe
 is — a fake that echoed the request back instead is what let the sweep message double-subtract the fee on
 mainnet). A cooperative fake would let through precisely the bugs these tests exist to catch.
 
+The suite runs on **Microsoft.Testing.Platform**, not VSTest: xunit.v3 4.0.0 dropped the VSTest bridge on the
+.NET 10 SDK. Two things turn that on and both are needed — `UseMicrosoftTestingPlatformRunner` in the test
+`.csproj`, and the repository-root `global.json`, which is what makes plain `dotnet test` speak MTP. The
+`--filter "Category=…"` syntax below is unaffected; MTP's xunit runner accepts VSTest filters verbatim. What
+does change is the console-verbosity flag: `--logger "console;verbosity=detailed"` (and its `-l` short form)
+is VSTest-only, and **MTP does not reject it** — it reads it as a filter, matches no tests, and exits 5 with
+"Zero tests ran". Use `--output Detailed` instead.
+
 It also covers what the compiler cannot: `ViewComponentCompatibilityTests` resolves every `<vc:…>` tag,
 partial, layout and UI-extension target the plugin names as a string against the components and views that
 actually exist in the pinned submodule. Those are resolved by name at render time, so a green build against
@@ -75,7 +83,7 @@ not burned, because sweeps are directed at the wallet's own static deposit addre
 
 ```bash
 SPARK_REGTEST_WALLET_GENERATE=1 dotnet test \
-  --filter "FullyQualifiedName~Generate_a_wallet_mnemonic" -l "console;verbosity=detailed"
+  --filter "FullyQualifiedName~Generate_a_wallet_mnemonic" --output Detailed
 ```
 
 This needs no network, so it works from a machine whose IP the SSP blocks. The generator **asserts that

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
Supersedes #12, which could not go green on its own.

## Why the bump needed a migration

xunit.v3 4.0.0 carries Microsoft.Testing.Platform 2.3.3, which dropped the VSTest bridge on the .NET 10 SDK. On #12 the build itself was clean — `0 Error(s)` — and all four jobs still failed at `dotnet test`:

```
Microsoft.Testing.Platform.MSBuild.targets(320,5): error : Testing with VSTest target is no longer
supported by Microsoft.Testing.Platform on .NET 10 SDK and later.
```

The bump is not separable from the migration: 4.0.0 cannot run under the runner this repository was using.

## What changed

**The runner.** Two halves, and setting either alone leaves the identical error: `UseMicrosoftTestingPlatformRunner` in the test project, and a repository-root `global.json` declaring the test runner, which is what makes plain `dotnet test` speak MTP. The solution carries no btcpayserver test projects, so a root `global.json` reaches nothing in the submodule.

**No test source is touched**, and `--filter "Category=…"` still works everywhere it was used — xunit's MTP runner accepts VSTest filters verbatim. The one casualty is `--logger "console;verbosity=detailed"`, which is VSTest-only; both workflows that passed it now pass `--output Detailed`.

That last one is worth knowing rather than merely fixing: **MTP does not reject the old flag.** It takes it as a filter, matches nothing, and exits 5 with "Zero tests ran" — red, but red for a reason that reads nothing like a bad command line. In `spark-regtest-wallet` the flag is load-bearing rather than cosmetic, since the job exists to read what the tool printed and the default verbosity hides a passing test's output.

**Two packages removed.** `Microsoft.NET.Test.Sdk` and `xunit.runner.visualstudio` are the VSTest host and its xunit adapter, and under MTP neither is on the path that runs a test. Keeping them builds and passes, so this is a deliberate removal, not a required one — a VSTest adapter in an MTP project invites debugging the wrong runner, and Dependabot would keep opening bumps for packages nothing executes. Dropping Test.Sdk is what made `OutputType=Exe` need saying out loud; it had been setting it for us.

## Verification

Against the .NET 10.0.302 SDK locally:

- clean Release build of the solution — 0 errors
- full suite: **1135 tests, 1051 passed, 84 skipped, 0 failed** — the same totals as before the migration
- each CI filter selects its expected set: Postgres 77, Integration 2, FundedRegtest 3
- `spark-regtest-wallet`'s generator still prints its banner under `--output Detailed`

The store job's run against real Postgres and the two live-network jobs are left to CI, which has the database and the SSP.