### PR TITLE
Label sweep transactions in the wallet; move deposits behind Advanced

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeSweepTransactionLabeler.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeSweepTransactionLabeler.cs
@@ -1,0 +1,24 @@
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Services;
+
+namespace BTCPayServer.Plugins.Flint.Tests.Fakes;
+
+/// <summary>
+/// Records what the engine asked to label, so tests can assert a sweep's transaction gets labelled in the
+/// store's wallet — and that a refusal or a cross-chain delivery does not.
+/// </summary>
+/// <remarks>
+/// The cross-chain gate lives in the production labeler (it is a fact about what appears in a Bitcoin
+/// wallet), so this fake records <em>every</em> call: a test asserting "no label" is then asserting the
+/// engine never asked, which is the stronger claim.
+/// </remarks>
+public sealed class FakeSweepTransactionLabeler : ISweepTransactionLabeler
+{
+    public List<(string StoreId, string TxId, SweepDestinationKind Kind)> Labeled { get; } = [];
+
+    public Task LabelAsync(SweepRecord record, string txId, CancellationToken cancellationToken = default)
+    {
+        Labeled.Add((record.StoreId, txId, record.DestinationKind));
+        return Task.CompletedTask;
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkSurfaceHarness.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkSurfaceHarness.cs
@@ -224,6 +224,7 @@ public sealed class SparkSurfaceHarness
             settings, runtime, sweepRecords, resolver,
             new CrossChainRouteResolver(NullLogger<CrossChainRouteResolver>.Instance),
             valueOracle,
+            new FakeSweepTransactionLabeler(),
             TimeProvider.System, NullLogger<SparkSweepEngine>.Instance);
 
         var provisionerLog = new CapturingLogger<SparkStoreProvisioner>();

--- a/BTCPayServer.Plugins.Flint.Tests/FundedRegtest/SparkFundedRegtestTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/FundedRegtest/SparkFundedRegtestTests.cs
@@ -397,6 +397,7 @@ public class SparkFundedRegtestTests
                 NullLogger<SweepDestinationResolver>.Instance),
             new CrossChainRouteResolver(NullLogger<CrossChainRouteResolver>.Instance),
             new FakeCrossChainValueOracle(),
+            new FakeSweepTransactionLabeler(),
             TimeProvider.System,
             NullLogger<SparkSweepEngine>.Instance);
     }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
@@ -1529,6 +1529,7 @@ public class SparkCrossChainSweepTests
             settings, runtime, records, resolver,
             new CrossChainRouteResolver(NullLogger<CrossChainRouteResolver>.Instance),
             oracle,
+            new FakeSweepTransactionLabeler(),
             time, NullLogger<SparkSweepEngine>.Instance);
 
         return new TestHarness(engine, sdk, records, settings, time, log, oracle, runtime);

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
@@ -39,7 +39,8 @@ public class SparkSweepEngineTests
         FakeSparkStoreRuntime Runtime,
         StubTimeProvider Time,
         WriteLog Log,
-        CapturingLogger<SparkSweepEngine> Logger);
+        CapturingLogger<SparkSweepEngine> Logger,
+        FakeSweepTransactionLabeler Labeler);
 
     /// <param name="sweep">
     /// The store's sweep configuration. Defaults to enabled with the shipped defaults, since almost every test is
@@ -63,6 +64,7 @@ public class SparkSweepEngineTests
         var settings = new FakeSparkStoreSettingsStore();
         var time = new StubTimeProvider(Origin);
         var logger = new CapturingLogger<SparkSweepEngine>();
+        var labeler = new FakeSweepTransactionLabeler();
 
         settings.Settings[StoreId] = new SparkSettings
         {
@@ -81,8 +83,8 @@ public class SparkSweepEngineTests
             NullLogger<SweepDestinationResolver>.Instance);
 
         var engine = new SparkSweepEngine(
-            settings, runtime, records, resolver, Routes(), Oracle(), time, logger);
-        return new Harness(engine, sdk, records, addresses, settings, runtime, time, log, logger);
+            settings, runtime, records, resolver, Routes(), Oracle(), labeler, time, logger);
+        return new Harness(engine, sdk, records, addresses, settings, runtime, time, log, logger, labeler);
     }
 
     /// <summary>
@@ -140,6 +142,48 @@ public class SparkSweepEngineTests
 
         // FeesIncluded genuinely drains: the balance lands on exactly the reserve.
         Assert.Equal(50_000, h.Sdk.BalanceSats);
+    }
+
+    [Fact]
+    public async Task A_sweep_labels_its_transaction_in_the_stores_wallet()
+    {
+        // The label is what tells a merchant reading their Bitcoin wallet where the incoming transaction came
+        // from; without it a sweep is money that arrived with no explanation.
+        var h = CreateHarness();
+
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        var labeled = Assert.Single(h.Labeler.Labeled);
+        Assert.Equal(StoreId, labeled.StoreId);
+        Assert.Equal(h.Sdk.NextOnchainTxId, labeled.TxId);
+        Assert.Equal(SweepDestinationKind.BitcoinAddress, labeled.Kind);
+    }
+
+    [Fact]
+    public async Task A_pass_that_sweeps_nothing_labels_nothing()
+    {
+        var h = CreateHarness(balanceSats: 10_000);
+
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        Assert.Empty(h.Labeler.Labeled);
+    }
+
+    [Fact]
+    public async Task A_crash_recovered_sweep_labels_its_transaction()
+    {
+        // The reconciliation path learns the txid from the SDK's payment rather than from the row, so the label
+        // must land there too — a sweep whose send raced a crash is exactly the transaction a merchant will go
+        // looking for.
+        var h = CreateHarness(balanceSats: 10_000);
+        const string key = "5d0a1cf1-2b3e-4b17-9c8a-7f0c2a0f9e21";
+        await h.Records.AddAsync(NewPending(key), Ct);
+        h.Sdk.Seed(CompletedExit(key, 450_000, 2_190));
+
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        var labeled = Assert.Single(h.Labeler.Labeled);
+        Assert.Equal("txid-recovered", labeled.TxId);
     }
 
     [Fact]
@@ -1215,7 +1259,8 @@ public class SparkSweepEngineTests
         var runtime = new FakeSparkStoreRuntime();
         runtime.Clients[StoreId] = h.Sdk;
         var engine = new SparkSweepEngine(
-            h.Settings, runtime, h.Records, resolver, Routes(), Oracle(), h.Time,
+            h.Settings, runtime, h.Records, resolver, Routes(), Oracle(),
+            new FakeSweepTransactionLabeler(), h.Time,
             NullLogger<SparkSweepEngine>.Instance);
 
         var first = engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);

--- a/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
+++ b/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
@@ -271,7 +271,7 @@ public class SparkController : Controller
         _logger.LogWarning(
             "Store {StoreId}: Spark was set up but sweeping could not be enabled from the setup page: {Reason}",
             storeId, reason);
-        return $"Sweeping was not turned on: {reason} You can set it up on the Spark sweeps page.";
+        return $"Sweeping was not turned on: {reason} You can set it up on the Sweeps page.";
     }
 
     #endregion

--- a/BTCPayServer.Plugins.Flint/Services/BTCPayWalletSweepTransactionLabeler.cs
+++ b/BTCPayServer.Plugins.Flint/Services/BTCPayWalletSweepTransactionLabeler.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Data;
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Services;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>
+/// The real <see cref="ISweepTransactionLabeler"/>, over core's <c>WalletRepository</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why the label goes on the transaction and not only on the address.</b> The reserving path already writes
+/// <c>generatedBy: "Spark sweep"</c> onto the address object, but the wallet's transactions list looks up wallet
+/// objects of type <c>tx</c> alone — address metadata never reaches those rows (only the coin-selection view
+/// merges it). So without this, a sweep lands in the store's Bitcoin wallet as an anonymous incoming
+/// transaction, which for money that moved on its own is the wrong default. This writes the same kind of
+/// transaction attachment core's payouts and invoices write, so the row gets a <c>flint-sweep</c> chip with a
+/// tooltip, filterable like any other label.
+/// </para>
+/// <para>
+/// <b>Best-effort by contract.</b> Every call site runs after money has already moved; a labelling failure is
+/// logged and swallowed, because there is no version of "retry the sweep" that makes a missing label worth it.
+/// The write itself is idempotent — <c>EnsureCreated</c> ignores rows that already exist — so the two resolution
+/// paths (fresh send, crash reconciliation) and a Sent→Confirmed promotion can all call it for one transaction.
+/// </para>
+/// </remarks>
+public sealed class BTCPayWalletSweepTransactionLabeler : ISweepTransactionLabeler
+{
+    /// <summary>Spark is Bitcoin-only, and so is every transaction this labels.</summary>
+    private const string CryptoCode = "BTC";
+
+    /// <summary>
+    /// The attachment type, which is also the chip text in the wallet's transactions list and the label a
+    /// merchant can filter by. Kebab-case like core's own (<c>payout</c>, <c>payment-request</c>).
+    /// </summary>
+    internal const string AttachmentType = "flint-sweep";
+
+    /// <summary>Shown when the merchant hovers the chip. Core's generic tag renderer reads it from the data.</summary>
+    internal const string Tooltip = "Swept from this store's Spark wallet by the Flint plugin";
+
+    private readonly WalletRepository _walletRepository;
+    private readonly ILogger<BTCPayWalletSweepTransactionLabeler> _logger;
+
+    public BTCPayWalletSweepTransactionLabeler(
+        WalletRepository walletRepository,
+        ILogger<BTCPayWalletSweepTransactionLabeler> logger)
+    {
+        _walletRepository = walletRepository;
+        _logger = logger;
+    }
+
+    public async Task LabelAsync(SweepRecord record, string txId, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        ArgumentException.ThrowIfNullOrEmpty(txId);
+
+        // A cross-chain delivery never appears in the store's Bitcoin wallet, so there is no transaction row
+        // for a label to decorate — the provider's Spark-side transfer is not an on-chain transaction at all.
+        //
+        // Both Bitcoin destination modes are labelled, deliberately. The label is a row keyed by txid that only
+        // ever renders when the wallet actually contains the transaction: a sweep into the store's wallet always
+        // does, and a sweep to a fixed address does exactly when that address turns out to be one the store's
+        // wallet watches — which is when a merchant would want the label most. For a genuinely external address
+        // the row is inert, which costs nothing.
+        if (record.DestinationKind is not SweepDestinationKind.BitcoinAddress)
+            return;
+
+        try
+        {
+            // The id makes the sweep findable from the wallet object later; the tooltip is what the merchant
+            // reads. No link, deliberately: this runs on a background pass with no request context, and a
+            // hand-built root-relative URL would break under a non-root path base.
+            await _walletRepository.AddWalletTransactionAttachment(
+                    new WalletId(record.StoreId, CryptoCode),
+                    txId,
+                    [new Attachment(AttachmentType, record.IdempotencyKey, new JObject { ["tooltip"] = Tooltip })],
+                    WalletObjectData.Types.Tx)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Store {StoreId}: could not label sweep transaction {TxId} in the store's wallet",
+                record.StoreId, txId);
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/ISweepTransactionLabeler.cs
+++ b/BTCPayServer.Plugins.Flint/Services/ISweepTransactionLabeler.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Plugins.Flint.Data;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>
+/// Labels a sweep's on-chain transaction in the store's BTCPay wallet, so the transactions list says where
+/// the money came from.
+/// </summary>
+/// <remarks>
+/// A seam over core's <c>WalletRepository</c> for the same reason <see cref="ISweepAddressSource"/> is one:
+/// the repository is a concrete class over the application database, and the engine's economics are unit-tested
+/// without either. Implementations must be best-effort — a label that cannot be written must never fail or
+/// retry a sweep that has already moved money.
+/// </remarks>
+public interface ISweepTransactionLabeler
+{
+    /// <summary>
+    /// Labels <paramref name="txId"/> in the wallet of the store that owns <paramref name="record"/>.
+    /// </summary>
+    /// <param name="record">The sweep the transaction belongs to. Decides whether a label applies at all.</param>
+    /// <param name="txId">
+    /// The transaction id, passed separately because the caller may hold it before it is mirrored onto the
+    /// record — the reconciliation path learns it from the SDK's payment, not from the row.
+    /// </param>
+    Task LabelAsync(SweepRecord record, string txId, CancellationToken cancellationToken = default);
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
@@ -206,6 +206,7 @@ public sealed class SparkSweepEngine
     private readonly CrossChainRouteResolver _routes;
     private readonly ICrossChainValueOracle _valueOracle;
     private readonly TimeProvider _timeProvider;
+    private readonly ISweepTransactionLabeler _transactionLabeler;
     private readonly ILogger<SparkSweepEngine> _logger;
 
     /// <summary>
@@ -221,6 +222,7 @@ public sealed class SparkSweepEngine
         SweepDestinationResolver destinations,
         CrossChainRouteResolver routes,
         ICrossChainValueOracle valueOracle,
+        ISweepTransactionLabeler transactionLabeler,
         TimeProvider timeProvider,
         ILogger<SparkSweepEngine> logger)
     {
@@ -230,6 +232,7 @@ public sealed class SparkSweepEngine
         _destinations = destinations;
         _routes = routes;
         _valueOracle = valueOracle;
+        _transactionLabeler = transactionLabeler;
         _timeProvider = timeProvider;
         _logger = logger;
     }
@@ -1943,6 +1946,12 @@ public sealed class SparkSweepEngine
                 "Store {StoreId}: sweep {IdempotencyKey} resolved as {Status} "
                 + "(fee {FeeSats} sat, txid {TxId})",
                 storeId, record.IdempotencyKey, status, payment.FeeSats, payment.TxId ?? "unknown");
+
+            // The reconciliation path learns the txid from the SDK's payment rather than from the row, so this
+            // covers a sweep whose send raced a crash — the label lands when the fate is finally known. The
+            // write is idempotent, so a Sent row later promoted to Confirmed labels once.
+            if (status is SweepRecordStatus.Sent or SweepRecordStatus.Confirmed && payment.TxId is not null)
+                await _transactionLabeler.LabelAsync(record, payment.TxId, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -1994,6 +2003,12 @@ public sealed class SparkSweepEngine
         record.DeliveredAmountBaseUnits = deliveredBaseUnits ?? record.DeliveredAmountBaseUnits;
         record.ProviderOrderId = providerOrderId ?? record.ProviderOrderId;
         record.CompletedAt = now;
+
+        // After the resolution is durable, never before: the label decorates a transaction that happened, and a
+        // labelling failure is logged and swallowed inside the labeler rather than allowed to disturb a sweep
+        // that has already moved money.
+        if (status is SweepRecordStatus.Sent or SweepRecordStatus.Confirmed && txId is not null)
+            await _transactionLabeler.LabelAsync(record, txId, cancellationToken).ConfigureAwait(false);
 
         return new SweepRunResult(kind, reason, record);
     }

--- a/BTCPayServer.Plugins.Flint/SparkPlugin.cs
+++ b/BTCPayServer.Plugins.Flint/SparkPlugin.cs
@@ -126,6 +126,10 @@ public class SparkPlugin : BaseBTCPayServerPlugin
         // the resolver holds the rules about which mode wins and when to refuse, and is unit-tested against a fake
         // of the source.
         services.AddSingleton<ISweepAddressSource, BTCPayWalletSweepAddressSource>();
+
+        // Labels a sweep's transaction in the store's wallet once its txid is known, so the transactions list
+        // says where the money came from instead of showing an anonymous incoming transaction.
+        services.AddSingleton<ISweepTransactionLabeler, BTCPayWalletSweepTransactionLabeler>();
         services.AddSingleton(provider =>
         {
             // The chain is fixed for the life of the process, so it is resolved once here rather than per sweep.

--- a/BTCPayServer.Plugins.Flint/Views/Shared/Spark/SparkNav.cshtml
+++ b/BTCPayServer.Plugins.Flint/Views/Shared/Spark/SparkNav.cshtml
@@ -11,7 +11,6 @@
         Flint             status once configured, setup before that
           Sweeps          sweep configuration and history
           Stable Balance  mainnet only
-          Deposits        on-chain top-ups and anything stuck
           Advanced        wallet details and the settings most stores never touch
 
     Core passes a MainNavViewModel here and the store on it is the authoritative id — HttpContext.GetStoreData
@@ -24,8 +23,10 @@
     the destination for the same reason — the setup page requires CanModifyStoreSettings, so offering the link
     to a view-only user would only ever produce an access-denied page.
 
-    Removal has no entry: it is a destructive action reached from the Advanced page, next to the state it
-    destroys.
+    Removal and deposits have no entry. Removal is a destructive action reached from the Advanced page, next
+    to the state it destroys. Deposits are the exception, not a flow: a Spark wallet is funded by customers
+    paying invoices, so manual top-ups live behind the Advanced page — and when a deposit is actually stuck,
+    the status page's alert links straight to them.
 *@
 @{
     var storeId = SparkNavStoreId.From(Model) ?? Context.GetCurrentStoreId();
@@ -101,12 +102,6 @@
                 </a>
             </li>
         }
-        <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
-            <a layout-menu-item="@SparkNavPages.Deposits" asp-area="" asp-controller="Spark"
-               asp-action="Deposit" asp-route-storeId="@storeId">
-                <span>Deposits</span>
-            </a>
-        </li>
         <li class="nav-item nav-item-sub" permission="@Policies.CanViewStoreSettings">
             <a layout-menu-item="@SparkNavPages.Advanced" asp-area="" asp-controller="Spark"
                asp-action="Advanced" asp-route-storeId="@storeId">

--- a/BTCPayServer.Plugins.Flint/Views/Spark/Advanced.cshtml
+++ b/BTCPayServer.Plugins.Flint/Views/Spark/Advanced.cshtml
@@ -77,6 +77,16 @@
             </tbody>
         </table>
 
+        <h3 class="mt-5 mb-3">On-chain deposits</h3>
+        <p class="text-secondary">
+            The wallet is funded by customers paying invoices — it never needs a top-up to work. Deposits
+            exist for the rare store that wants to move its own Bitcoin onto Spark.
+        </p>
+        <a class="btn btn-secondary" asp-action="Deposit" asp-route-storeId="@Model.StoreId"
+           id="SparkDepositLink">
+            Deposit address and unclaimed deposits
+        </a>
+
         <form method="post" asp-action="AdvancedSweep" asp-route-storeId="@Model.StoreId"
               permission="@Policies.CanModifyStoreSettings">
             <h3 class="mt-5 mb-3">Sweep tuning</h3>

--- a/BTCPayServer.Plugins.Flint/Views/Spark/Deposit.cshtml
+++ b/BTCPayServer.Plugins.Flint/Views/Spark/Deposit.cshtml
@@ -1,11 +1,15 @@
 @model SparkDepositViewModel
 @{
-    ViewData.SetLayoutModel(new LayoutModel(SparkNavPages.Deposits, "Deposits").SetCategory(SparkNavCategory.Id));
+    // No nav entry of its own: manual top-ups are the exception, not a flow, so the page is reached from the
+    // Advanced section (or from the status page's stuck-deposit alert) and keeps that entry lit.
+    ViewData.SetLayoutModel(new LayoutModel(SparkNavPages.Advanced, "Deposits").SetCategory(SparkNavCategory.Id));
 
-    // A trail back to the plugin root. Without one, TitleHeader synthesises a single crumb equal to the title
-    // and prints the heading twice.
+    // A trail back through the section, so the heading is not the only entry in it. Without one, TitleHeader
+    // synthesises a single crumb equal to the title and prints the heading twice.
     BTCPayServer.ViewDataDictionaryExtensions.SetBreadcrumbs(ViewData,
         new BTCPayServer.Components.Breadcrumb.BreadcrumbItem("Flint", Action: "Status",
+            Controller: "Spark", RouteValues: new { storeId = Model.StoreId }),
+        new BTCPayServer.Components.Breadcrumb.BreadcrumbItem("Advanced", Action: "Advanced",
             Controller: "Spark", RouteValues: new { storeId = Model.StoreId }));
 
     var view = Model.Deposits;

--- a/BTCPayServer.Plugins.Flint/Views/SparkNavPages.cs
+++ b/BTCPayServer.Plugins.Flint/Views/SparkNavPages.cs
@@ -30,10 +30,10 @@ public static class SparkNavPages
     /// <summary>Stable Balance settings. Rendered only where Stable Balance can work — mainnet.</summary>
     public const string StableBalance = "SparkStableBalance";
 
-    /// <summary>On-chain deposits: the address, and anything sent to it that has not been credited.</summary>
-    public const string Deposits = "SparkDeposits";
-
-    /// <summary>Wallet details, recovery-phrase provenance and the settings most stores never touch.</summary>
+    /// <summary>
+    /// Wallet details, recovery-phrase provenance and the settings most stores never touch. The deposits and
+    /// removal pages borrow this entry: both are reached from the Advanced page rather than from the nav.
+    /// </summary>
     public const string Advanced = "SparkAdvanced";
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
+## [Unreleased]
+
+### Added
+
+- **Sweeps are labelled in the store's Bitcoin wallet.** Once a sweep's transaction id is known — at send,
+  or when crash reconciliation resolves it — the plugin writes a `flint-sweep` label onto the transaction in
+  the store's BTCPay wallet, the same way core labels payouts and invoices. The wallet's transactions list
+  then says where the money came from, with a tooltip, filterable like any other label. Cross-chain sweeps
+  are not labelled, because their delivery never appears in a Bitcoin wallet.
+
+### Changed
+
+- **Deposits moved off the navigation, behind Advanced.** A Spark wallet is funded by customers paying
+  invoices — no merchant needs to send their own funds in for the plugin to work — so the deposits page is
+  now reached from the Advanced page instead of carrying a top-level entry. The status page still flags a
+  stuck deposit loudly and links straight to the page that fixes it.
+
 ## [0.1.2] — 2026-08-17
 
 A UI pass ahead of publicising the plugin: fewer words, and a page for the things most stores never touch.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ install. Every release artifact is signed; the releases page carries `SHA256SUMS
 check both the hash and the signature before you upload anything. Verify them — this plugin holds
 Lightning keys on your server.
 
-Once installed, the plugin appears per-store under **Plugins → Spark**, and as a **Set up Spark** option
+Once installed, the plugin appears per-store under **Plugins → Flint**, and as a **Set up Flint** option
 on the store's *Connect to a Lightning node* screen. It does nothing at all until a store is set up.
 
 **Uninstalling the plugin is not the same as removing Spark from a store.** *Server settings → Plugins →
@@ -73,7 +73,7 @@ see [Setting a store up](docs/store-setup.md) for exactly what that destroys.
 
 ## Getting a store running
 
-1. **[Set the store up](docs/store-setup.md)** — one page under **Plugins → Spark**, one question (where
+1. **[Set the store up](docs/store-setup.md)** — one page under **Plugins → Flint**, one question (where
    the seed comes from). LNURL and Lightning addresses work through BTCPay core the moment it finishes.
 2. **[Turn sweeping on](docs/sweeping.md)** — off until you do, and it is the only thing that bounds how
    much of the store's money depends on the Spark operators. Set the threshold deliberately; the shipped

--- a/docs/deposits.md
+++ b/docs/deposits.md
@@ -2,7 +2,10 @@
 
 # Funding the wallet on-chain
 
-Under **Plugins → Flint → Deposits**. A stuck deposit is also flagged loudly on the status page.
+Under **Plugins → Flint → Advanced → Deposit address and unclaimed deposits**. Deposits have no navigation
+entry of their own, because a Spark wallet is funded by customers paying invoices — a merchant never needs to
+top it up for the plugin to work. A stuck deposit is flagged loudly on the status page, which links straight
+to this page when there is actually something to claim.
 
 The wallet has one **static Bitcoin address**. It does not rotate, so save it once and reuse it. Money sent
 to it credits the store's Spark balance after **three confirmations**, at which point the SDK claims it —

--- a/docs/stable-balance.md
+++ b/docs/stable-balance.md
@@ -2,7 +2,7 @@
 
 # Holding the balance in dollars: Stable Balance
 
-Under **Plugins → Spark → Stable Balance**. Off until a merchant turns it on, and **mainnet only** — USDB
+Under **Plugins → Flint → Stable Balance**. Off until a merchant turns it on, and **mainnet only** — USDB
 has no regtest deployment, and the plugin refuses to store the setting elsewhere rather than accepting it
 and silently never converting.
 

--- a/docs/store-setup.md
+++ b/docs/store-setup.md
@@ -2,7 +2,7 @@
 
 # Setting a store up
 
-Everything lives under **Plugins → Spark** in the store's navigation, or behind the **Set up Spark**
+Everything lives under **Plugins → Flint** in the store's navigation, or behind the **Set up Flint**
 option on the store's *Connect to a Lightning node* screen. There is one page and no connection string to
 copy: the plugin writes the store's `BTC-LN` and `BTC-LNURL` payment-method configuration itself, so LNURL
 and Lightning addresses work through BTCPay core once setup finishes.

--- a/docs/sweeping.md
+++ b/docs/sweeping.md
@@ -39,7 +39,10 @@ allowing anything; the form refuses a flat ceiling above the smallest sweep you 
 configured, the plugin will not pay more than half of what a sweep delivers.
 
 **Destinations** default to a fresh, labelled address from the store's own BTC derivation scheme, reserved
-and therefore rotated on every sweep, so sweeps are not all linked to one address on the blockchain. A store
+and therefore rotated on every sweep, so sweeps are not all linked to one address on the blockchain. Once a
+sweep's transaction id is known, the transaction itself is also labelled `flint-sweep` in the store's BTCPay
+wallet — the same mechanism core uses for payouts — so the wallet's transactions list says where the money
+came from. A store
 with no on-chain wallet in BTCPay can set one fixed address instead, validated against this server's chain
 both on save and again before every send. A store set to sweep into its own wallet that has no wallet is
 **refused with a reason** — it never falls back to an address left over from an earlier configuration.


### PR DESCRIPTION
Two changes ahead of the public release.

## Sweeps are labelled in the store's Bitcoin wallet

A sweep used to arrive in the store's wallet as an anonymous incoming transaction. The address-reservation path writes `generatedBy: "Spark sweep"` onto the *address* object, but the wallet's transactions list only reads labels attached to *tx* objects — so nothing ever showed on the row.

The engine now labels the transaction the way core labels payouts and invoices: a `flint-sweep` attachment with a tooltip ("Swept from this store's Spark wallet by the Flint plugin"), written once a sweep resolves **Sent** or **Confirmed** with a txid — on the fresh-send path and on crash reconciliation, which learns the txid from the SDK rather than from the row. The chip is filterable like any other wallet label.

Design points a reviewer should check:

- **`ISweepTransactionLabeler` seam** over core's `WalletRepository`, mirroring `ISweepAddressSource`: the engine's economics stay unit-testable without the application database. The production labeler is best-effort — a labelling failure is logged and swallowed, because nothing should retry a sweep that already moved money — and the underlying write is idempotent, so a Sent→Confirmed promotion labels once.
- **Both Bitcoin destination modes are labelled**, deliberately. The label row only renders when the wallet actually contains the transaction: always for store-wallet sweeps, and for fixed-address sweeps exactly when the address turns out to be one the store's wallet watches. For a genuinely external address the row is inert. Cross-chain sweeps are skipped — their delivery never appears in a Bitcoin wallet.

## Deposits move off the navigation, behind Advanced

A Spark wallet is funded by customers paying invoices — there is no user journey that requires a merchant to send their own funds in. The deposits page keeps existing (it is the stuck-deposit rescue path) but is now reached from the Advanced page, with a Flint → Advanced breadcrumb. The status page still flags a stuck deposit loudly and links straight to the page that fixes it.

## Also

Docs caught up with the UI: the navigation path is **Plugins → Flint** (docs still said Spark), and the Lightning-node screen's option is **Set up Flint**. `docs/sweeping.md` documents the new transaction label.

Suite: 1,057 passed (three new engine tests: happy-path label, no-label on a pass that sweeps nothing, label on crash recovery), 84 skipped as usual.