### PR TITLE
Release 0.1.3

### DIFF
--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -45,7 +45,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>0.1.2</Version>
+    <Version>0.1.3</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
-## [Unreleased]
+## [0.1.3] — 2026-08-17
 
 ### Added
 


### PR DESCRIPTION
Bumps `<Version>` to 0.1.3 and turns the changelog's Unreleased section into the `## [0.1.3] — 2026-08-17` heading. The release content is #16 (sweep transaction labels in the store's wallet, deposits behind Advanced); this PR is the version bump only.

After merge, tagging `v0.1.3` on the merge commit triggers package.yml, which verifies the tag against the built version, signs the artifact, and attaches it to the GitHub Release.