### PR TITLE
Validate provider-supplied sweep txid before writing the wallet label

### DIFF
--- a/BTCPayServer.Plugins.Flint/Services/BTCPayWalletSweepTransactionLabeler.cs
+++ b/BTCPayServer.Plugins.Flint/Services/BTCPayWalletSweepTransactionLabeler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Data;
+using BTCPayServer.Plugins.Flint;
 using BTCPayServer.Plugins.Flint.Data;
 using BTCPayServer.Services;
 using Microsoft.Extensions.Logging;
@@ -57,7 +58,6 @@ public sealed class BTCPayWalletSweepTransactionLabeler : ISweepTransactionLabel
     public async Task LabelAsync(SweepRecord record, string txId, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(record);
-        ArgumentException.ThrowIfNullOrEmpty(txId);
 
         // A cross-chain delivery never appears in the store's Bitcoin wallet, so there is no transaction row
         // for a label to decorate — the provider's Spark-side transfer is not an on-chain transaction at all.
@@ -70,6 +70,20 @@ public sealed class BTCPayWalletSweepTransactionLabeler : ISweepTransactionLabel
         if (record.DestinationKind is not SweepDestinationKind.BitcoinAddress)
             return;
 
+        // The txid comes from the Spark provider's payment data — the same class of externally-supplied 32-byte
+        // identifier NormaliseHash guards elsewhere — so it is validated (64 hex chars, canonical lowercase)
+        // before it can become a wallet-object id and a rendered "flint-sweep" provenance label. This also keeps
+        // the best-effort contract total: a malformed id is skipped, never thrown, so it cannot abort a
+        // reconciliation pass or surface after money has moved.
+        var normalizedTxId = SparkLightningClient.NormaliseHash(txId);
+        if (normalizedTxId is null)
+        {
+            _logger.LogWarning(
+                "Store {StoreId}: not labelling sweep transaction {TxId}: malformed txid (expected 64 hex chars)",
+                record.StoreId, txId);
+            return;
+        }
+
         try
         {
             // The id makes the sweep findable from the wallet object later; the tooltip is what the merchant
@@ -77,7 +91,7 @@ public sealed class BTCPayWalletSweepTransactionLabeler : ISweepTransactionLabel
             // hand-built root-relative URL would break under a non-root path base.
             await _walletRepository.AddWalletTransactionAttachment(
                     new WalletId(record.StoreId, CryptoCode),
-                    txId,
+                    normalizedTxId,
                     [new Attachment(AttachmentType, record.IdempotencyKey, new JObject { ["tooltip"] = Tooltip })],
                     WalletObjectData.Types.Tx)
                 .ConfigureAwait(false);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
+## [Unreleased]
+
+### Changed
+
+- **Sweep labels validate the provider's transaction id before writing it to the wallet.** The txid that
+  labels a sweep comes from the Spark provider's payment data, so it is now checked as a well-formed Bitcoin
+  transaction id (64 hex characters) — the same guard the plugin already applies to externally-supplied
+  payment hashes — before it becomes a wallet object and a rendered `flint-sweep` label. A malformed id is
+  skipped and logged, never thrown, keeping the labeler's best-effort contract total: a bad provider value
+  cannot abort a reconciliation pass or attach a false "swept from this store's Spark wallet" provenance
+  label to an unrelated transaction in the store's wallet. Cross-chain deliveries remain unlabelled and skip
+  this check entirely.
+
 ## [0.1.3] — 2026-08-17
 
 ### Added


### PR DESCRIPTION
## What

Validate the sweep labeler's transaction id before it becomes a wallet label and a rendered `flint-sweep` chip in the store's BTCPay wallet.

`BTCPayWalletSweepTransactionLabeler.LabelAsync` was the one place in the plugin that accepted a provider-supplied 32-byte identifier with no format check: it did `ThrowIfNullOrEmpty` and wrote whatever string it got straight into `WalletRepository.AddWalletTransactionAttachment` as a `tx`-type wallet-object id.

## The path

- Untrusted source: the Spark provider's payment data (`payment.TxId` / resolved `txId`) — the same class of data the plugin already validates upstream, e.g. `SparkLightningClient.NormaliseHash` for payment hashes.
- Sink: `SparkSweepEngine` fresh-send (`ResolveAsync`) and crash-reconciliation (`PromoteAsync`) call sites hand it to `LabelAsync`, which persists it as a labelled wallet object — and the merchant's wallet UI renders that label as "Swept from this store's Spark wallet by the Flint plugin".

A malicious or compromised provider can therefore attach false sweep provenance to an arbitrary transaction in the store's wallet (e.g. a customer deposit) and persist arbitrary strings as tx-type wallet-object rows.

## The fix

Reuse `SparkLightningClient.NormaliseHash` — the existing 64-hex-chars + canonical-lowercase validation for exactly this shape of externally-supplied identifier — inside `LabelAsync`, then write the normalized id:

- Malformed id → skipped and logged (warning), **never thrown**. The labeler's best-effort contract stays total: a bad value cannot abort a reconciliation pass or surface after money has moved.
- Valid id → stored in canonical lowercase, which also removes the (unleveraged) case-variant duplication risk on the wallet-object id.
- Cross-chain deliveries are unchanged: the destination-kind gate still returns before validation, because their Spark-side transfer ids are not on-chain transaction ids at all.

## Verification

- Finding surfaced by the security-quorum glm-5.3 panel benchmark (three independent reviewer seats, corroborated) and re-verified against this checkout's source; the `NormaliseHash` guard and both call sites were confirmed in-tree.
- Behavior of the two affected code paths traced at `SparkSweepEngine.cs:1954` (reconciliation) and `:2011` (fresh send).
- Could not compile or run the test suite locally: no .NET SDK on this machine and the `btcpayserver` submodule is uninitialized. The change is 1:1 with an existing internal helper and CI (including `PluginVersionTests`) covers the build on merge.
- CHANGELOG gains an `[Unreleased]` entry; the version-heading test only matches numeric `## [x.y.z]` headings so inserting `[Unreleased]` above `0.1.3` keeps it green.
