### PR TITLE
Make the funded regtest job block pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,18 +215,26 @@ jobs:
     concurrency:
       group: funded-regtest-wallet
       cancel-in-progress: false
-    # ADVISORY, like integration-test, and for the same reason plus two of its own. Beyond depending on a
-    # third-party service, this suite depends on a *wallet with a balance*: it will go red when the CI wallet
-    # runs dry, which is an operations event and not a defect in the pull request that happened to be open at
-    # the time. Blocking merges on the state of a faucet-funded balance would be a bad trade. The suite says so
-    # itself — a drained wallet fails with an instruction to top it up, not an assertion about numbers.
+    # BLOCKING on pull requests, advisory on schedule and push. This is the gate integration-test's comment
+    # proposes but has not yet earned; this job earned it the other way round, by demonstrating the cost of
+    # not having it: the suite ran red for two days behind a green checkmark (a saturated counting window in
+    # the interrupted-sweep test, fixed by #22) and nothing surfaced it until someone happened to open the
+    # Actions tab. On a PR a human is present to judge a failure and re-run a transient one, so there the
+    # job turns the run red like any other test.
     #
-    # What makes it useful anyway is the artefact. This is the only job in the repository that produces the
-    # log output of a *completed* payment, which is the one stated gap in the plugin's log audit and the
-    # open question in SparkLogScrubber's remarks. The preimage assertion inside the suite is a hard one; if the
-    # scrubber ever lets a preimage through, this job reports a real failure with the value in the message.
-    # Someone has to look at the run summary — the same standing caveat integration-test carries.
-    continue-on-error: true
+    # Scheduled and push runs stay advisory because the suite depends on a third-party service and on a
+    # *wallet with a balance*: it goes red when the CI wallet runs dry, which is an operations event and not
+    # a defect in main. A drained wallet fails with an instruction to top it up, not an assertion about
+    # numbers — on a PR, fund the wallet and re-run rather than reading that as a code failure. Fork PRs are
+    # unaffected: without the seed secret the gate below skips the suite and the job passes trivially.
+    #
+    # What makes the job worth watching outside PRs is the artefact. This is the only job in the repository
+    # that produces the log output of a *completed* payment, which is the one stated gap in the plugin's log
+    # audit and the open question in SparkLogScrubber's remarks. The preimage assertion inside the suite is a
+    # hard one; if the scrubber ever lets a preimage through, this job reports a real failure with the value
+    # in the message. On schedule and push runs, someone still has to look at the run summary — the same
+    # standing caveat integration-test carries.
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7

--- a/docs/ci-and-releases.md
+++ b/docs/ci-and-releases.md
@@ -3,17 +3,19 @@
 # CI, releases & upstream updates
 
 - **`.github/workflows/ci.yml`** runs on every push to `main`, on all PRs, and on a daily schedule so
-  SSP/SDK drift shows up on days with no commits. Four jobs, two of which gate a merge:
+  SSP/SDK drift shows up on days with no commits. Four jobs, three of which gate a pull request:
 
   | job | gates a merge? | why |
   |---|---|---|
   | `build-and-test` | **yes** | no external dependency; a failure is always our bug |
   | `store-test` | **yes** | real Postgres in a service container, no third-party network |
   | `integration-test` | no — `continue-on-error` | depends on Lightspark's hosted regtest; an outage there would block merges |
-  | `funded-regtest-test` | no — `continue-on-error` | the above, plus it depends on a faucet-funded balance, so it goes red when the CI wallet drains — an operations event, not a defect in whichever PR was open |
+  | `funded-regtest-test` | **on PRs** — advisory on schedule/push | a human is present on a PR to judge a failure; scheduled and push runs stay advisory because the suite also depends on a faucet-funded balance, and the CI wallet draining is an operations event, not a defect in main |
 
-  Both advisory jobs report their real pass/fail in the run summary. **Someone has to look**: an SDK
-  error-string re-wording, or a preimage reaching the log, shows as a failed job inside a green run.
+  The advisory runs still report their real pass/fail in the run summary. **Someone has to look**: an SDK
+  error-string re-wording, or a preimage reaching the log, shows as a failed job inside a green
+  scheduled run. A drained wallet failing a PR is answered by funding the wallet and re-running, not by
+  reading it as a code failure.
 - **`.github/workflows/spark-regtest-wallet.yml`** is manual-only. It prints the CI regtest wallet's
   static deposit address and balance so a maintainer can fund it — see
   ["A funded regtest wallet for CI"](testing.md#a-funded-regtest-wallet-for-ci). It never prints the seed, and
@@ -45,5 +47,7 @@
   discovery logic in `scripts/check-btcpayserver-update.sh`.
 - **Branch protection**: not configured by these workflows. For `main`, enable "Require status
   checks to pass before merging" with `ci.yml`'s `build-and-test` **and `store-test`** jobs required
-  (and `integration-test` and `funded-regtest-test` intentionally *not* required, since both are
-  `continue-on-error` by design), plus "Require branches to be up to date before merging".
+  (`integration-test` intentionally *not* required, since it is `continue-on-error` by design), plus
+  "Require branches to be up to date before merging". `funded-regtest-test` blocks PRs since it is
+  no longer `continue-on-error` there; requiring it in branch protection as well is a choice —
+  doing so means a drained CI wallet holds every merge until someone funds it.


### PR DESCRIPTION
Flips `funded-regtest-test` from unconditionally advisory to `continue-on-error: ${{ github.event_name != 'pull_request' }}` — blocking on PRs, advisory on schedule and push. This is the split the workflow's own comments proposed: on a PR a human is present to judge a failure and re-run a transient one, while scheduled/push runs stay advisory so a drained CI wallet or an SSP outage remains an operations signal instead of turning main red. The suite just demonstrated why the PR gate matters — it ran red for two days behind a green checkmark until #22.

Fork PRs are unaffected (no seed secret → the gate step skips the suite and the job passes trivially). `integration-test` is left as-is per its documented wait-for-flake-rate-data plan.

Also updates docs/ci-and-releases.md: the merge-gate table, the advisory-runs caveat, and the branch-protection note (requiring the job in branch protection is now possible but means a drained wallet holds every merge until funded).

This PR's own funded job runs under the new policy, so a green run here is the verification.