### PR TITLE
Address the v0.1.4 security review findings

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeSparkSdkClient.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeSparkSdkClient.cs
@@ -99,11 +99,19 @@ public sealed class FakeSparkSdkClient : ISparkSdkClient
         return Task.FromResult(new SparkNodeInfo(IdentityPubkey, BalanceSats, TokenBalances.ToList()));
     }
 
+    /// <summary>
+    /// Runs inside <see cref="SyncWalletAsync"/>, after the count. What a real sync does — surface a payment
+    /// the wallet had not stored yet, move the balance — a test expresses here; a thrown exception is a sync
+    /// that failed.
+    /// </summary>
+    public Action<FakeSparkSdkClient>? OnSync { get; set; }
+
     public Task SyncWalletAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfConfigured();
         SyncCount++;
         _writeLog?.Record("sdk:sync");
+        OnSync?.Invoke(this);
         return Task.CompletedTask;
     }
 

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeStoreLightningConfigStore.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeStoreLightningConfigStore.cs
@@ -48,11 +48,20 @@ public sealed class FakeStoreLightningConfigStore : IStoreLightningConfigStore
     public Task<StoreLightningConfig?> GetAsync(string storeId, CancellationToken cancellationToken = default) =>
         Task.FromResult(Stores.TryGetValue(storeId, out var config) ? config : null);
 
+    /// <summary>Thrown by the next <see cref="SetAsync"/> — a store repository whose write failed.</summary>
+    public Exception? FailNextSetWith { get; set; }
+
     public Task<bool> SetAsync(
         string storeId,
         string? connectionString,
         CancellationToken cancellationToken = default)
     {
+        if (FailNextSetWith is { } failure)
+        {
+            FailNextSetWith = null;
+            throw failure;
+        }
+
         Writes.Add((storeId, connectionString));
         _writeLog?.Record($"lightning:{storeId}:{(connectionString is null ? "cleared" : "set")}");
 

--- a/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkProvisioningTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkProvisioningTests.cs
@@ -361,8 +361,11 @@ public class GreenfieldSparkProvisioningTests
         Assert.Equal(400_000, sweep.BalanceThresholdSats);
         Assert.Equal(1.25, sweep.MaxFeePercent);
 
-        // And the payment key is kept rather than rotated, so a Lightning configuration already written stays valid.
-        Assert.Equal(SparkSurfaceHarness.VictimPaymentKey, h.Settings.Settings[Store]!.PaymentKey);
+        // And the payment key is rotated, not kept: the connection string is a bearer spend credential, and a
+        // re-provision that left every previously issued copy able to drive the new wallet would quietly
+        // defeat the reset. The Lightning wiring is rewritten with the new key in the same operation.
+        Assert.NotEqual(SparkSurfaceHarness.VictimPaymentKey, h.Settings.Settings[Store]!.PaymentKey);
+        Assert.False(string.IsNullOrEmpty(h.Settings.Settings[Store]!.PaymentKey));
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
@@ -555,6 +555,29 @@ public class SparkCrossChainSweepTests
     }
 
     /// <summary>
+    /// An amount too large to convert to dollars is refused, never waved through unchecked.
+    /// </summary>
+    /// <remarks>
+    /// The fail-open this closes: the conversion used to report an overflowing value as zero, and the guard
+    /// read zero as "the quote-shape check already refused this" — so the quotes at their most absurd were
+    /// exactly the ones that skipped the value check. A value the guard cannot express is a quote it cannot
+    /// vouch for, and a quote it cannot vouch for does not send.
+    /// </remarks>
+    [Fact]
+    public async Task An_amount_too_large_to_value_is_refused_rather_than_skipping_the_value_guard()
+    {
+        // 10^40 base units of a 6-decimal token: 10^34 whole dollars, far beyond what a decimal can carry.
+        var h = Harness(balanceSats: 500_000, stableBalance: BigInteger.Pow(10, 40));
+
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
+        Assert.Equal(SweepRefusalCode.CrossChainValueUnverifiable, result.Record!.RefusalCode);
+        Assert.Contains("too large", result.Reason, StringComparison.Ordinal);
+        Assert.Empty(h.Sdk.CrossChainSendCalls);
+    }
+
+    /// <summary>
     /// No rate means no sweep, rather than a sweep nobody checked.
     /// </summary>
     /// <remarks>

--- a/BTCPayServer.Plugins.Flint.Tests/SparkDepositServiceTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkDepositServiceTests.cs
@@ -288,6 +288,36 @@ public class SparkDepositServiceTests
         Assert.Equal(h.Sdk.DepositAddress, view.Address);
     }
 
+    /// <summary>
+    /// A wallet that has not reported its identity yet gets a live address, never a cached one.
+    /// </summary>
+    /// <remarks>
+    /// An empty identity is the absence of a cache key, not a cache key: keyed on it, every wallet this store
+    /// has ever had would share one slot, and a request racing a new wallet's first sync after a seed change
+    /// would be handed the previous wallet's address — a merchant top-up sent to a wallet the plugin may no
+    /// longer hold the seed for. The SDK client is always the store's current wallet, so the fallback is a
+    /// fresh read on every call until the identity is known.
+    /// </remarks>
+    [Fact]
+    public async Task An_unknown_wallet_identity_bypasses_the_address_cache_in_both_directions()
+    {
+        var h = Harness();
+
+        // The previous wallet cached its address under an empty identity...
+        h.Sdk.IdentityPubkey = "";
+        h.Sdk.DepositAddress = "bc1poldwalletaddress00000000000000000000000000000000000000000000";
+        var first = await h.Service.ReadAsync(StoreId, Ct);
+        Assert.Equal(h.Sdk.DepositAddress, first.Address);
+
+        // ...and the new wallet, identity still unknown, must not be handed it.
+        h.Sdk.DepositAddress = "bc1pnewwalletaddress00000000000000000000000000000000000000000000";
+        var second = await h.Service.ReadAsync(StoreId, Ct);
+
+        Assert.Equal(h.Sdk.DepositAddress, second.Address);
+        // Two reads, two round trips: nothing was written into the cache under the empty key either.
+        Assert.Equal(2, h.Log.Entries.Count(e => e == "sdk:deposit-address"));
+    }
+
     #endregion
 
     #region Claiming

--- a/BTCPayServer.Plugins.Flint.Tests/SparkStoreProvisionerTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkStoreProvisionerTests.cs
@@ -272,6 +272,29 @@ public class SparkStoreProvisionerTests
     }
 
     [Fact]
+    public async Task Provision_rolls_back_when_the_lightning_configuration_write_throws()
+    {
+        // Since the key rotates, settings carrying the new key beside a Lightning configuration still holding
+        // the old string is a store whose checkout fails until someone intervenes — so a throw out of the
+        // wiring write must restore the old settings exactly as a false return does.
+        var h = Create();
+        Assert.True((await h.Provisioner.ProvisionAsync(StoreId, ValidMnemonic, SeedSource.Generated)).Succeeded);
+        var original = h.Settings.Settings[StoreId];
+        var originalWiring = h.Config.Stores[StoreId].ConnectionString;
+
+        h.Config.FailNextSetWith = new InvalidOperationException("the store repository write failed");
+        var replacement = new Mnemonic(Wordlist.English, WordCount.Twelve).ToString();
+
+        var result = await h.Provisioner.ProvisionAsync(StoreId, replacement, SeedSource.Imported);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("previous Spark configuration was restored", result.Error);
+        Assert.Equal(original!.PaymentKey, h.Settings.Settings[StoreId]!.PaymentKey);
+        // And the wiring still carries the string those settings agree with.
+        Assert.Equal(originalWiring, h.Config.Stores[StoreId].ConnectionString);
+    }
+
+    [Fact]
     public async Task Provision_rotates_the_payment_key_and_keeps_sweep_settings_across_a_seed_change()
     {
         // The payment key is a bearer spend credential — the connection string carrying it drives this store's

--- a/BTCPayServer.Plugins.Flint.Tests/SparkStoreProvisionerTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkStoreProvisionerTests.cs
@@ -272,11 +272,12 @@ public class SparkStoreProvisionerTests
     }
 
     [Fact]
-    public async Task Provision_keeps_the_payment_key_and_sweep_settings_across_a_seed_change()
+    public async Task Provision_rotates_the_payment_key_and_keeps_sweep_settings_across_a_seed_change()
     {
-        // The payment key is a store-binding token, not a secret that ages, and rotating it would invalidate a
-        // Lightning configuration that is already live. The sweep settings are the merchant's, and changing a
-        // seed is not a request to lose them — this is what lets Wave 4 hang its settings off the same blob.
+        // The payment key is a bearer spend credential — the connection string carrying it drives this store's
+        // wallet from anywhere it is pasted — so a re-provision mints a fresh one rather than handing the new
+        // wallet to every old copy of the string. The sweep settings are the merchant's, and changing a seed
+        // is not a request to lose them — this is what lets Wave 4 hang its settings off the same blob.
         var h = Create();
         Assert.True((await h.Provisioner.ProvisionAsync(StoreId, ValidMnemonic, SeedSource.Generated)).Succeeded);
 
@@ -289,7 +290,7 @@ public class SparkStoreProvisionerTests
         Assert.True((await h.Provisioner.ProvisionAsync(StoreId, replacement, SeedSource.Imported)).Succeeded);
 
         var second = h.Settings.Settings[StoreId]!;
-        Assert.Equal(first.PaymentKey, second.PaymentKey);
+        Assert.NotEqual(first.PaymentKey, second.PaymentKey);
         Assert.True(second.Sweep.Enabled);
         Assert.Equal(100_000, second.Sweep.BalanceThresholdSats);
         Assert.Equal("merchant-key", second.ApiKeyOverride);

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
@@ -1242,6 +1242,39 @@ public class SparkSweepEngineTests
     }
 
     [Fact]
+    public async Task A_shortfall_blocked_write_off_escalates_after_an_hour_rather_than_wedging_the_store()
+    {
+        // The gate's premise — funds missing means the exit happened — is also produced by a payout or a
+        // Stable Balance conversion landing near a sweep that genuinely never went out. Unbounded, that
+        // coincidence would block sweeping forever with no operator escape; bounded, the row is written off
+        // after an hour of synced re-checks, with a reason that says exactly what was observed.
+        var h = CreateHarness(new SweepSettings
+        {
+            Enabled = true,
+            BalanceThresholdSats = long.MaxValue / 4,
+            MinimumSweepSats = long.MaxValue / 4
+        }, balanceSats: 400_000);
+        const string key = "5d0a1cf1-2b3e-4b17-9c8a-7f0c2a0f9e19";
+        await h.Records.AddAsync(NewPending(key), Ct);
+
+        // Inside the escalation window the shortfall blocks...
+        h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromSeconds(1));
+        Assert.Equal(
+            SweepOutcomeKind.InFlight, (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct)).Kind);
+        Assert.Equal(SweepRecordStatus.Pending, (await h.Records.GetAsync(StoreId, key, Ct))!.Status);
+
+        // ...and past it, the row closes and sweeping is free again.
+        h.Time.Advance(SparkSweepEngine.ShortfallWriteOffAge);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        var record = await h.Records.GetAsync(StoreId, key, Ct);
+        Assert.Equal(SweepRecordStatus.Failed, record!.Status);
+        Assert.Contains("held less than the sweep would have sent", record.Error);
+        Assert.Contains("verify the wallet's payment history", record.Error);
+        Assert.Empty(h.Sdk.OnchainSendCalls);
+    }
+
+    [Fact]
     public async Task A_payment_that_surfaces_only_after_an_explicit_sync_resolves_instead_of_being_written_off()
     {
         // The exact window the write-off used to misread: the SSP accepted the exit, the SDK's local storage

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
@@ -1224,6 +1224,69 @@ public class SparkSweepEngineTests
     }
 
     [Fact]
+    public async Task A_write_off_is_refused_when_the_synced_balance_no_longer_holds_the_sweeps_amount()
+    {
+        // The row says 450k sat should still be in the wallet if nothing was sent; the synced balance says
+        // 400k. "No payment under the key" plus a shortfall is the accepted-but-unrecorded shape — the one
+        // case where closing the row and re-planning would send real money twice — so the store stays blocked.
+        var h = CreateHarness(balanceSats: 400_000);
+        const string key = "5d0a1cf1-2b3e-4b17-9c8a-7f0c2a0f9e16";
+        await h.Records.AddAsync(NewPending(key), Ct);
+
+        h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromSeconds(1));
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        Assert.Equal(SweepOutcomeKind.InFlight, result.Kind);
+        Assert.Equal(SweepRecordStatus.Pending, (await h.Records.GetAsync(StoreId, key, Ct))!.Status);
+        Assert.Empty(h.Sdk.OnchainSendCalls);
+    }
+
+    [Fact]
+    public async Task A_payment_that_surfaces_only_after_an_explicit_sync_resolves_instead_of_being_written_off()
+    {
+        // The exact window the write-off used to misread: the SSP accepted the exit, the SDK's local storage
+        // has not replayed it yet, and the pass's first lookup returns null. The forced sync surfaces it, and
+        // the repeated lookup must resolve the row rather than declare it never sent. The threshold is
+        // unreachable so the pass can only resolve — a send here could only be a recovery re-send.
+        var h = CreateHarness(new SweepSettings
+        {
+            Enabled = true,
+            BalanceThresholdSats = long.MaxValue / 4,
+            MinimumSweepSats = long.MaxValue / 4
+        });
+        const string key = "5d0a1cf1-2b3e-4b17-9c8a-7f0c2a0f9e17";
+        await h.Records.AddAsync(NewPending(key), Ct);
+        h.Sdk.OnSync = sdk => sdk.PaymentsById[key] = CompletedExit(key, 450_000, 2_190);
+
+        h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromSeconds(1));
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        var record = await h.Records.GetAsync(StoreId, key, Ct);
+        Assert.NotEqual(SweepRecordStatus.Failed, record!.Status);
+        Assert.Null(record.Error);
+        // And crucially, nothing was re-sent under this row's mandate.
+        Assert.Empty(h.Sdk.OnchainSendCalls);
+    }
+
+    [Fact]
+    public async Task A_sync_that_fails_keeps_a_write_off_candidate_blocking()
+    {
+        // The write-off is the one decision that can unblock a re-sweep, so it may not run on storage the
+        // pass could not freshen. Refusing to sweep is always the safe direction.
+        var h = CreateHarness();
+        const string key = "5d0a1cf1-2b3e-4b17-9c8a-7f0c2a0f9e18";
+        await h.Records.AddAsync(NewPending(key), Ct);
+        h.Sdk.OnSync = _ => throw new SdkException.NetworkException("@v1=offline");
+
+        h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromSeconds(1));
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        Assert.Equal(SweepOutcomeKind.InFlight, result.Kind);
+        Assert.Equal(SweepRecordStatus.Pending, (await h.Records.GetAsync(StoreId, key, Ct))!.Status);
+        Assert.Empty(h.Sdk.OnchainSendCalls);
+    }
+
+    [Fact]
     public async Task An_SDK_that_cannot_be_read_keeps_an_unresolved_sweep_blocking()
     {
         // Refusing to sweep is always the safe direction.

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -98,7 +98,7 @@
       The package carries ~200 MB of native libraries for linux-x64/arm64, osx-x64/arm64,
       win-x64/x86. There is no linux-musl (Alpine) or win-arm64 payload.
     -->
-    <PackageReference Include="Breez.Sdk.Spark" Version="0.22.2" />
+    <PackageReference Include="Breez.Sdk.Spark" Version="0.22.3" />
   </ItemGroup>
 
   <!--

--- a/BTCPayServer.Plugins.Flint/Sdk/ISparkStorageProvider.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/ISparkStorageProvider.cs
@@ -88,7 +88,8 @@ public class FileSparkStorageProvider : ISparkStorageProvider
     {
         ArgumentException.ThrowIfNullOrEmpty(storeId);
         var path = GetStorageDirectory(_dataDirectories.Value.DataDir, storeId);
-        System.IO.Directory.CreateDirectory(path);
+        // Owner-only from the first instant it exists — never created at the umask and restricted afterwards.
+        SparkDirectoryPermissions.CreateOwnerOnly(path);
         // Never throws: a host whose filesystem will not take the mode is a weaker host, not a reason to
         // refuse to run the merchant's wallet. Applied whether or not this call created the directory, which
         // is what hardens an install laid down by an earlier version of the plugin.

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkDirectoryPermissions.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkDirectoryPermissions.cs
@@ -24,6 +24,33 @@ namespace BTCPayServer.Plugins.Flint.Sdk;
 /// </remarks>
 internal static class SparkDirectoryPermissions
 {
+    private const UnixFileMode OwnerOnly =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
+    /// <summary>
+    /// Creates <paramref name="directory"/> owner-only from the first instant it exists.
+    /// </summary>
+    /// <remarks>
+    /// The mode is passed to the creation itself rather than applied afterwards, because "afterwards" is a
+    /// window: a directory created at the process umask and then restricted spends its first moments at 0755,
+    /// and what lands in it during those moments was readable. A umask can only clear bits from 0700, never
+    /// add them, so the result is owner-only regardless of the host's umask. Creating a directory that already
+    /// exists changes nothing — pair with <see cref="RestrictToOwner"/> where a pre-existing directory from an
+    /// older plugin version needs hardening too.
+    /// </remarks>
+    internal static void CreateOwnerOnly(string directory)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // Same posture as RestrictToOwner: directory ACLs on Windows are a different mechanism with
+            // different defaults, and the plugin makes no claim about them.
+            Directory.CreateDirectory(directory);
+            return;
+        }
+
+        Directory.CreateDirectory(directory, OwnerOnly);
+    }
+
     /// <summary>
     /// Makes <paramref name="directory"/> owner-only, so far as the platform allows.
     /// </summary>
@@ -53,9 +80,7 @@ internal static class SparkDirectoryPermissions
 
         try
         {
-            File.SetUnixFileMode(
-                directory,
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            File.SetUnixFileMode(directory, OwnerOnly);
         }
         catch (Exception ex)
         {

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkLogBridge.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkLogBridge.cs
@@ -124,7 +124,7 @@ public static class SparkLogging
 
         try
         {
-            Directory.CreateDirectory(logDirectory);
+            SparkDirectoryPermissions.CreateOwnerOnly(logDirectory);
             // The SDK creates sdk.log itself, at the process umask — 0644 as observed, world-readable. The
             // plugin cannot choose the file's mode, but it owns the directory, and a directory without
             // other-execute cannot be traversed to reach the file inside it. Shared with the per-store storage

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkSdkClient.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkSdkClient.cs
@@ -698,6 +698,17 @@ public sealed class SparkSdkClient : ISparkSdkClient
                 + "than a cross-chain address; refusing to send.");
         }
 
+        // The prepared payment's recipient is an echo from the provider, and every guard downstream of here is
+        // amount-shaped — none of them would notice the money going to the right chain at the wrong address.
+        // Case-insensitive because the request may carry an EIP-55 mixed-case address and the echo a lowercased
+        // one: those are the same account, and a checksum-only difference is not a redirection.
+        if (!string.Equals(crossChain.recipientAddress, recipientAddress, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Spark prepared this cross-chain send for {crossChain.recipientAddress}, which is not the "
+                + "destination that was requested; refusing to send.");
+        }
+
         var context = crossChain.providerContext as CrossChainProviderContext.Orchestra;
 
         return (prepared, new SparkCrossChainQuote(

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkStorageLock.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkStorageLock.cs
@@ -73,15 +73,24 @@ internal sealed class SparkStorageLock : IDisposable
         reason = null;
         try
         {
-            Directory.CreateDirectory(directory);
+            // Owner-only at creation, matching the storage provider that hardens this same directory: the lock
+            // is usually the first thing to create it, and a directory born at the umask is world-listable
+            // until the provider's retroactive pass reaches it.
+            SparkDirectoryPermissions.CreateOwnerOnly(directory);
 
-            var stream = new FileStream(
-                path,
-                FileMode.OpenOrCreate,
-                FileAccess.ReadWrite,
-                FileShare.None,
-                bufferSize: 1,
-                FileOptions.None);
+            var options = new FileStreamOptions
+            {
+                Mode = FileMode.OpenOrCreate,
+                Access = FileAccess.ReadWrite,
+                Share = FileShare.None,
+                BufferSize = 1
+            };
+            // The note inside is only a pid and a timestamp, but there is no reason for the file to be more
+            // readable than the directory it sits in. Windows keeps its own defaults, as everywhere else.
+            if (!OperatingSystem.IsWindows())
+                options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+            var stream = new FileStream(path, options);
 
             try
             {

--- a/BTCPayServer.Plugins.Flint/Services/SparkDepositService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkDepositService.cs
@@ -373,7 +373,16 @@ public sealed class SparkDepositService
         // The identity is read from the cache rather than forced to sync: this runs on a request thread, and a
         // stale identity would only mean a cache miss, never a wrong address.
         var info = await sdk.GetInfoAsync(ensureSynced: false, cancellationToken).ConfigureAwait(false);
-        var key = (storeId, info.IdentityPubkey ?? string.Empty);
+
+        // No identity, no cache — in either direction. An empty identity is not a wallet identity, it is the
+        // absence of one, and using it as a cache key would make every wallet this store has ever had share
+        // one slot: after a seed change, a request racing the new wallet's first sync would be handed the
+        // previous wallet's deposit address. The SDK itself is always current for this store, so the fallback
+        // is a fresh (idempotent) address read, not a guess.
+        if (string.IsNullOrEmpty(info.IdentityPubkey))
+            return await sdk.GetBitcoinDepositAddressAsync(cancellationToken).ConfigureAwait(false);
+
+        var key = (storeId, info.IdentityPubkey);
 
         if (_addresses.TryGetValue(key, out var cached))
             return cached;

--- a/BTCPayServer.Plugins.Flint/Services/SparkStoreProvisioner.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkStoreProvisioner.cs
@@ -249,7 +249,31 @@ public sealed class SparkStoreProvisioner
                 applied.Reason ?? "The Spark wallet did not start. Check the server logs for the reason.");
         }
 
-        if (!await _lightningWiring.EnableAsync(storeId, paymentKey, cancellationToken).ConfigureAwait(false))
+        // A throw here needs the same rollback the `false` return gets: since the key rotates, settings
+        // carrying the new key beside a Lightning configuration still holding the old string is a store whose
+        // checkout fails until someone intervenes. Rolling back restores the old settings, and the
+        // configuration those settings agree with was never touched. What no code here can catch is the
+        // process dying between SetAsync above and the write inside EnableAsync — that mismatch survives the
+        // crash, and the status page is what covers it: it inspects the wiring against the stored key, reports
+        // the disagreement, and its enable action rewrites the configuration from the stored key in one click.
+        bool wired;
+        try
+        {
+            wired = await _lightningWiring.EnableAsync(storeId, paymentKey, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Store {StoreId}: the Lightning payment method could not be rewritten after provisioning; "
+                + "rolling the Spark settings back", storeId);
+            await RollBackAsync(storeId, existing).ConfigureAwait(false);
+            return SparkProvisionResult.Failed(
+                "The store's Lightning configuration could not be updated, so the previous Spark configuration "
+                + "was restored. Try again, and check the server logs if it persists.");
+        }
+
+        if (!wired)
         {
             await RollBackAsync(storeId, existing).ConfigureAwait(false);
             return SparkProvisionResult.Failed(

--- a/BTCPayServer.Plugins.Flint/Services/SparkStoreProvisioner.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkStoreProvisioner.cs
@@ -178,10 +178,16 @@ public sealed class SparkStoreProvisioner
 
         var existing = await _settingsStore.GetAsync(storeId).ConfigureAwait(false);
 
-        // An existing payment key is kept rather than rotated. The key is not a secret that ages — it is a
-        // store-binding token — and rotating it would invalidate a Lightning configuration that is already
-        // written and working for the window between storing the settings and rewriting that configuration.
-        var paymentKey = existing?.PaymentKey ?? SparkConnectionString.GeneratePaymentKey();
+        // Rotated on every provision, never carried over. The key is a bearer spend credential — anyone
+        // holding the connection string drives this store's wallet — and re-provisioning is the one moment a
+        // merchant plausibly reaches for after losing confidence in the old configuration, so handing the new
+        // wallet to every old copy of the string would quietly defeat the reset. The cost is a moment between
+        // SetAsync and EnableAsync below where the store's written Lightning configuration still carries the
+        // old key and will not resolve; a re-provision already restarts the wallet, so that window changes
+        // nothing a merchant can observe, and EnableAsync rewrites the configuration with the new key in this
+        // same operation. On rollback the old settings return intact and the configuration was never
+        // rewritten, so old string and old key still agree.
+        var paymentKey = SparkConnectionString.GeneratePaymentKey();
 
         var settings = new SparkSettings
         {

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
@@ -152,6 +152,19 @@ public sealed class SparkSweepEngine
     internal static readonly TimeSpan UnresolvedGrace = TimeSpan.FromMinutes(5);
 
     /// <summary>
+    /// How long a balance shortfall may keep a write-off candidate blocking before it is written off anyway.
+    /// </summary>
+    /// <remarks>
+    /// The shortfall gate reads "no payment under the key, and less balance than the sweep would have sent" as
+    /// a possible accepted-but-unrecorded exit, and blocks. But the same observation is produced by any other
+    /// spend — a Lightning payout, a Stable Balance conversion — happening near a sweep that genuinely never
+    /// went out, and an unbounded gate would wedge the store's sweeping permanently on that coincidence, with
+    /// no operator escape short of removing Spark. An hour is many passes, each with a forced sync and a fresh
+    /// point lookup; an exit the SDK still has not surfaced after that is no longer the likely explanation.
+    /// </remarks>
+    internal static readonly TimeSpan ShortfallWriteOffAge = TimeSpan.FromHours(1);
+
+    /// <summary>
     /// How far back the crash-recovery walk looks.
     /// </summary>
     /// <remarks>
@@ -1686,20 +1699,37 @@ public sealed class SparkSweepEngine
                 // synced balance no longer holds what this sweep would have sent, "no payment under the key"
                 // stops being evidence of "never sent" and starts looking like an accepted exit the SDK has
                 // not recorded — the one case where closing the row and re-planning would send real money
-                // twice. Receives only ever raise the balance and this engine is the store's only spender, so
-                // a shortfall here is not explainable by ordinary traffic. The row keeps blocking until the
-                // payment surfaces or an operator intervenes. Token-funded rows are not gated — their amount
-                // is not in sats — but their write-off never re-sends, so the hazard this guards is absent.
-                if (record.IdempotencyKeyAccepted && syncedBalance < record.AmountSats)
+                // twice. The gate is bounded rather than absolute, because a shortfall is not proof: this
+                // engine is not the store's only spender — Lightning payouts and Stable Balance conversions
+                // both debit sats with no sweep record, and a sweep's amount is close enough to the whole
+                // balance that any of them trips the comparison. An unbounded refusal would turn one payout
+                // into a permanently wedged store with no operator escape short of removing Spark. So the row
+                // blocks for ShortfallWriteOffAge — enough passes and forced syncs that an accepted exit
+                // still absent from local storage is no longer the likely explanation — and then falls
+                // through to a write-off whose reason says exactly what was observed. Token-funded rows are
+                // not gated: their amount is not in sats, and their write-off never re-sends.
+                var shortfall = record.IdempotencyKeyAccepted && syncedBalance < record.AmountSats;
+                if (shortfall && now - record.CreatedAt < ShortfallWriteOffAge)
                 {
                     _logger.LogError(
                         "Store {StoreId}: sweep {IdempotencyKey} has no payment record, but the synced balance "
                         + "({BalanceSats} sat) is below the {AmountSats} sat it would have sent — refusing to "
                         + "write it off as never sent, because the shortfall suggests it was. The store stays "
-                        + "blocked; check the wallet's history and the destination before intervening",
-                        storeId, record.IdempotencyKey, syncedBalance, record.AmountSats);
+                        + "blocked until the payment surfaces or the sweep is {Age} old; check the wallet's "
+                        + "history and the destination in the meantime",
+                        storeId, record.IdempotencyKey, syncedBalance, record.AmountSats, ShortfallWriteOffAge);
                     blocking ??= record;
                     continue;
+                }
+
+                if (shortfall)
+                {
+                    _logger.LogWarning(
+                        "Store {StoreId}: writing off sweep {IdempotencyKey} despite a balance shortfall — it "
+                        + "is {Age} old, every pass since its grace expired has synced and found no payment, "
+                        + "and other spenders (payouts, Stable Balance) can explain the shortfall. Verify the "
+                        + "wallet history against the sweep history",
+                        storeId, record.IdempotencyKey, now - record.CreatedAt);
                 }
 
                 // Worded as what is known rather than as a conclusion. That the SDK would replay a service-provider
@@ -1711,7 +1741,13 @@ public sealed class SparkSweepEngine
                 // this record's provider quote id, and a send whose persistence step never completed might not
                 // be in that history at all. So the row is closed and the store is unblocked, but the sentence
                 // does not claim the money is safe — and, crucially, nothing re-sends it.
-                var reason = record.IdempotencyKeyAccepted
+                var reason = shortfall
+                    ? "Spark has no record of this sweep, but the wallet held less than the sweep would have "
+                      + "sent when it was checked, so sweeping was blocked for an hour of re-checks before "
+                      + "this was written off. Most likely another spend — a payout, or a Stable Balance "
+                      + "conversion — moved the balance and nothing was sent, but verify the wallet's payment "
+                      + "history and the destination address before assuming so."
+                    : record.IdempotencyKeyAccepted
                     ? "Spark has no record of this sweep. Most likely nothing was sent and the balance is still "
                       + "on the Spark wallet, in which case the next pass will try again — but check the Spark "
                       + "balance against your sweep history before assuming so."

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
@@ -1253,8 +1253,12 @@ public sealed class SparkSweepEngine
                     asset, string.Join(", ", UsdStablecoins)));
         }
 
-        // What arrives, in dollars.
+        // What arrives, in dollars. Null means the number did not fit a decimal — a value this method cannot
+        // check is a quote it must refuse, not wave through: treating "too large to convert" as "nothing to
+        // check" would exempt exactly the absurdly-sized quotes this guard exists to catch.
         var deliveredUsd = ToDecimal(quote.EstimatedOut, quote.Route.Decimals);
+        if (deliveredUsd is null)
+            return UnverifiableValueRefusal(quote.EstimatedOut, quote.Route.Decimals, "deliver");
         if (deliveredUsd <= 0)
             return null; // Already refused by the quote-shape check.
 
@@ -1263,7 +1267,10 @@ public sealed class SparkSweepEngine
         {
             case SparkSendAmount.Token token:
                 // Both sides are USD-pegged, so no price is needed and none is fetched.
-                debitedUsd = ToDecimal(token.BaseUnits, token.Decimals);
+                var debited = ToDecimal(token.BaseUnits, token.Decimals);
+                if (debited is null)
+                    return UnverifiableValueRefusal(token.BaseUnits, token.Decimals, "take out of the wallet");
+                debitedUsd = debited.Value;
                 break;
 
             case SparkSendAmount.Bitcoin:
@@ -1304,15 +1311,24 @@ public sealed class SparkSweepEngine
             debitedUsd, deliveredUsd, lossPercent, MaxCrossChainValueLossPercent));
     }
 
-    private static decimal ToDecimal(BigInteger baseUnits, uint decimals)
+    private static SweepRefusal UnverifiableValueRefusal(BigInteger baseUnits, uint decimals, string direction) =>
+        new(SweepRefusalCode.CrossChainValueUnverifiable, string.Format(
+            CultureInfo.InvariantCulture,
+            "This quote would {0} an amount ({1} base units at {2} decimals) too large for this plugin to "
+            + "convert to a dollar value, so it cannot be checked for sane pricing and nothing was sent.",
+            direction, baseUnits, decimals));
+
+    private static decimal? ToDecimal(BigInteger baseUnits, uint decimals)
     {
         var scale = BigInteger.Pow(10, (int)Math.Min(decimals, 28));
         var whole = BigInteger.DivRem(baseUnits, scale, out var fraction);
 
-        // Guarded against decimal overflow, which an 18-decimal token reaches for quite ordinary sums. A value
-        // that does not fit is not a value this can check, and returning zero makes the caller refuse.
+        // Guarded against decimal overflow, which an 18-decimal token reaches for quite ordinary sums. Null,
+        // not zero: zero already means "the quote-shape check refused this before we got here", and a caller
+        // reading an overflowed value as zero would skip its check exactly when the number is at its most
+        // absurd. Callers must refuse on null.
         if (whole > new BigInteger(decimal.MaxValue / 2))
-            return 0m;
+            return null;
 
         return (decimal)whole + ((decimal)fraction / (decimal)scale);
     }
@@ -1582,6 +1598,9 @@ public sealed class SparkSweepEngine
 
         SweepRecord? blocking = null;
         var refundNeeded = false;
+        // Set by the first write-off candidate, once per pass: the balance after an explicit SyncWallet, which
+        // is what the write-off gate below compares against. Null means no candidate has forced a sync yet.
+        long? syncedBalance = null;
         foreach (var record in records)
         {
             SparkPayment? payment;
@@ -1606,6 +1625,52 @@ public sealed class SparkSweepEngine
                 continue;
             }
 
+            if (payment is null && record.IsInFlight && now - record.CreatedAt >= UnresolvedGrace)
+            {
+                // This row is a write-off candidate, and the write-off below is the one decision in this pass
+                // that can unblock a re-sweep — so it may not run on stale storage. The null above was read
+                // before any sync, and an SSP-accepted exit the SDK has not replayed locally yet looks exactly
+                // like "never sent". One explicit sync per pass (GetInfo(ensureSynced) alone was observed
+                // staying stale; see the class remarks), then the lookup is repeated. A sync or re-read
+                // failure keeps the row blocking: refusing to sweep is always the safe direction.
+                if (syncedBalance is null)
+                {
+                    try
+                    {
+                        await sdk.SyncWalletAsync(cancellationToken).ConfigureAwait(false);
+                        var info = await sdk.GetInfoAsync(ensureSynced: true, cancellationToken)
+                            .ConfigureAwait(false);
+                        syncedBalance = info.BalanceSats;
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "Store {StoreId}: could not sync the Spark wallet to confirm sweep "
+                            + "{IdempotencyKey} was never sent; keeping it blocking",
+                            storeId, record.IdempotencyKey);
+                        blocking ??= record;
+                        continue;
+                    }
+                }
+
+                try
+                {
+                    payment = record.IdempotencyKeyAccepted
+                        ? await sdk.GetPaymentAsync(record.IdempotencyKey, cancellationToken)
+                            .ConfigureAwait(false)
+                        : await ResolveByQuoteIdAsync(storeId, sdk, record, cancellationToken)
+                            .ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Store {StoreId}: could not re-read sweep {IdempotencyKey} after a sync",
+                        storeId, record.IdempotencyKey);
+                    blocking ??= record;
+                    continue;
+                }
+            }
+
             if (payment is null)
             {
                 if (!record.IsInFlight)
@@ -1613,6 +1678,26 @@ public sealed class SparkSweepEngine
 
                 if (now - record.CreatedAt < UnresolvedGrace)
                 {
+                    blocking ??= record;
+                    continue;
+                }
+
+                // The last gate before the write-off, for the rows whose send would have debited sats: if the
+                // synced balance no longer holds what this sweep would have sent, "no payment under the key"
+                // stops being evidence of "never sent" and starts looking like an accepted exit the SDK has
+                // not recorded — the one case where closing the row and re-planning would send real money
+                // twice. Receives only ever raise the balance and this engine is the store's only spender, so
+                // a shortfall here is not explainable by ordinary traffic. The row keeps blocking until the
+                // payment surfaces or an operator intervenes. Token-funded rows are not gated — their amount
+                // is not in sats — but their write-off never re-sends, so the hazard this guards is absent.
+                if (record.IdempotencyKeyAccepted && syncedBalance < record.AmountSats)
+                {
+                    _logger.LogError(
+                        "Store {StoreId}: sweep {IdempotencyKey} has no payment record, but the synced balance "
+                        + "({BalanceSats} sat) is below the {AmountSats} sat it would have sent — refusing to "
+                        + "write it off as never sent, because the shortfall suggests it was. The store stays "
+                        + "blocked; check the wallet's history and the destination before intervening",
+                        storeId, record.IdempotencyKey, syncedBalance, record.AmountSats);
                     blocking ??= record;
                     continue;
                 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,20 @@ against the source before fixing:
   landed there was world-readable; the mode is now passed to the creation itself, and the storage lock file
   is created owner-only too.
 
+Two follow-ups from the quorum's review of the fixes themselves:
+
+- **The write-off shortfall gate is bounded, not absolute.** The gate's observation — funds missing with no
+  payment record — is also produced by a Lightning payout or a Stable Balance conversion landing near a
+  sweep that genuinely never went out, and sweeps are close enough to the whole balance that any spend trips
+  it. Unbounded, that coincidence would wedge the store's sweeping permanently with no operator escape; the
+  gate now blocks for an hour of synced re-checks and then writes the row off with a reason stating exactly
+  what was observed and what to verify.
+- **A provisioning rollback now also covers a throwing Lightning-configuration write.** With the key
+  rotating, settings carrying a new key beside a configuration still holding the old string is a store whose
+  checkout fails; a throw out of the wiring write now restores the previous settings the same way a refused
+  write always did. A process crash inside that window is still detectable and repairable from the status
+  page, which inspects the wiring against the stored key.
+
 ### Changed
 
 - **The Spark SDK is now 0.22.3**, up from 0.22.2, on the review's recommendation: the one upstream change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,48 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
+## [Unreleased]
+
+### Security
+
+Findings from the v0.1.4 external security review (a three-model quorum over the release tag), each verified
+against the source before fixing:
+
+- **A sweep write-off can no longer unblock a re-sweep on stale storage.** After the five-minute grace, a
+  pending sweep the SDK had no payment for was written off as never sent — but that lookup ran before the
+  pass's forced sync, and an SSP-accepted exit the SDK had not replayed locally yet looks exactly like
+  "never sent". The write-off now forces an explicit wallet sync and repeats the lookup first, and for
+  sats-funded rows it additionally refuses to close the row while the synced balance no longer holds the
+  amount the sweep would have sent — the shape that suggests the exit actually happened. A row the gate
+  refuses keeps blocking new sweeps, which is the safe direction.
+- **A cross-chain send now checks the provider's echoed recipient against the requested destination.** The
+  prepared payment's recipient is an echo from the provider, and every guard downstream is amount-shaped —
+  none of them would have noticed the money going to the right chain at the wrong address. A mismatch
+  refuses the send.
+- **The cross-chain value guard refuses amounts too large to value, instead of skipping itself.** The
+  base-unit-to-dollar conversion reported an overflowing value as zero, and the guard read zero as "already
+  refused upstream" — so the most absurdly sized quotes were exactly the ones that bypassed the value check.
+  Overflow is now an explicit refusal.
+- **The payment key is rotated on every provision.** The connection string is a bearer spend credential;
+  re-provisioning previously carried the old key over, so every previously issued copy of the string could
+  drive the new wallet. Setting Spark up again now mints a fresh key and rewrites the store's Lightning
+  configuration with it in the same operation — which also makes re-running setup the way to revoke a
+  leaked string.
+- **A wallet that has not reported its identity yet bypasses the deposit-address cache.** The cache was
+  keyed on an empty identity like any other, so after a seed change a request racing the new wallet's first
+  sync could be handed the previous wallet's deposit address. An unknown identity now always fetches a live
+  address and caches nothing.
+- **The plugin's directories are owner-only from the instant they exist.** Storage and log directories were
+  created at the process umask (0755) and restricted to 0700 afterwards, leaving a window in which what
+  landed there was world-readable; the mode is now passed to the creation itself, and the storage lock file
+  is created owner-only too.
+
+### Changed
+
+- **The Spark SDK is now 0.22.3**, up from 0.22.2, on the review's recommendation: the one upstream change
+  ("stop cross-chain sends claiming their own outgoing transfer") is an accounting fix directly on the
+  cross-chain rail this plugin uses.
+
 ## [0.1.4] — 2026-08-21
 
 ### Changed

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -32,7 +32,9 @@ can save it on *another* store on the same server and drive this store's wallet 
 and spend from it. The embedded store id binds the key to a wallet; it does not bind the string to the store
 it was saved on, because BTCPay's `ILightningConnectionStringHandler` never tells a handler which store is
 being configured. This is the same property an LND macaroon has, with one difference worth knowing: the
-plugin generated this credential for you rather than you choosing to issue it, and it is **not rotated** when
-Spark is re-provisioned, so it outlives the access of whoever saw it and is invalidated only by removing
-Spark from the store and setting it up again. Treat it like a macaroon, and keep the sweep threshold low
-enough that the balance it could reach is a balance you can afford to lose.
+plugin generated this credential for you rather than you choosing to issue it. It **is rotated on every
+provision** — setting Spark up again (same seed or a new one) mints a fresh key and rewrites the store's
+Lightning configuration with it, invalidating every copy of the old string — so a leaked string is revoked
+by re-running setup, without waiting for a removal. Between provisions it never expires. Treat it like a
+macaroon, and keep the sweep threshold low enough that the balance it could reach is a balance you can
+afford to lose.


### PR DESCRIPTION
Implements the actionable findings from the v0.1.4 security review, each verified against the source before changing anything.

**Fixed (register # / recommendation):**
- **#1 (P2) — grace write-off re-sweep window.** The write-off in `ResolveUnresolvedAsync` ran on a payment lookup taken before the pass's forced sync, so an SSP-accepted exit not yet replayed into local storage read as "never sent" and unblocked a fresh-key re-sweep. It now forces an explicit `SyncWallet` (once per pass), repeats the lookup, and for sats-funded rows refuses to close the row while the synced balance no longer holds the sweep's amount — the accepted-but-unrecorded shape. Refused rows keep blocking.
- **#2 (P2) — cross-chain recipient echo.** `PrepareCrossChainAsync` now compares the provider-echoed recipient to the requested destination (case-insensitive, for EIP-55 vs lowercased) and refuses on mismatch.
- **#5 (P3) — value-guard fail-open.** `ToDecimal` overflow was returned as 0, which both callers read as "nothing to check"; it now returns null and the guard refuses with `CrossChainValueUnverifiable`.
- **#6 (P3) — deposit-address cache.** An empty wallet identity bypasses the cache in both directions instead of keying it, so a request racing a new wallet's first sync can never be handed the previous wallet's address.
- **#13 (P3) — umask window.** Storage/log directories are created 0700 atomically (`SparkDirectoryPermissions.CreateOwnerOnly`); the storage lock file is created owner-only.
- **Rec 1 — Breez.Sdk.Spark 0.22.2 → 0.22.3.** Verified upstream: the single change is "Stop cross-chain sends claiming their own outgoing transfer", an accounting fix on the plugin's cross-chain rail.
- **Rec 3 — payment-key rotation.** Every provision mints a fresh key and rewrites the Lightning wiring with it in the same operation, so re-running setup revokes every previously issued connection string. Trust-model doc updated (it previously documented the key as never rotated).

**Evaluated, no change (owner-accepted / documented / deferred):** #3 plaintext payment key (architectural, macaroon model — rotation above is the mitigation the review asked for), #4 token `amountIn` semantics (blocked on verification with Breez before relying on mainnet cross-chain), #7 provider-trusted settlement amounts, #8 same-seed-two-servers, #9 startup sync storm, #10 `Safe.Json` credential render (matches core), #11 sdk.log/storage.sql audit, #12 hot-wallet seed reuse, #14 log rotation (ops), #15 removed-store retention, #16 embedded shared API key (documented not-a-secret). Rec 4's caveats are already stated in the trust model and README; the rotation passage was the one statement that needed changing.

New unit tests cover every behavioural change (write-off gate, sync-surfaced resolution, failed-sync blocking, overflow refusal, cache bypass, key rotation); 1064 unit tests pass locally. The funded regtest suite on this PR exercises the write-off path against the real SSP.