### PR TITLE
Release 0.1.4.1

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -174,8 +174,11 @@ jobs:
           built="$(basename "$ARTIFACT_DIR")"
           IFS=. read -r major minor patch _rest <<< "$built"
           built3="${major:-0}.${minor:-0}.${patch:-0}"
-          if [ "v$built3" != "$TAG" ]; then
-            echo "error: tag $TAG does not match the built plugin version v$built3" \
+          # A tag may name three components (v0.1.4) or all four (v0.1.4.1, a point release whose fourth
+          # component is real, not the assembly-version padding built3 exists to strip). Accept the tag when
+          # it matches either reading; reject everything else.
+          if [ "v$built3" != "$TAG" ] && [ "v$built" != "$TAG" ]; then
+            echo "error: tag $TAG does not match the built plugin version v$built3 or v$built" \
                  "(PluginPacker reported '$built')." >&2
             echo "Bump <Version> in $PROJECT_PATH, or retag." >&2
             exit 1

--- a/BTCPayServer.Plugins.Flint.Tests/PluginVersionTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/PluginVersionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -38,9 +39,11 @@ public class PluginVersionTests
     {
         var declared = CsprojVersion();
 
-        // The csproj carries three components and the assembly attribute is padded to four, so compare on the
-        // three that are authored. Revision is never set deliberately and must not become a fourth thing to bump.
-        Assert.Equal(declared, ThreeComponents(ReportedVersion));
+        // The assembly attribute is always padded to four components, so compare on however many the csproj
+        // actually authors: three normally, four for a point release (0.1.4.1). An unauthored revision is
+        // padding to strip, never a fourth thing to bump.
+        var authored = declared.Count(c => c == '.') + 1;
+        Assert.Equal(declared, Components(ReportedVersion, authored));
     }
 
     [Fact]
@@ -50,7 +53,7 @@ public class PluginVersionTests
 
         // The newest entry is the first "## [x.y.z]" heading in the file. Keep-a-Changelog order is
         // newest-first, so anything else means the file has been edited in the wrong place.
-        var newest = Regex.Match(changelog, @"^##\s*\[(?<version>\d+\.\d+\.\d+)\]", RegexOptions.Multiline);
+        var newest = Regex.Match(changelog, @"^##\s*\[(?<version>\d+\.\d+\.\d+(?:\.\d+)?)\]", RegexOptions.Multiline);
         Assert.True(newest.Success, "CHANGELOG.md has no '## [x.y.z]' heading; the newest release must have one.");
 
         Assert.Equal(CsprojVersion(), newest.Groups["version"].Value);
@@ -89,12 +92,15 @@ public class PluginVersionTests
         Assert.True(match.Success, "BTCPayServer.Plugins.Flint.csproj has no <Version> property.");
 
         var version = match.Groups["version"].Value.Trim();
-        Assert.Matches(@"^\d+\.\d+\.\d+$", version);
+        // Three components normally; a fourth only for a point release cut from an already-tagged version.
+        Assert.Matches(@"^\d+\.\d+\.\d+(\.\d+)?$", version);
         return version;
     }
 
-    private static string ThreeComponents(Version version) =>
-        $"{version.Major}.{version.Minor}.{Math.Max(version.Build, 0)}";
+    private static string Components(Version version, int count) =>
+        count >= 4
+            ? $"{version.Major}.{version.Minor}.{Math.Max(version.Build, 0)}.{Math.Max(version.Revision, 0)}"
+            : $"{version.Major}.{version.Minor}.{Math.Max(version.Build, 0)}";
 
     private static string RepoRoot()
     {

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -45,7 +45,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>0.1.4</Version>
+    <Version>0.1.4.1</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
-## [Unreleased]
+## [0.1.4.1] — 2026-08-21
 
 ### Security
 


### PR DESCRIPTION
Bumps `<Version>` to 0.1.4.1 and dates the changelog's Unreleased section, covering the security-review fixes and the Breez.Sdk.Spark 0.22.3 bump merged in #25.

First four-component point release, so two pieces of version plumbing learn to accept an authored fourth component: `PluginVersionTests` (regexes plus comparing on however many components the csproj authors) and `package.yml`'s tag guard (accepts `v<built3>` or the full `v<built>`). Unauthored assembly padding is still stripped, and three-part releases behave exactly as before.

Will be tagged `v0.1.4.1` and published as a **pre-release** pending the security scan of the tag.