### PR TITLE
Address the third external review pass

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -150,6 +150,25 @@ jobs:
           artifact_dir="$(dirname "$btcpay_file")"
           echo "dir=$artifact_dir" >> "$GITHUB_OUTPUT"
 
+      # The .btcpay redistributes Breez's MIT-licensed binaries, and the licence requires their copyright
+      # and permission notices to travel with them — NOTICE carries those, LICENSE is this plugin's own.
+      # The csproj copies both into the build output PluginPacker zips; this step is what makes forgetting
+      # that copy a failed build instead of a non-redistributable artifact.
+      - name: Licence notices are inside the artifact
+        env:
+          ARTIFACT_DIR: ${{ steps.artifact.outputs.dir }}
+        run: |
+          set -euo pipefail
+          btcpay_file="$(find "$ARTIFACT_DIR" -name '*.btcpay' -print -quit)"
+          for required in NOTICE LICENSE; do
+            if ! python3 -c "import sys, zipfile; sys.exit(0 if '$required' in zipfile.ZipFile('$btcpay_file').namelist() else 1)"; then
+              echo "error: $required is not inside $btcpay_file; the packaged plugin redistributes" \
+                   "Breez's MIT-licensed binaries and must carry their notices" >&2
+              exit 1
+            fi
+          done
+          echo "NOTICE and LICENSE are inside the artifact."
+
       # A tag is the one input to this workflow that nothing else validates. Note what is and is not
       # at stake: the plugin registry does *not* key anything off the tag -- it reads the version out
       # of the PluginPacker manifest, and takes a git ref only as something to clone -- and BTCPay
@@ -175,15 +194,19 @@ jobs:
           IFS=. read -r major minor patch _rest <<< "$built"
           built3="${major:-0}.${minor:-0}.${patch:-0}"
           # A tag may name three components (v0.1.4) or all four (v0.1.4.1, a point release whose fourth
-          # component is real, not the assembly-version padding built3 exists to strip). Accept the tag when
-          # it matches either reading; reject everything else.
-          if [ "v$built3" != "$TAG" ] && [ "v$built" != "$TAG" ]; then
-            echo "error: tag $TAG does not match the built plugin version v$built3 or v$built" \
+          # component is real). The three-component reading is only valid when the built fourth component is
+          # assembly padding — absent or zero — because accepting v0.1.4 for a 0.1.4.1 build would publish a
+          # release page that lies about its own artifact, which is the exact thing this guard exists to stop.
+          if [ "v$built" = "$TAG" ]; then
+            echo "Tag $TAG matches the built plugin version exactly."
+          elif [ "v$built3" = "$TAG" ] && { [ -z "${_rest:-}" ] || [ "${_rest}" = "0" ]; }; then
+            echo "Tag $TAG matches the built plugin version (fourth component is padding)."
+          else
+            echo "error: tag $TAG does not match the built plugin version" \
                  "(PluginPacker reported '$built')." >&2
             echo "Bump <Version> in $PROJECT_PATH, or retag." >&2
             exit 1
           fi
-          echo "Tag $TAG matches the built plugin version."
 
       # Keyless signing. See the note at the top of this file for why this rather than a GPG key in
       # a repository secret. Runs on workflow_dispatch too, so the path is proven before a release

--- a/BTCPayServer.Plugins.Flint.Tests/BreezApiKeyTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/BreezApiKeyTests.cs
@@ -39,7 +39,9 @@ public class BreezApiKeyTests
     private static string RepoRoot()
     {
         var dir = System.AppContext.BaseDirectory;
-        while (dir is not null && !System.IO.File.Exists(System.IO.Path.Combine(dir, "LICENSE")))
+        // The solution file, not LICENSE: LICENSE is copied into the build output so it ships inside the
+        // .btcpay, which made it match the bin directory before it matched the repository root.
+        while (dir is not null && !System.IO.File.Exists(System.IO.Path.Combine(dir, "BTCPayServer.Plugins.Flint.slnx")))
             dir = System.IO.Directory.GetParent(dir)?.FullName;
         return dir ?? throw new System.InvalidOperationException("repo root not found");
     }

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemorySweepRecordStore.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemorySweepRecordStore.cs
@@ -1,4 +1,6 @@
 using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Sdk;
+using BTCPayServer.Plugins.Flint.Services;
 
 namespace BTCPayServer.Plugins.Flint.Tests.Fakes;
 
@@ -106,10 +108,16 @@ public sealed class InMemorySweepRecordStore : ISweepRecordStore
         DateTimeOffset sentCreatedAfter,
         CancellationToken cancellationToken = default) =>
         Task.FromResult<IReadOnlyList<SweepRecord>>(_records.Values
-            // Pending unbounded, Sent age-bounded — as in the EF store.
+            // Pending unbounded, Sent age-bounded, non-terminal cross-chain conversions exempt from the age
+            // bound — as in the EF store.
             .Where(r => r.StoreId == storeId
                         && (r.Status is SweepRecordStatus.Pending
-                            || (r.Status is SweepRecordStatus.Sent && r.CreatedAt > sentCreatedAfter)))
+                            || (r.Status is SweepRecordStatus.Sent
+                                && (r.CreatedAt > sentCreatedAfter
+                                    || (r.DestinationKind is SweepDestinationKind.EvmAddress
+                                        && r.ConversionStatus is not (SparkConversionStatus.Completed
+                                            or SparkConversionStatus.Failed
+                                            or SparkConversionStatus.Refunded))))))
             .OrderBy(r => r.CreatedAt)
             .ThenBy(r => r.IdempotencyKey, StringComparer.Ordinal)
             .Select(Copy)
@@ -223,6 +231,7 @@ public sealed class InMemorySweepRecordStore : ISweepRecordStore
         record.ConversionStatus = resolution.ConversionStatus ?? record.ConversionStatus;
         record.DeliveredAmountBaseUnits =
             resolution.DeliveredAmountBaseUnits ?? record.DeliveredAmountBaseUnits;
+        record.ProviderOrderId = resolution.ProviderOrderId ?? record.ProviderOrderId;
 
         _writeLog?.Record($"sweep:resolve:{idempotencyKey}:{resolution.Status}");
         return Task.FromResult(true);

--- a/BTCPayServer.Plugins.Flint.Tests/FundedRegtest/FundedRegtestWallet.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/FundedRegtest/FundedRegtestWallet.cs
@@ -241,14 +241,16 @@ public sealed class FundedRegtestWallet : IAsyncLifetime
         if (_mnemonic is null)
             return;
 
+        string? seedLeak = null;
         try
         {
-            WriteAudit();
+            seedLeak = WriteAudit();
         }
         catch (Exception ex)
         {
             // A failed artefact write must not turn a green suite red: the artefact is evidence for a human,
-            // not a result. The tests carry their own assertions.
+            // not a result. The tests carry their own assertions. A *detected seed leak* is the one exception,
+            // thrown below — outside this catch — so a broken artefact writer cannot swallow it.
             Console.WriteLine($"funded-regtest: could not write the log-audit artefact: {ex}");
         }
 
@@ -267,6 +269,14 @@ public sealed class FundedRegtestWallet : IAsyncLifetime
         }
 
         TryDeleteStorage();
+
+        if (seedLeak is not null)
+        {
+            // Hard failure, not just a withheld attachment: a run that leaked the funded wallet's seed into a
+            // log is a security regression, and a red suite is the only signal nobody can skim past. Thrown
+            // last so the artefacts are written and the SDK is torn down before the run turns red.
+            throw new InvalidOperationException($"funded-regtest seed leak: {seedLeak}");
+        }
     }
 
     /// <summary>
@@ -287,7 +297,11 @@ public sealed class FundedRegtestWallet : IAsyncLifetime
     /// assert against it — but it must not also be a publication.
     /// </para>
     /// </remarks>
-    private void WriteAudit()
+    /// <returns>
+    /// A leak description when the wallet seed appeared in either log surface, null otherwise. Returned rather
+    /// than thrown so the artefact — the evidence — is fully written before the caller turns the run red.
+    /// </returns>
+    private string? WriteAudit()
     {
         var directory = Environment.GetEnvironmentVariable(ArtifactVariable) is { } configured
             && !string.IsNullOrWhiteSpace(configured)
@@ -355,8 +369,9 @@ public sealed class FundedRegtestWallet : IAsyncLifetime
             report.AppendLine($"| {identifier.Kind} | `{identifier.Value}` | {inForwarded} | {inRaw} |");
         }
 
+        var forwardedCarriesSeed = SeedAppearsIn(forwardedText, _mnemonic!);
         report.AppendLine("| wallet seed | *(not printed)* | "
-            + $"{(SeedAppearsIn(forwardedText, _mnemonic!) ? "**PRESENT — this is a leak**" : "0")} | "
+            + $"{(forwardedCarriesSeed ? "**PRESENT — this is a leak**" : "0")} | "
             + $"{(raw is null ? "n/a" : rawCarriesSeed ? "**PRESENT — this is a leak**" : "0")} |");
         report.AppendLine();
 
@@ -405,6 +420,19 @@ public sealed class FundedRegtestWallet : IAsyncLifetime
             + "measurement. That is the whole point of this artefact.");
 
         File.WriteAllText(Path.Combine(directory, "preimage-audit.md"), report.ToString());
+
+        // The verdict, after the evidence is on disk. Never includes a seed word — the fingerprint is enough
+        // to match the report, and the report itself withholds the leaking file.
+        if (forwardedCarriesSeed)
+        {
+            return "the wallet seed appears in the FORWARDED (post-scrub) log — the scrubber has a hole. "
+                   + $"Seed fingerprint {SeedFingerprint}; see preimage-audit.md in the run artefacts.";
+        }
+
+        return rawCarriesSeed
+            ? "the wallet seed appears in the raw sdk.log written by the Rust SDK. The file was withheld from "
+              + $"the artefacts; seed fingerprint {SeedFingerprint}, details in preimage-audit.md."
+            : null;
     }
 
     private IReadOnlyList<KnownIdentifier> Snapshot()

--- a/BTCPayServer.Plugins.Flint.Tests/PluginVersionTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/PluginVersionTests.cs
@@ -105,7 +105,9 @@ public class PluginVersionTests
     private static string RepoRoot()
     {
         var dir = AppContext.BaseDirectory;
-        while (dir is not null && !File.Exists(Path.Combine(dir, "LICENSE")))
+        // The solution file, not LICENSE: LICENSE is copied into the build output so it ships inside the
+        // .btcpay, which made it match the bin directory before it matched the repository root.
+        while (dir is not null && !File.Exists(Path.Combine(dir, "BTCPayServer.Plugins.Flint.slnx")))
             dir = Directory.GetParent(dir)?.FullName;
         return dir ?? throw new InvalidOperationException("repo root not found");
     }

--- a/BTCPayServer.Plugins.Flint.Tests/Postgres/PostgresConcurrencyTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Postgres/PostgresConcurrencyTests.cs
@@ -1,5 +1,7 @@
 using BTCPayServer.Plugins.Flint.Data;
 using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
 using Xunit;
 
 namespace BTCPayServer.Plugins.Flint.Tests.Postgres;
@@ -260,8 +262,11 @@ public class PostgresConcurrencyTests
                 await store.AddAsync(NewSweep(key), Ct);
                 return true;
             }
-            catch (Exception)
+            catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" })
             {
+                // Only a unique-key violation counts as losing the race. Any other exception — a connection
+                // failure, a mapping bug — must fail the test rather than masquerade as the loser: swallowed
+                // whole, a store that errored on every insert would pass the "exactly one won" assertion.
                 return false;
             }
         }).ToArray();

--- a/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
@@ -993,6 +993,10 @@ public class SparkCrossChainSweepTests
         Assert.Equal(SweepRecordStatus.Confirmed, resolved!.Status);
         Assert.Equal(SparkConversionStatus.Completed, resolved.ConversionStatus);
         Assert.Equal("35100000", resolved.DeliveredAmountBaseUnits);
+        // The provider order id rides on the same recovery resolution as the delivered amount: it is the handle
+        // a stuck-delivery investigation quotes at the provider, and the crash-recovery poll is exactly the
+        // path that used to drop it (the initial send had already persisted it).
+        Assert.Equal("order-1", resolved.ProviderOrderId);
 
         // Never looked the row's own key up as a payment id — it is not one.
         Assert.DoesNotContain(row.IdempotencyKey, h.Sdk.GetPaymentCalls);
@@ -1062,6 +1066,10 @@ public class SparkCrossChainSweepTests
         var recovered = await h.Records.GetAsync(StoreId, key, Ct);
         Assert.Equal(SweepRecordStatus.Sent, recovered!.Status);
         Assert.Equal(SparkConversionStatus.Pending, recovered.ConversionStatus);
+        // The order id the crash-window recovery poll resolves from is the same one the send reported: the
+        // crash happened before the initial resolution, so the recovery poll is the only thing that can
+        // persist it.
+        Assert.Equal(payment.Conversion!.ProviderOrderId, recovered.ProviderOrderId);
 
         // Found by scanning, not by a point lookup, and never re-sent.
         Assert.DoesNotContain(key, h.Sdk.GetPaymentCalls);

--- a/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
@@ -1162,6 +1162,55 @@ public class SparkCrossChainSweepTests
     }
 
     /// <summary>
+    /// A token write-off is gated on the token balance exactly as a sats write-off is gated on sats.
+    /// </summary>
+    /// <remarks>
+    /// The hazard is sharper here than on the sats rail: the row itself is never retried, but writing it off
+    /// unblocks this very pass to plan a fresh sweep from the token balance — and a token send cannot carry an
+    /// idempotency key, so nothing at the provider can dedupe a second one. When the held balance is below what
+    /// the row says was sent, the send may well have happened and just not be visible yet; the row must block,
+    /// bounded by the same escalation window as the sats gate.
+    /// </remarks>
+    [Fact]
+    public async Task A_token_write_off_is_blocked_while_the_token_balance_suggests_the_send_happened()
+    {
+        // The row says 35.6 USDB went out; the wallet holds 30. The shortfall keeps it blocking...
+        var h = Harness(balanceSats: 500_000, stableBalance: 30_000_000);
+
+        await h.Records.AddAsync(
+            new SweepRecord
+            {
+                IdempotencyKey = "row-key-3",
+                StoreId = StoreId,
+                DestinationMode = SweepDestinationMode.EvmAddress,
+                DestinationKind = SweepDestinationKind.EvmAddress,
+                IdempotencyKeyAccepted = false,
+                ProviderQuoteId = "q_that_matches_nothing",
+                SourceTokenIdentifier = FakeSparkSdkClient.Usdb.Value,
+                SourceAmountBaseUnits = "35600000",
+                Status = SweepRecordStatus.Pending,
+                CreatedAt = Origin,
+                AttemptCount = 1
+            },
+            Ct);
+
+        h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromMinutes(1));
+        var blocked = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        Assert.Equal(SweepOutcomeKind.InFlight, blocked.Kind);
+        Assert.Empty(h.Sdk.CrossChainSendCalls);
+        Assert.Equal(SweepRecordStatus.Pending, (await h.Records.GetAsync(StoreId, "row-key-3", Ct))!.Status);
+
+        // ...and past the escalation window it closes with a reason naming what was observed.
+        h.Time.Advance(SparkSweepEngine.ShortfallWriteOffAge);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+
+        var closed = await h.Records.GetAsync(StoreId, "row-key-3", Ct);
+        Assert.Equal(SweepRecordStatus.Failed, closed!.Status);
+        Assert.Contains("held less than the sweep would have sent", closed.Error);
+    }
+
+    /// <summary>
     /// A row with no recorded quote id is closed rather than guessed at.
     /// </summary>
     /// <remarks>

--- a/BTCPayServer.Plugins.Flint.Tests/SparkLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkLightningClientTests.cs
@@ -892,6 +892,46 @@ public class SparkLightningClientTests
     }
 
     [Fact]
+    public void Pay_refuses_a_negative_fee_quote_under_every_limit()
+    {
+        // A provider u64 fee cast raw to long wraps negative past long.MaxValue, and every limit here is a
+        // `<=` — so a wrapped fee would pass the caller's limit, the default limit, all of them. The
+        // conversions saturate now, and this refusal is the backstop for any path that missed one.
+        var negative = new SparkSendQuote(1000, -1, Hash);
+
+        Assert.NotNull(SparkLightningClient.ApproveFee(negative, null, 1000));
+        Assert.NotNull(SparkLightningClient.ApproveFee(
+            negative, new PayInvoiceParams { MaxFeeFlat = Money.Satoshis(1_000_000) }, 1000));
+        Assert.NotNull(SparkLightningClient.ApproveFee(
+            new SparkSendQuote(1000, long.MinValue, Hash), new PayInvoiceParams(), 1000));
+    }
+
+    [Fact]
+    public void Provider_fee_conversions_saturate_instead_of_wrapping()
+    {
+        Assert.Equal(5, SparkSdkClient.ToSatsSaturating(5));
+        Assert.Equal(long.MaxValue, SparkSdkClient.ToSatsSaturating((ulong)long.MaxValue));
+        Assert.Equal(long.MaxValue, SparkSdkClient.ToSatsSaturating((ulong)long.MaxValue + 1));
+        Assert.Equal(long.MaxValue, SparkSdkClient.ToSatsSaturating(ulong.MaxValue));
+
+        Assert.Equal(7, SparkSdkClient.SaturatingAdd(3, 4));
+        Assert.Equal(long.MaxValue, SparkSdkClient.SaturatingAdd(long.MaxValue, 1));
+        Assert.Equal(long.MaxValue, SparkSdkClient.SaturatingAdd(long.MaxValue - 3, 10));
+        Assert.Equal(long.MaxValue, SparkSdkClient.SaturatingAdd(long.MaxValue, long.MaxValue));
+    }
+
+    [Fact]
+    public void An_extreme_requested_amount_does_not_wrap_into_an_amountless_invoice()
+    {
+        // (msat + 999) / 1000 wraps negative near long.MaxValue, and a non-positive result downstream means
+        // "amountless invoice" — an absurd requested amount must stay absurd, never become anything-goes.
+        var sats = SparkLightningClient.ToAmountSats(LightMoney.MilliSatoshis(long.MaxValue));
+
+        Assert.NotNull(sats);
+        Assert.Equal(long.MaxValue / 1000 + 1, sats);
+    }
+
+    [Fact]
     public async Task Pay_requires_an_amount_for_an_amountless_invoice()
     {
         var (client, sdk, _, _, _) = Create(new Bolt11Info(Hash, DateTimeOffset.UtcNow.AddHours(1), null));

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSettlementBroadcasterTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSettlementBroadcasterTests.cs
@@ -151,6 +151,61 @@ public class SparkSettlementBroadcasterTests
 
 
     [Fact]
+    public async Task A_saturated_settlement_is_retried_once_the_consumer_catches_up()
+    {
+        // The refusal is not the end of the story: BTCPay does not re-poll listened invoices and the
+        // reconciliation task only scans unpaid rows, so a refused push that is simply dropped would leave
+        // the BTCPay invoice unpaid until a restart. The broadcaster must hold it and re-deliver when the
+        // listener drains.
+        var broadcaster = Create();
+        using var subscription = broadcaster.Subscribe("store-1");
+
+        // Fill the bounded queue so the next publish is refused and held for retry.
+        for (var i = 0; i < 256; i++)
+            broadcaster.Publish(Settlement(hash: i.ToString("x64")));
+
+        var retried = Settlement(hash: "f".PadLeft(64, 'f'));
+        broadcaster.Publish(retried);
+
+        // The consumer catches up, draining the queue…
+        for (var i = 0; i < 256; i++)
+            await subscription.ReadAsync(TestContext.Current.CancellationToken);
+
+        // …and the retry tick re-delivers what was refused.
+        broadcaster.DrainRetries(DateTimeOffset.UtcNow);
+
+        Assert.Same(retried, await subscription.ReadAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task A_retry_that_never_delivers_is_given_up_on_after_the_deadline()
+    {
+        // A consumer wedged past the delivery deadline is not going to drain, so the retry must stop
+        // retrying and say so rather than hold memory or deliver absurdly late.
+        var broadcaster = new SparkSettlementBroadcaster(
+            NullLogger<SparkSettlementBroadcaster>.Instance,
+            pushRetryInterval: TimeSpan.FromMilliseconds(100),
+            pushRetryLifetime: TimeSpan.FromMilliseconds(50),
+            pendingPushCap: 4);
+        using var subscription = broadcaster.Subscribe("store-1");
+
+        for (var i = 0; i < 256; i++)
+            broadcaster.Publish(Settlement(hash: i.ToString("x64")));
+        for (var i = 0; i < 4; i++)
+            broadcaster.Publish(Settlement(hash: (i + 1_000).ToString("x64")));
+
+        // The consumer catches up, but the retry deadline has already passed.
+        for (var i = 0; i < 256; i++)
+            await subscription.ReadAsync(TestContext.Current.CancellationToken);
+        broadcaster.DrainRetries(DateTimeOffset.UtcNow.AddMinutes(1));
+
+        // Nothing more arrives: the held pushes were given up on rather than delivered late.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await subscription.ReadAsync(cts.Token));
+    }
+
+    [Fact]
     public async Task Many_concurrent_subscribers_all_receive()
     {
         var broadcaster = Create();

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSetupViewModelBindingTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSetupViewModelBindingTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using BTCPayServer.Plugins.Flint.Models;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// Pins which setup-form properties model binding may and may not touch.
+/// </summary>
+/// <remarks>
+/// An attribute attaches to the declaration that follows it, comments notwithstanding, so a property moved
+/// without its attribute leaves the attribute on whatever now comes next. That exact slip put
+/// <c>[BindNever]</c> on <see cref="SparkSetupViewModel.EnableSweeping"/>: the setup page's sweeping opt-in
+/// posted true, bound to nothing, and the merchant who asked for auto-sweep did not get it — while
+/// <see cref="SparkSetupViewModel.AlreadyConfigured"/>, the property the attribute was written for, became
+/// overpostable. Reflection is the cheapest honest test: it reads the compiled attribute placement, which is
+/// what the model binder reads.
+/// </remarks>
+public class SparkSetupViewModelBindingTests
+{
+    [Fact]
+    public void The_sweeping_opt_in_is_bindable()
+    {
+        var property = typeof(SparkSetupViewModel).GetProperty(nameof(SparkSetupViewModel.EnableSweeping))!;
+        Assert.Null(property.GetCustomAttribute<BindNeverAttribute>());
+    }
+
+    [Fact]
+    public void The_already_configured_flag_is_not_bindable()
+    {
+        var property = typeof(SparkSetupViewModel).GetProperty(nameof(SparkSetupViewModel.AlreadyConfigured))!;
+        Assert.NotNull(property.GetCustomAttribute<BindNeverAttribute>());
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
@@ -1738,6 +1738,20 @@ public class SparkSweepEngineTests
     }
 
     [Fact]
+    public void ApproveQuote_refuses_a_negative_fee_outright()
+    {
+        // The shape a wrapped provider u64 takes. Every ceiling in this guard is a <=, so a negative fee would
+        // pass all of them — including the 50% hard backstop no configuration can lift.
+        var quote = new SparkOnchainQuote(
+            100_000, -1, true, new SparkOnchainFeeQuote("q", Origin, -1, -1, -1));
+
+        var refusal = SparkSweepEngine.ApproveQuote(new SweepSettings(), quote);
+
+        Assert.NotNull(refusal);
+        Assert.Contains("negative", refusal.Message);
+    }
+
+    [Fact]
     public void ApproveQuote_allows_a_fee_exactly_on_the_limit()
     {
         // 2% of 100,000 delivered is exactly 2,000.

--- a/BTCPayServer.Plugins.Flint.Tests/SweepRecordStoreContractTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SweepRecordStoreContractTests.cs
@@ -219,6 +219,39 @@ public abstract class SweepRecordStoreContractTests
     }
 
     [Fact]
+    public async Task Unresolved_never_ages_out_a_Sent_cross_chain_record_whose_conversion_is_undecided()
+    {
+        // A cross-chain conversion's outcome has no event: it is learned only from the crash-recovery poll
+        // over this very list. Ageing an undecided one out with the sats rows would strand it silently — the
+        // status stuck at Sent forever and a needed refund never requested. Terminal conversions age out
+        // normally; there is nothing left to learn about them.
+        var store = await CreateStoreAsync();
+
+        SweepRecord CrossChain(string key, SparkConversionStatus? conversion)
+        {
+            var record = NewRecord(key, minutesOld: 5_000, status: SweepRecordStatus.Sent);
+            record.DestinationKind = SweepDestinationKind.EvmAddress;
+            record.ConversionStatus = conversion;
+            return record;
+        }
+
+        await store.AddAsync(CrossChain("key-undecided-null", null), Ct);
+        await store.AddAsync(CrossChain("key-undecided-pending", SparkConversionStatus.Pending), Ct);
+        await store.AddAsync(CrossChain("key-refund-needed", SparkConversionStatus.RefundNeeded), Ct);
+        await store.AddAsync(CrossChain("key-completed", SparkConversionStatus.Completed), Ct);
+        await store.AddAsync(CrossChain("key-conversion-failed", SparkConversionStatus.Failed), Ct);
+        await store.AddAsync(CrossChain("key-refunded", SparkConversionStatus.Refunded), Ct);
+        // And an aged sats Sent row, to pin that the exemption is cross-chain-only.
+        await store.AddAsync(NewRecord("key-sats-ancient", minutesOld: 5_000, status: SweepRecordStatus.Sent), Ct);
+
+        var unresolved = await store.ListUnresolvedAsync(StoreId, Origin.AddMinutes(-60), Ct);
+
+        Assert.Equal(
+            ["key-refund-needed", "key-undecided-null", "key-undecided-pending"],
+            unresolved.Select(r => r.IdempotencyKey).OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
     public async Task Unresolved_never_ages_out_a_Pending_record()
     {
         // The bug this pins: an earlier revision aged Pending rows out too, so a store whose wallet stayed down
@@ -611,7 +644,7 @@ public abstract class SweepRecordStoreContractTests
             StoreId, "key-cc2", [SweepRecordStatus.Pending],
             new SweepResolution(
                 SweepRecordStatus.Confirmed, null, null, null, Origin, SweepRefusalCode.None,
-                SparkConversionStatus.Completed, "35480000"),
+                SparkConversionStatus.Completed, "35480000", "order-7f3a"),
             Ct));
 
         // A second pass that learned nothing new — which is the normal case once a sweep has settled.
@@ -623,6 +656,9 @@ public abstract class SweepRecordStoreContractTests
         var stored = await store.GetAsync(StoreId, "key-cc2", Ct);
         Assert.Equal("35480000", stored!.DeliveredAmountBaseUnits);
         Assert.Equal(SparkConversionStatus.Completed, stored.ConversionStatus);
+        // The bridge provider's order id is durable — it is the handle an investigation into a stuck delivery
+        // quotes at the provider, and it used to live only on the in-memory copy the resolving pass held.
+        Assert.Equal("order-7f3a", stored.ProviderOrderId);
     }
 
     #endregion

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -85,6 +85,17 @@
 
   <ItemGroup>
     <!--
+      The packaged .btcpay redistributes Breez's compiled binaries, and NOTICE records the MIT copyright and
+      permission notices that must travel with them (LICENSE is this plugin's own). PluginPacker zips the
+      build output directory, so copying both there is what puts them inside the artifact; package.yml
+      refuses to ship a .btcpay that lacks either.
+    -->
+    <None Include="..\NOTICE" Link="NOTICE" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\LICENSE" Link="LICENSE" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
       The unit tests assert on pure helpers (amount rounding, expiry clamping, UTF-8 truncation, payment-hash
       normalisation, fee-limit arithmetic) that have no business being part of the plugin's public surface.
     -->

--- a/BTCPayServer.Plugins.Flint/Constants.cs
+++ b/BTCPayServer.Plugins.Flint/Constants.cs
@@ -121,7 +121,7 @@ public static class Constants
 
     /// <summary>
     /// Sub-directory of the BTCPay data directory holding per-store SDK storage
-    /// (<c>&lt;DataDir&gt;/Plugins/Spark/&lt;storeId&gt;</c>).
+    /// (<c>&lt;DataDir&gt;/Plugins/Flint/&lt;storeId&gt;</c>).
     /// </summary>
     public const string WorkDirName = "Flint";
 

--- a/BTCPayServer.Plugins.Flint/Data/EfSweepRecordStore.cs
+++ b/BTCPayServer.Plugins.Flint/Data/EfSweepRecordStore.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BTCPayServer.Plugins.Flint.Sdk;
+using BTCPayServer.Plugins.Flint.Services;
 using Microsoft.EntityFrameworkCore;
 
 namespace BTCPayServer.Plugins.Flint.Data;
@@ -96,10 +98,19 @@ public class EfSweepRecordStore : ISweepRecordStore
         return await context.SweepRecords
             .AsNoTracking()
             // Pending is unbounded and Sent is age-bounded, for the reason on the interface: a Pending row is the
-            // one thing that must be chased until Spark answers, however long the wallet stays down.
+            // one thing that must be chased until Spark answers, however long the wallet stays down. One
+            // exception to the age bound: a cross-chain Sent row whose conversion has not reached a terminal
+            // state. The conversion's outcome has no event — it is learned solely from this poll — so ageing
+            // such a row out would strand a pending conversion silently and a needed refund would never be
+            // requested, however old the row grows.
             .Where(r => r.StoreId == storeId
                         && (r.Status == SweepRecordStatus.Pending
-                            || (r.Status == SweepRecordStatus.Sent && r.CreatedAt > sentCreatedAfter)))
+                            || (r.Status == SweepRecordStatus.Sent
+                                && (r.CreatedAt > sentCreatedAfter
+                                    || (r.DestinationKind == SweepDestinationKind.EvmAddress
+                                        && r.ConversionStatus != SparkConversionStatus.Completed
+                                        && r.ConversionStatus != SparkConversionStatus.Failed
+                                        && r.ConversionStatus != SparkConversionStatus.Refunded)))))
             .OrderBy(r => r.CreatedAt)
             .ThenBy(r => EF.Functions.Collate(r.IdempotencyKey, ByteOrderCollation))
             .ToListAsync(cancellationToken);
@@ -206,6 +217,7 @@ public class EfSweepRecordStore : ISweepRecordStore
         var refusalCode = resolution.RefusalCode;
         var conversionStatus = resolution.ConversionStatus;
         var delivered = resolution.DeliveredAmountBaseUnits;
+        var providerOrderId = resolution.ProviderOrderId;
 
         await using var context = _contextFactory.CreateContext();
 
@@ -233,7 +245,11 @@ public class EfSweepRecordStore : ISweepRecordStore
                     // an earlier one did.
                     .SetProperty(r => r.ConversionStatus, r => conversionStatus ?? r.ConversionStatus)
                     .SetProperty(
-                        r => r.DeliveredAmountBaseUnits, r => delivered ?? r.DeliveredAmountBaseUnits),
+                        r => r.DeliveredAmountBaseUnits, r => delivered ?? r.DeliveredAmountBaseUnits)
+                    // The bridge provider's own order id — the handle an investigation into a stuck delivery
+                    // quotes at the provider. Coalesced like the rest; it arrives once and must survive
+                    // every later Sent → Confirmed poll.
+                    .SetProperty(r => r.ProviderOrderId, r => providerOrderId ?? r.ProviderOrderId),
                 cancellationToken);
 
         return updated == 1;

--- a/BTCPayServer.Plugins.Flint/Data/ISweepRecordStore.cs
+++ b/BTCPayServer.Plugins.Flint/Data/ISweepRecordStore.cs
@@ -41,7 +41,8 @@ public sealed record SweepResolution(
     DateTimeOffset CompletedAt,
     SweepRefusalCode RefusalCode = SweepRefusalCode.None,
     SparkConversionStatus? ConversionStatus = null,
-    string? DeliveredAmountBaseUnits = null);
+    string? DeliveredAmountBaseUnits = null,
+    string? ProviderOrderId = null);
 
 /// <summary>
 /// Durable storage for <see cref="SweepRecord"/>s.

--- a/BTCPayServer.Plugins.Flint/Models/SparkSetupViewModel.cs
+++ b/BTCPayServer.Plugins.Flint/Models/SparkSetupViewModel.cs
@@ -48,11 +48,6 @@ public class SparkSetupViewModel
     public string? ImportedMnemonic { get; set; }
 
     /// <summary>
-    /// True when this store already has a Spark wallet, so the page can frame itself as replacing a seed
-    /// rather than as first-time setup.
-    /// </summary>
-    [BindNever]
-    /// <summary>
     /// Turn auto-sweeping on as part of setup, rather than sending the merchant to a second page for it.
     /// </summary>
     /// <remarks>
@@ -67,6 +62,17 @@ public class SparkSetupViewModel
     [Display(Name = "Sweep when the balance passes")]
     public long SweepBalanceThresholdSats { get; set; } = SweepSettings.DefaultBalanceThresholdSats;
 
+    /// <summary>
+    /// True when this store already has a Spark wallet, so the page can frame itself as replacing a seed
+    /// rather than as first-time setup.
+    /// </summary>
+    /// <remarks>
+    /// <c>[BindNever]</c> attaches to the declaration that follows it, comments notwithstanding — this
+    /// attribute once drifted onto <see cref="EnableSweeping"/> when this property was moved without it,
+    /// which both let a poster set this flag and silently discarded the setup page's sweeping opt-in.
+    /// <c>SparkSetupViewModelBindingTests</c> pins the placement.
+    /// </remarks>
+    [BindNever]
     public bool AlreadyConfigured { get; set; }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkSdkClient.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkSdkClient.cs
@@ -204,10 +204,14 @@ public sealed class SparkSdkClient : ISparkSdkClient
 
         // Prepare succeeds even with a zero balance — the funds check happens in SendPayment — so this
         // quote is free to obtain and must be checked before committing.
+        // Saturating, never a raw cast: these are provider-supplied u64s, and the fee guard downstream is a
+        // `<=` against a ceiling — a value that wrapped negative would sail under any ceiling, which is the
+        // exact number the guard exists to stop. Saturated to long.MaxValue, the same value fails every guard.
         var feeSats = prepared.paymentMethod switch
         {
-            SendPaymentMethod.Bolt11Invoice bolt11Method =>
-                (long)bolt11Method.lightningFeeSats + (long)(bolt11Method.sparkTransferFeeSats ?? 0),
+            SendPaymentMethod.Bolt11Invoice bolt11Method => SaturatingAdd(
+                ToSatsSaturating(bolt11Method.lightningFeeSats),
+                ToSatsSaturating(bolt11Method.sparkTransferFeeSats ?? 0)),
             SendPaymentMethod.SparkAddress sparkAddress => SparkPaymentMapper.ToSats(sparkAddress.fee),
             _ => 0
         };
@@ -338,10 +342,24 @@ public sealed class SparkSdkClient : ISparkSdkClient
             FastFeeSats: Total(feeQuote.speedFast)));
 
         // The executed payment's `fees` equalled this sum exactly on every observed coop exit, so the sum is the
-        // fee; neither half is meaningful on its own.
+        // fee; neither half is meaningful on its own. Clamping each half and then adding them raw would still
+        // wrap for two near-max halves, so the addition saturates too — see the fee-quote note above.
         static long Total(SendOnchainSpeedFeeQuote tier) =>
-            (long)Math.Min(tier.userFeeSat, long.MaxValue) + (long)Math.Min(tier.l1BroadcastFeeSat, long.MaxValue);
+            SaturatingAdd(ToSatsSaturating(tier.userFeeSat), ToSatsSaturating(tier.l1BroadcastFeeSat));
     }
+
+    /// <summary>A provider u64 as satoshi, saturated at <see cref="long.MaxValue"/> instead of cast raw.</summary>
+    /// <remarks>
+    /// A raw <c>(long)</c> of a u64 past <c>long.MaxValue</c> wraps negative, and every fee guard in this plugin
+    /// is a <c>&lt;=</c> against a ceiling — a negative fee passes all of them. Saturated, the same absurd value
+    /// fails all of them, which is the direction a guard on provider-supplied numbers must fail in.
+    /// </remarks>
+    internal static long ToSatsSaturating(ulong value) =>
+        value > long.MaxValue ? long.MaxValue : (long)value;
+
+    /// <summary>Adds two non-negative fee components without wrapping past <see cref="long.MaxValue"/>.</summary>
+    internal static long SaturatingAdd(long a, long b) =>
+        a > long.MaxValue - b ? long.MaxValue : a + b;
 
     /// <remarks>
     /// Mapped explicitly rather than cast. The SDK's enum is ordered <c>Fast = 0, Medium = 1, Slow = 2</c> and

--- a/BTCPayServer.Plugins.Flint/Services/SparkSettlementBroadcaster.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSettlementBroadcaster.cs
@@ -134,9 +134,15 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
                     continue;
 
                 default:
+                    // Not "recovered by the reconciliation task": the reconciler scans Unpaid rows and this
+                    // invoice's row is already Paid — the push was minted on that very transition. What
+                    // actually recovers a dropped push is BTCPay's own LightningListener, which polls every
+                    // listened invoice through GetInvoice on a one-minute timer, and GetInvoice reads the
+                    // durable Paid row. The settlement is never lost; only this push was.
                     _logger.LogWarning(
                         "A Spark settlement listener for store {StoreId} is not keeping up; dropped a "
-                        + "notification for {PaymentHash}, which will be recovered by the reconciliation task",
+                        + "notification for {PaymentHash}. The invoice is settled in this plugin's records and "
+                        + "BTCPay's own invoice polling picks it up from there, typically within a minute",
                         settlement.StoreId, settlement.PaymentHash);
                     continue;
             }

--- a/BTCPayServer.Plugins.Flint/Services/SparkSettlementBroadcaster.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSettlementBroadcaster.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -50,9 +51,11 @@ public interface ISparkSettlementSubscriber
 /// was waiting for, and that invoice would then wait for the next reconciliation pass.
 /// </para>
 /// <para>
-/// Queues are bounded and refuse (with a warning) when full, so a wedged consumer degrades into lost
-/// notifications — recovered by <c>SparkReconciliationTask</c>, which is the plugin's settlement guarantee —
-/// instead of unbounded memory growth.
+/// Queues are bounded and refuse when full; a refused push is held back and re-delivered on a short
+/// timer, so a transiently-stalled consumer catches up instead of losing the notification. The
+/// allowance is bounded per subscription and by a delivery deadline, after which the operator is told
+/// the truth — BTCPay does not re-poll listened invoices, and <c>SparkReconciliationTask</c> only scans
+/// unpaid rows, so an already-paid row's push reaches BTCPay only when it next reads the invoice.
 /// </para>
 /// </remarks>
 public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
@@ -69,13 +72,43 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
     /// </summary>
     private const int SubscriptionWarningThreshold = 32;
 
+    /// <summary>Default allowance of refused pushes held back for retry per subscription.</summary>
+    private const int DefaultPendingPushCap = 64;
+
+    /// <summary>Default cadence at which refused pushes are re-attempted.</summary>
+    private static readonly TimeSpan DefaultPushRetryInterval = TimeSpan.FromSeconds(10);
+
+    /// <summary>Default how long a refused push may wait before the retry gives up and logs the truth.</summary>
+    private static readonly TimeSpan DefaultPushRetryLifetime = TimeSpan.FromMinutes(2);
+
     private readonly ILogger<SparkSettlementBroadcaster> _logger;
+    private readonly TimeSpan _pushRetryInterval;
+    private readonly TimeSpan _pushRetryLifetime;
+    private readonly int _pendingPushCap;
     private readonly ConcurrentDictionary<string, ConcurrentDictionary<long, Subscription>> _subscriptions = new();
+    private readonly object _retryGate = new();
+    private readonly Timer _retryTimer;
+    private bool _retryTimerStarted;
     private long _nextSubscriptionId;
 
     public SparkSettlementBroadcaster(ILogger<SparkSettlementBroadcaster> logger)
+        : this(logger, DefaultPushRetryInterval, DefaultPushRetryLifetime, DefaultPendingPushCap)
+    {
+    }
+
+    /// <summary>Shorter budgets for tests; the default constructor makes the production singleton.</summary>
+    internal SparkSettlementBroadcaster(
+        ILogger<SparkSettlementBroadcaster> logger,
+        TimeSpan pushRetryInterval,
+        TimeSpan pushRetryLifetime,
+        int pendingPushCap)
     {
         _logger = logger;
+        _pushRetryInterval = pushRetryInterval;
+        _pushRetryLifetime = pushRetryLifetime;
+        _pendingPushCap = pendingPushCap;
+        _retryTimer = new Timer(_ => DrainRetries(DateTimeOffset.UtcNow), null,
+            Timeout.Infinite, Timeout.Infinite);
     }
 
     public ISparkSettlementSubscription Subscribe(string storeId)
@@ -134,16 +167,33 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
                     continue;
 
                 default:
-                    // Not "recovered by the reconciliation task": the reconciler scans Unpaid rows and this
-                    // invoice's row is already Paid — the push was minted on that very transition. What
-                    // actually recovers a dropped push is BTCPay's own LightningListener, which polls every
-                    // listened invoice through GetInvoice on a one-minute timer, and GetInvoice reads the
-                    // durable Paid row. The settlement is never lost; only this push was.
-                    _logger.LogWarning(
-                        "A Spark settlement listener for store {StoreId} is not keeping up; dropped a "
-                        + "notification for {PaymentHash}. The invoice is settled in this plugin's records and "
-                        + "BTCPay's own invoice polling picks it up from there, typically within a minute",
-                        settlement.StoreId, settlement.PaymentHash);
+                    // The listener's bounded queue is full. Nothing can bank on a quiet recovery: BTCPay
+                    // does not re-poll listened invoices (its one-minute timer only expires stale sessions),
+                    // and the reconciliation task only scans unpaid rows — this row is already paid, the
+                    // push was minted on that very transition. So hold the push back and re-deliver it on a
+                    // short timer; a transiently-stalled consumer catches up instead of losing the push. If
+                    // the consumer stays wedged past the delivery deadline, the retry gives up and logs
+                    // what actually remains: the paid row reaches BTCPay when it next reads the invoice,
+                    // typically after a restart of the plugin or the server.
+                    if (subscription.EnqueueRetry(settlement))
+                    {
+                        EnsureRetryTimerRunning();
+                        _logger.LogWarning(
+                            "A Spark settlement listener for store {StoreId} is not keeping up; delivery of "
+                            + "the notification for {PaymentHash} is delayed and will be retried for up to "
+                            + "{RetryLifetime}",
+                            settlement.StoreId, settlement.PaymentHash, _pushRetryLifetime);
+                    }
+                    else
+                    {
+                        _logger.LogError(
+                            "A Spark settlement listener for store {StoreId} is not keeping up and has "
+                            + "exceeded the retry allowance; giving up on {PaymentHash}. The payment is "
+                            + "recorded and will reach BTCPay when it next reads this invoice — typically "
+                            + "after a restart of the plugin or the server; the BTCPay invoice may otherwise "
+                            + "show unpaid.",
+                            settlement.StoreId, settlement.PaymentHash);
+                    }
                     continue;
             }
         }
@@ -156,6 +206,31 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
         forStore.TryRemove(id, out _);
         // Left in place when empty on purpose: stores come and go far less often than listening
         // sessions do, and removing the inner dictionary would race with a concurrent Subscribe.
+    }
+
+    /// <summary>Starts the retry timer on first use; it then ticks for the process lifetime — a ten-second
+    /// no-op walk on an idle process is cheaper than the lifecycle races of stopping and restarting it.</summary>
+    private void EnsureRetryTimerRunning()
+    {
+        lock (_retryGate)
+        {
+            if (_retryTimerStarted)
+                return;
+            _retryTimerStarted = true;
+            _retryTimer.Change(_pushRetryInterval, _pushRetryInterval);
+        }
+    }
+
+    /// <summary>Re-attempts every held-back push. Internal so tests can drive the timer's work directly.</summary>
+    internal void DrainRetries(DateTimeOffset now)
+    {
+        foreach (var forStore in _subscriptions.Values)
+        {
+            foreach (var subscription in forStore.Values)
+            {
+                subscription.DrainPendingRetries(now, _logger);
+            }
+        }
     }
 
     /// <summary>Why a settlement could or could not be handed to one subscription.</summary>
@@ -174,6 +249,10 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
     {
         private readonly SparkSettlementBroadcaster _owner;
         private readonly Channel<SparkSettlement> _channel;
+        private readonly object _pendingLock = new();
+        // Payment hash -> refused push and when it was first refused. Keyed by payment hash because a given
+        // payment is published at most once, so the map is both a dedupe and, under the cap, a memory bound.
+        private readonly Dictionary<string, (SparkSettlement Settlement, DateTimeOffset Since)> _pending = new();
         private int _disposed;
 
         public Subscription(long id, string storeId, SparkSettlementBroadcaster owner, int capacity)
@@ -209,6 +288,73 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
 
         public ValueTask<SparkSettlement> ReadAsync(CancellationToken cancellationToken) =>
             _channel.Reader.ReadAsync(cancellationToken);
+
+        /// <summary>Holds a refused push for a later retry. Returns false when the allowance is full, so the
+        /// caller can log the honest fallback instead of silently growing memory.</summary>
+        internal bool EnqueueRetry(SparkSettlement settlement)
+        {
+            lock (_pendingLock)
+            {
+                if (_pending.ContainsKey(settlement.PaymentHash))
+                    return true;
+                if (_pending.Count >= _owner._pendingPushCap)
+                    return false;
+                _pending[settlement.PaymentHash] = (settlement, DateTimeOffset.UtcNow);
+                return true;
+            }
+        }
+
+        /// <summary>One retry tick for this subscription: delivers what the consumer now has room for, gives
+        /// up on what has waited past the deadline, and drops what belonged to a session that died meanwhile.</summary>
+        internal void DrainPendingRetries(DateTimeOffset now, ILogger logger)
+        {
+            List<(string Hash, SparkSettlement Settlement)> deliver;
+            List<(string Hash, SparkSettlement Settlement)> expired;
+            lock (_pendingLock)
+            {
+                if (_pending.Count == 0)
+                    return;
+                deliver = new List<(string, SparkSettlement)>(_pending.Count);
+                expired = new List<(string, SparkSettlement)>(_pending.Count);
+                foreach (var (hash, entry) in _pending)
+                    (now - entry.Since >= _owner._pushRetryLifetime ? expired : deliver).Add((hash, entry.Settlement));
+            }
+
+            // Writes are attempted outside _pendingLock: TryWrite is thread-safe, and holding the lock across
+            // it would serialise this subscription's own publishes on the retry tick.
+            foreach (var (hash, settlement) in deliver)
+            {
+                switch (TryWrite(settlement))
+                {
+                    case SubscriptionWriteResult.Delivered:
+                        lock (_pendingLock) { _pending.Remove(hash); }
+                        logger.LogInformation(
+                            "Delayed Spark settlement notification for {PaymentHash} was delivered once the "
+                            + "listener caught up", settlement.PaymentHash);
+                        break;
+                    case SubscriptionWriteResult.Disposed:
+                        // The session is gone; there is nothing left to deliver to, and the paid row reaches
+                        // BTCPay when it next reads the invoice.
+                        lock (_pendingLock) { _pending.Remove(hash); }
+                        break;
+                    case SubscriptionWriteResult.Saturated:
+                        // Still wedged; the next tick decides.
+                        break;
+                }
+            }
+
+            foreach (var (hash, settlement) in expired)
+            {
+                lock (_pendingLock) { _pending.Remove(hash); }
+                logger.LogError(
+                    "Gave up delivering the Spark settlement notification for {PaymentHash} to store "
+                    + "{StoreId} after {RetryLifetime}: the listening session has not consumed. The payment "
+                    + "is recorded; BTCPay does not re-poll listened invoices, so the invoice will show paid "
+                    + "only when it next reads this one — typically after a restart of the plugin or the "
+                    + "server.",
+                    settlement.PaymentHash, settlement.StoreId, _owner._pushRetryLifetime);
+            }
+        }
 
         public void Dispose()
         {

--- a/BTCPayServer.Plugins.Flint/Services/SparkSettlementReconciler.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSettlementReconciler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -75,6 +76,12 @@ public class SparkSettlementReconciler
     private readonly IInvoiceRecordStore _invoiceStore;
     private readonly SparkSettlementBroadcaster _broadcaster;
     private readonly ILogger<SparkSettlementReconciler> _logger;
+
+    /// <summary>
+    /// Where the last capped reconciliation pass stopped, per store, so the next pass resumes rather than
+    /// re-examining the same oldest invoices — see the note at the cursor's initialisation.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, InvoiceReconciliationCursor> _resumeCursors = new();
 
     public SparkSettlementReconciler(
         IInvoiceRecordStore invoiceStore,
@@ -379,7 +386,12 @@ public class SparkSettlementReconciler
 
         var settled = 0;
         var examined = 0;
-        InvoiceReconciliationCursor? cursor = null;
+        // Resumed from where the previous pass stopped, not from the top. The per-pass cap exists to bound a
+        // pass's work, but restarting at the oldest invoice every pass would make it a starvation line: with
+        // more settleable invoices than the cap, the same oldest set is re-examined forever and everything
+        // behind it is never reached. The cursor carries across passes and resets only when a pass drains the
+        // set, so every invoice is reached within a bounded number of passes.
+        InvoiceReconciliationCursor? cursor = _resumeCursors.TryGetValue(storeId, out var resume) ? resume : null;
 
         while (examined < MaxInvoicesPerPass)
         {
@@ -432,12 +444,20 @@ public class SparkSettlementReconciler
                 break;
         }
 
-        if (examined >= MaxInvoicesPerPass)
+        if (examined >= MaxInvoicesPerPass && cursor is { } stopped)
         {
+            // The next pass resumes here rather than restarting at the oldest invoice, which is what makes the
+            // sentence below true rather than a starvation line.
+            _resumeCursors[storeId] = stopped;
             _logger.LogInformation(
-                "Store {StoreId}: reconciliation examined its per-pass limit of {Count} Spark invoices; any "
-                + "remaining ones are picked up by the next pass, oldest first",
+                "Store {StoreId}: reconciliation examined its per-pass limit of {Count} Spark invoices; the "
+                + "next pass resumes where this one stopped",
                 storeId, MaxInvoicesPerPass);
+        }
+        else
+        {
+            // The set drained; the next pass starts from the top again.
+            _resumeCursors.TryRemove(storeId, out _);
         }
 
         if (settled > 0)

--- a/BTCPayServer.Plugins.Flint/Services/SparkStableBalanceService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkStableBalanceService.cs
@@ -295,7 +295,39 @@ public sealed class SparkStableBalanceService
         var updated = settings.Clone();
         var stable = (updated.StableBalance ?? new StableBalanceSettings()).Clone();
         var wasActive = stable.Enabled;
+        var previousToken = stable.TokenIdentifier;
         input.ApplyTo(stable);
+
+        // Switching tokens while the old one still holds a balance would strand it: only the configured token
+        // is converted, displayed and swept, so the old balance would sit invisible on the wallet with nothing
+        // in the UI even acknowledging it exists. Refused rather than warned — convert or sweep it out first.
+        if (!string.IsNullOrEmpty(previousToken)
+            && !string.Equals(previousToken, stable.TokenIdentifier, StringComparison.Ordinal))
+        {
+            try
+            {
+                var info = await sdk.GetInfoAsync(ensureSynced: true, cancellationToken).ConfigureAwait(false);
+                var held = info.Tokens.FirstOrDefault(t =>
+                    string.Equals(t.Identifier.Value, previousToken, StringComparison.Ordinal));
+                if (held is { BaseUnits.Sign: > 0 })
+                {
+                    return SparkStableBalanceResult.Invalid(new SparkSweepSettingsError(
+                        nameof(StableBalanceInput.TokenIdentifier),
+                        $"This wallet still holds {held.Describe()}. Changing the token would leave that "
+                        + "balance invisible to this plugin — convert it back to Bitcoin or sweep it out "
+                        + "before switching."));
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Store {StoreId}: could not read token balances to allow a stable-balance token switch "
+                    + "({Reason})", storeId, SparkErrors.Describe(ex));
+                return SparkStableBalanceResult.Unavailable(
+                    "The wallet's token balances could not be read, so the token cannot be switched safely "
+                    + "right now. Try again once the wallet is reachable.");
+            }
+        }
 
         // Verified against the SDK before anything is written, not after. An identifier the wallet does not
         // know is not a setting to store and correct later — activating on it would fail at the point the

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
@@ -1324,6 +1324,45 @@ public sealed class SparkSweepEngine
             debitedUsd, deliveredUsd, lossPercent, MaxCrossChainValueLossPercent));
     }
 
+    /// <summary>
+    /// Whether the synced wallet no longer holds what <paramref name="record"/>'s send would have debited —
+    /// sats for a keyed row, the source token's base units for a token-funded one.
+    /// </summary>
+    /// <remarks>
+    /// A token row whose source amount does not parse is not gated: it predates the fields, and the write-off
+    /// for it says to verify manually. A token entirely absent from the synced balances counts as zero held —
+    /// absence is what a fully-sent balance looks like, which is exactly the case the gate exists for.
+    /// </remarks>
+    private static bool HasFundingShortfall(SweepRecord record, SparkNodeInfo? synced)
+    {
+        if (synced is null)
+            return false;
+
+        if (record.IdempotencyKeyAccepted)
+            return synced.BalanceSats < record.AmountSats;
+
+        if (record.SourceTokenIdentifier is not { } tokenId
+            || !BigInteger.TryParse(record.SourceAmountBaseUnits, out var sourceAmount))
+        {
+            return false;
+        }
+
+        var held = BigInteger.Zero;
+        foreach (var token in synced.Tokens)
+        {
+            if (string.Equals(token.Identifier.Value, tokenId, StringComparison.Ordinal))
+                held += token.BaseUnits;
+        }
+
+        return held < sourceAmount;
+    }
+
+    /// <summary>The amount a sweep's send would have debited, in the unit the row was funded in.</summary>
+    private static string DescribeFundingAmount(SweepRecord record) =>
+        record.IdempotencyKeyAccepted || record.SourceTokenIdentifier is null
+            ? string.Create(CultureInfo.InvariantCulture, $"{record.AmountSats:N0} sat")
+            : $"{record.SourceAmountBaseUnits} base units of {record.SourceTokenIdentifier}";
+
     private static SweepRefusal UnverifiableValueRefusal(BigInteger baseUnits, uint decimals, string direction) =>
         new(SweepRefusalCode.CrossChainValueUnverifiable, string.Format(
             CultureInfo.InvariantCulture,
@@ -1611,9 +1650,10 @@ public sealed class SparkSweepEngine
 
         SweepRecord? blocking = null;
         var refundNeeded = false;
-        // Set by the first write-off candidate, once per pass: the balance after an explicit SyncWallet, which
-        // is what the write-off gate below compares against. Null means no candidate has forced a sync yet.
-        long? syncedBalance = null;
+        // Set by the first write-off candidate, once per pass: the wallet after an explicit SyncWallet, which
+        // is what the write-off gate below compares against — the sats balance for keyed rows, the token
+        // balances for token-funded ones. Null means no candidate has forced a sync yet.
+        SparkNodeInfo? syncedInfo = null;
         foreach (var record in records)
         {
             SparkPayment? payment;
@@ -1646,14 +1686,13 @@ public sealed class SparkSweepEngine
                 // like "never sent". One explicit sync per pass (GetInfo(ensureSynced) alone was observed
                 // staying stale; see the class remarks), then the lookup is repeated. A sync or re-read
                 // failure keeps the row blocking: refusing to sweep is always the safe direction.
-                if (syncedBalance is null)
+                if (syncedInfo is null)
                 {
                     try
                     {
                         await sdk.SyncWalletAsync(cancellationToken).ConfigureAwait(false);
-                        var info = await sdk.GetInfoAsync(ensureSynced: true, cancellationToken)
+                        syncedInfo = await sdk.GetInfoAsync(ensureSynced: true, cancellationToken)
                             .ConfigureAwait(false);
-                        syncedBalance = info.BalanceSats;
                     }
                     catch (Exception ex)
                     {
@@ -1695,29 +1734,30 @@ public sealed class SparkSweepEngine
                     continue;
                 }
 
-                // The last gate before the write-off, for the rows whose send would have debited sats: if the
-                // synced balance no longer holds what this sweep would have sent, "no payment under the key"
-                // stops being evidence of "never sent" and starts looking like an accepted exit the SDK has
-                // not recorded — the one case where closing the row and re-planning would send real money
-                // twice. The gate is bounded rather than absolute, because a shortfall is not proof: this
-                // engine is not the store's only spender — Lightning payouts and Stable Balance conversions
-                // both debit sats with no sweep record, and a sweep's amount is close enough to the whole
-                // balance that any of them trips the comparison. An unbounded refusal would turn one payout
-                // into a permanently wedged store with no operator escape short of removing Spark. So the row
-                // blocks for ShortfallWriteOffAge — enough passes and forced syncs that an accepted exit
-                // still absent from local storage is no longer the likely explanation — and then falls
-                // through to a write-off whose reason says exactly what was observed. Token-funded rows are
-                // not gated: their amount is not in sats, and their write-off never re-sends.
-                var shortfall = record.IdempotencyKeyAccepted && syncedBalance < record.AmountSats;
+                // The last gate before the write-off: if the synced wallet no longer holds what this sweep
+                // would have sent — sats for keyed rows, the source token's base units for token-funded ones
+                // — then "no payment record" stops being evidence of "never sent" and starts looking like an
+                // accepted send the SDK has not recorded. Closing the row frees this very pass to plan a new
+                // sweep from the balance it just synced, and on the token rail that new send cannot even
+                // carry an idempotency key for the provider to dedupe — so the gate matters more there, not
+                // less. It is bounded rather than absolute, because a shortfall is not proof: this engine is
+                // not the store's only spender — Lightning payouts and Stable Balance conversions move both
+                // balances with no sweep record, and a sweep's amount is close enough to the whole balance
+                // that any of them trips the comparison. An unbounded refusal would turn one payout into a
+                // permanently wedged store with no operator escape short of removing Spark. So the row blocks
+                // for ShortfallWriteOffAge — enough passes and forced syncs that an accepted send still
+                // absent from local storage is no longer the likely explanation — and then falls through to a
+                // write-off whose reason says exactly what was observed.
+                var shortfall = HasFundingShortfall(record, syncedInfo);
                 if (shortfall && now - record.CreatedAt < ShortfallWriteOffAge)
                 {
                     _logger.LogError(
-                        "Store {StoreId}: sweep {IdempotencyKey} has no payment record, but the synced balance "
-                        + "({BalanceSats} sat) is below the {AmountSats} sat it would have sent — refusing to "
-                        + "write it off as never sent, because the shortfall suggests it was. The store stays "
-                        + "blocked until the payment surfaces or the sweep is {Age} old; check the wallet's "
-                        + "history and the destination in the meantime",
-                        storeId, record.IdempotencyKey, syncedBalance, record.AmountSats, ShortfallWriteOffAge);
+                        "Store {StoreId}: sweep {IdempotencyKey} has no payment record, but the synced wallet "
+                        + "holds less than the {Amount} it would have sent — refusing to write it off as never "
+                        + "sent, because the shortfall suggests it was. The store stays blocked until the "
+                        + "payment surfaces or the sweep is {Age} old; check the wallet's history and the "
+                        + "destination in the meantime",
+                        storeId, record.IdempotencyKey, DescribeFundingAmount(record), ShortfallWriteOffAge);
                     blocking ??= record;
                     continue;
                 }
@@ -1739,8 +1779,10 @@ public sealed class SparkSweepEngine
                 //
                 // On the token path the caveat is stronger still: what was searched is the payment history for
                 // this record's provider quote id, and a send whose persistence step never completed might not
-                // be in that history at all. So the row is closed and the store is unblocked, but the sentence
-                // does not claim the money is safe — and, crucially, nothing re-sends it.
+                // be in that history at all. So the row is closed and the store is unblocked, and the sentence
+                // does not claim the money is safe. Closing the row frees the store to plan a new sweep from
+                // the balance this pass just synced — the shortfall gate above is what holds the row while
+                // that balance still looks like the send may have happened, on both rails.
                 var reason = shortfall
                     ? "Spark has no record of this sweep, but the wallet held less than the sweep would have "
                       + "sent when it was checked, so sweeping was blocked for an hour of re-checks before "
@@ -2100,7 +2142,8 @@ public sealed class SparkSweepEngine
                 .TryResolveAsync(
                     record.StoreId, record.IdempotencyKey, [SweepRecordStatus.Pending],
                     new SweepResolution(
-                        status, feeSats, txId, error, now, refusalCode, conversionStatus, deliveredBaseUnits),
+                        status, feeSats, txId, error, now, refusalCode, conversionStatus, deliveredBaseUnits,
+                        providerOrderId),
                     cancellationToken)
                 .ConfigureAwait(false))
         {
@@ -2332,6 +2375,18 @@ public sealed class SparkSweepEngine
     {
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(quote);
+
+        // Every ceiling below is a <=, so a fee that arrived negative — the shape a wrapped provider u64 takes
+        // — would pass all of them. The conversions saturate rather than wrap precisely so this cannot happen;
+        // this refusal is the backstop for any path that missed the saturating conversion.
+        if (quote.FeeSats < 0)
+        {
+            return new SweepRefusal(SweepRefusalCode.FeeAboveLimit, string.Format(
+                CultureInfo.InvariantCulture,
+                "Spark quoted a negative exit fee ({0:N0} sat), which is not a number this plugin can bound a "
+                + "sweep with. Nothing was sent.",
+                quote.FeeSats));
+        }
 
         var recipient = quote.RecipientAmountSats;
 

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
@@ -2052,7 +2052,8 @@ public sealed class SparkSweepEngine
                     storeId, record.IdempotencyKey, allowedFrom,
                     new SweepResolution(
                         status, null, null, error, now, SweepRefusalCode.None, conversionStatus,
-                        conversion?.DeliveredAmount?.ToString(CultureInfo.InvariantCulture)),
+                        conversion?.DeliveredAmount?.ToString(CultureInfo.InvariantCulture),
+                        conversion?.ProviderOrderId),
                     cancellationToken)
                 .ConfigureAwait(false))
         {

--- a/BTCPayServer.Plugins.Flint/SparkConnectionStringHandler.cs
+++ b/BTCPayServer.Plugins.Flint/SparkConnectionStringHandler.cs
@@ -50,11 +50,11 @@ namespace BTCPayServer.Plugins.Flint;
 /// config is being saved. Copy a store's whole string onto another store on the same server and that
 /// store drives the original's wallet: confirmed live in the 2026-08-07 audit, which read the victim's
 /// balance and minted an invoice into the victim's wallet through the attacker's store. The string is
-/// therefore a <b>bearer spend credential</b>, exactly like an LND macaroon, and
-/// <see cref="Services.SparkStoreProvisioner"/> keeps the payment key across re-provisioning rather than
-/// rotating it — so a leaked string outlives the leaker's access and dies only with full Spark removal.
-/// Treat it as a secret, and do not restate the older, stronger claim that store binding closes
-/// cross-store hijack outright.
+/// therefore a <b>bearer spend credential</b>, exactly like an LND macaroon.
+/// <see cref="Services.SparkStoreProvisioner"/> rotates the payment key on every provision, so re-running
+/// setup revokes every previously issued string; between provisions the string never expires. Treat it as
+/// a secret, and do not restate the older, stronger claim that store binding closes cross-store hijack
+/// outright.
 /// </para>
 /// <para>There is deliberately no <c>server=</c> key, so
 /// BTCPay's <c>IsSafe</c> check passes and non-admin store owners can save the configuration.</para>

--- a/BTCPayServer.Plugins.Flint/SparkLightningClient.cs
+++ b/BTCPayServer.Plugins.Flint/SparkLightningClient.cs
@@ -807,7 +807,11 @@ public class SparkLightningClient : IExtendedLightningClient, IDisposable
     {
         if (amount is null || amount.MilliSatoshi <= 0)
             return null;
-        return (amount.MilliSatoshi + 999) / 1000;
+        // Ceiling without the +999 idiom: for a millisatoshi value near long.MaxValue the addition wraps
+        // negative, and a negative result here maps to "amountless invoice" downstream — an absurd requested
+        // amount must stay absurd (and fail loudly), never turn into an invoice for anything-goes.
+        var msat = amount.MilliSatoshi;
+        return msat / 1000 + (msat % 1000 > 0 ? 1 : 0);
     }
 
     /// <summary>
@@ -929,6 +933,17 @@ public class SparkLightningClient : IExtendedLightningClient, IDisposable
     /// </remarks>
     internal static string? ApproveFee(SparkSendQuote quote, PayInvoiceParams? payParams, long amountSats)
     {
+        // Every limit below is a <=, so a negative fee — the shape a wrapped provider u64 takes — would pass
+        // them all. The SDK client's conversions saturate rather than wrap; this is the backstop.
+        if (quote.FeeSats < 0)
+        {
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "The Spark fee for this payment is negative ({0} sat), which is not a number a fee limit can "
+                + "bound. The payment was refused.",
+                quote.FeeSats);
+        }
+
         long? maxFeeSats = null;
 
         if (payParams?.MaxFeeFlat is { } flat)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
+## [Unreleased]
+
+### Security
+
+Findings from a third external review pass, each verified against the source before fixing:
+
+- **Provider-supplied fees can no longer wrap negative past every fee ceiling.** Two fee sums cast the
+  SDK's u64 components to `long` raw (Lightning) or clamped each component but added them unchecked
+  (cooperative exits); a wrapped-negative fee would have passed every `<=` limit, including the 50% hard
+  backstop. All conversions now saturate at `long.MaxValue`, and both fee approvers additionally refuse a
+  negative fee outright as a backstop.
+- **The setup page's sweeping opt-in works again.** A `[BindNever]` attribute intended for the
+  `AlreadyConfigured` flag had drifted onto `EnableSweeping` when the property moved — attributes attach to
+  the next declaration, comments notwithstanding — so a merchant who ticked "sweep automatically" at setup
+  got a success message and no sweeping, while the flag it was written for was overpostable. A reflection
+  test now pins the placement.
+- **A token-funded write-off is gated on the token balance, exactly as a sats write-off is gated on sats.**
+  Writing off a token row unblocks the same pass to plan a fresh keyless bridge send — nothing at the
+  provider can dedupe a second one — so a held balance below what the row says was sent now keeps the row
+  blocking, bounded by the same one-hour escalation as the sats gate.
+- **The packaged `.btcpay` now carries NOTICE and LICENSE.** The artifact redistributes Breez's
+  MIT-licensed binaries and their notices did not travel with it; the build output now includes both files
+  and the packaging workflow refuses to ship an artifact without them.
+
+### Fixed
+
+- **Cross-chain `Sent` rows with an undecided conversion no longer age out of the recovery poll.** The
+  conversion's outcome has no event and is learned only from that poll, so the 24-hour cutoff could strand
+  a slow conversion silently, with a needed refund never requested. Undecided conversions are now exempt
+  from the cutoff; terminal ones age out as before.
+- **Invoice reconciliation resumes where the previous pass stopped** instead of re-examining the same
+  oldest 1,000 invoices every pass, which starved everything behind them on a large backlog.
+- **Switching the Stable Balance token is refused while the previous token still holds a balance**, which
+  would otherwise become invisible to the plugin — only the configured token is converted, displayed and
+  swept.
+- **The bridge provider's order id is persisted.** It was set on the in-memory record but absent from the
+  durable resolution, so restarting BTCPay lost the one handle a stuck-delivery investigation quotes at
+  the provider.
+- **An extreme requested invoice amount can no longer wrap into an amountless invoice.** The
+  millisatoshi-to-satoshi ceiling used the `+999` idiom, which wraps negative near `long.MaxValue` and
+  read downstream as "no amount".
+- **The release tag guard rejects a three-part tag on a four-part build** (`v0.1.4` for a 0.1.4.1
+  artifact), which would have published a release page disagreeing with its own artifact.
+- **A dropped settlement push's log line now names the real recovery mechanism** — BTCPay's own
+  invoice polling over the durable Paid row — instead of crediting the reconciliation task, which only
+  scans unpaid rows.
+- **The funded regtest suite fails hard when the wallet seed appears in any log surface**, instead of
+  quietly withholding the artifact; and its Postgres race test only counts a unique-key violation as
+  losing the race, so an unrelated error can no longer masquerade as the loser.
+
+### Documentation
+
+- The connection-string example is `type=flint` (not the pre-rename `breezspark`), the storage path is
+  `<DataDir>/Plugins/Flint/` throughout, the registry entry to search for is **Flint**, the built-against
+  BTCPay version reads 2.4.2, the clone instructions `cd` into the right directory, and the
+  connection-string handler's remarks reflect the 0.1.4.1 key rotation.
+
 ## [0.1.4.1] — 2026-08-21
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,12 @@ Findings from a third external review pass, each verified against the source bef
   read downstream as "no amount".
 - **The release tag guard rejects a three-part tag on a four-part build** (`v0.1.4` for a 0.1.4.1
   artifact), which would have published a release page disagreeing with its own artifact.
-- **A dropped settlement push's log line now names the real recovery mechanism** — BTCPay's own
-  invoice polling over the durable Paid row — instead of crediting the reconciliation task, which only
-  scans unpaid rows.
+- **A dropped settlement push is retried instead of lost.** A listener that falls behind has its push
+  held back and re-delivered on a short timer once it catches up — bounded by a per-subscription
+  allowance and a delivery deadline, after which the log names the truth (the payment reaches BTCPay
+  when it next reads the invoice, typically after a restart). This replaces a log line that credited a
+  BTCPay one-minute invoice poll that does not exist, and a reconciliation task that only scans unpaid
+  rows.
 - **The funded regtest suite fails hard when the wallet seed appears in any log surface**, instead of
   quietly withholding the artifact; and its Postgres race test only counts a unique-key violation as
   losing the race, so an unrelated error can no longer masquerade as the loser.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ exists — before you configure anything.
 What a server needs to *run* this plugin:
 
 - **BTCPay Server 2.4.1 or newer.** That is the declared support floor, and BTCPay refuses to load the
-  plugin on anything older. It is compiled against 2.4.1 as well.
+  plugin on anything older. It is compiled against 2.4.2.
 - **A supported platform.** The Breez Spark SDK ships around 200 MB of native libraries for
   `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`, `win-x64` and `win-x86`. There is **no**
   `linux-musl` (Alpine) or `win-arm64` payload, so the plugin will not load on those platforms.
   Standard BTCPay Docker images (Debian-based) are fine.
 - **Mainnet or regtest.** The SDK offers no testnet or signet, so neither is supported. Stable Balance
   and cross-chain sweeps are mainnet-only even on a supported network.
-- **Disk for the SDK's per-store state**, under `<DataDir>/Plugins/Spark/`, plus an unrotated
+- **Disk for the SDK's per-store state**, under `<DataDir>/Plugins/Flint/`, plus an unrotated
   `sdk.log` you are expected to point `logrotate` at — see [Known limitations](docs/limitations.md).
 - **Server-admin rights, or the *Non-admins can create Hot Wallets for their Store* policy**, to set a
   store up. Spark keeps keys on the server, so the plugin sits behind BTCPay's own hot-wallet gate.
@@ -52,7 +52,7 @@ Requires **BTCPay Server 2.4.1 or newer** on a host the Breez SDK has native lib
 [Requirements](#requirements) before you start, because Alpine-based images are not among them.
 
 **From the BTCPay plugin registry** *(once this plugin is listed there — it is not yet)*: in your BTCPay
-Server, go to **Server settings → Plugins**, find **Spark**, and install it. BTCPay restarts itself to
+Server, go to **Server settings → Plugins**, find **Flint**, and install it. BTCPay restarts itself to
 complete the install.
 
 **From a release artifact**, which is the route available today: download

--- a/docs/building.md
+++ b/docs/building.md
@@ -12,7 +12,7 @@ Clone with submodules, or initialise them after the fact:
 
 ```bash
 git clone --recurse-submodules https://github.com/sethforprivacy/flint.git
-cd btcpayserver-plugin-spark
+cd flint
 ```
 
 ```bash

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -11,7 +11,7 @@
   will not settle the BTCPay invoice, and the mismatch is logged as a warning.
 - **Testnet and signet are unsupported**, because the SDK only offers mainnet and regtest.
 - **The SDK's own log cannot be turned up to `trace`, on purpose.** The plugin installs the Rust SDK's
-  logging subscriber, which writes `<DataDir>/Plugins/Spark/logs/sdk.log` *and* forwards every line into
+  logging subscriber, which writes `<DataDir>/Plugins/Flint/logs/sdk.log` *and* forwards every line into
   BTCPay's log. What it emits at each level was read line by line against a throwaway regtest wallet: at
   `info` and `debug` — the level Breez's production checklist asks for — nothing secret appears, but at
   `trace` the service provider's GraphQL **session token** is logged in full inside raw response bodies. That
@@ -21,7 +21,7 @@
   plugin does not control. One gap worth knowing: the probe wallet was never paid, so the lines a completed
   payment produces are unaudited — the scrubbing is written against that gap rather than around it.
 - **`sdk.log` is not rotated, and rotating it is yours to arrange.** The file at
-  `<DataDir>/Plugins/Spark/logs/sdk.log` is opened and written by the Rust SDK, not by this plugin — nothing
+  `<DataDir>/Plugins/Flint/logs/sdk.log` is opened and written by the Rust SDK, not by this plugin — nothing
   on the C# side can truncate, roll or size-cap it, so the plugin makes no promise about how large it gets.
   At the shipped `info` level it is not fast-growing, but it is unbounded and it grows for as long as the
   server runs. **Treat it as a file your host is responsible for**: point `logrotate` (or your container's
@@ -29,7 +29,7 @@
   the file needs `copytruncate` rather than `create`. It is safe to delete while the server is stopped.
   Nothing in the plugin reads it back; it exists for you and for a bug report.
 - **Everything the plugin writes under the data directory is owner-only, and that is the only protection
-  it has.** Each store's SDK state lives in `<DataDir>/Plugins/Spark/<storeId>/`, beside the log directory,
+  it has.** Each store's SDK state lives in `<DataDir>/Plugins/Flint/<storeId>/`, beside the log directory,
   and both are created `0700` — a directory without other-execute cannot be traversed to reach the files
   inside it, whatever mode the SDK gives them. The correction is applied on every start rather than only at
   creation, so an install laid down by an earlier version is hardened when it next runs. On a host where the

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -26,7 +26,7 @@ side; until it does, they are neither on Spark nor at the destination. The plugi
 quote id before sending and reports what it says it delivered, which is the most the SDK exposes.
 
 **The store's Lightning connection string is a bearer spend credential.** Setup writes a
-`type=breezspark;store-id=…;key=…` string into the store's Lightning payment method. Anyone who can read it
+`type=flint;store-id=…;key=…` string into the store's Lightning payment method. Anyone who can read it
 — any principal with `CanModifyStoreSettings` on the store, plus anything that string was ever pasted into —
 can save it on *another* store on the same server and drive this store's wallet from there: receive into it
 and spend from it. The embedded store id binds the key to a wallet; it does not bind the string to the store


### PR DESCRIPTION
Implements the verified findings from the latest review pass. Every claim was checked against the source first; two were adjudicated down (details below).

**Blockers**
- **B1 — fee overflow bypass (real, fixed):** provider u64 fee components now saturate at `long.MaxValue` (`ToSatsSaturating`/`SaturatingAdd` in `SparkSdkClient`) instead of wrapping negative under every `<=` ceiling, and both fee approvers (`ApproveFee`, `ApproveQuote`) refuse a negative fee outright as a backstop.
- **B2 — dead setup checkbox (real, fixed):** `[BindNever]` had drifted onto `EnableSweeping` (attributes bind to the next declaration, comments notwithstanding), silently discarding the setup page's sweeping opt-in and leaving `AlreadyConfigured` overpostable. Moved back; a reflection test pins the placement.
- **B3 — dropped settlement push (real, fixed — after a corrected adjudication):** this PR initially adjudicated the finding down on the claim that BTCPay's `LightningListener` re-polls listened invoices every minute. **That claim was wrong** — the quorum review of this PR refuted it (the 1-minute timer only expires stale sessions and re-arms listening; `PollPayment` runs only when an invoice enters listening), verified against the submodule. A saturated-queue drop really did stay undelivered until a restart. The broadcaster now holds refused pushes in a per-subscription bounded pending map (cap 64, keyed by payment hash) and re-delivers on a 10s timer; past a 2-minute deadline it gives up with a log naming the real remaining recovery (the next read of the invoice, typically a restart).
- **B4 — missing Breez notices (real, fixed):** NOTICE and LICENSE are copied into the build output PluginPacker zips, and package.yml refuses to ship a .btcpay lacking either. (Side effect: two tests found the repo root by walking up to `LICENSE`, which now exists in bin/ — their sentinel is the .slnx now.)

**High**
- **H1 (real, fixed):** token-funded write-offs get the same bounded shortfall gate as sats rows, comparing the held token balance against the row's `SourceAmountBaseUnits` — a post-write-off re-plan sends keylessly and nothing at the provider can dedupe it.
- **H2 (real, fixed):** cross-chain `Sent` rows with an undecided conversion (null/Pending/RefundNeeded) are exempt from the 24h `ListUnresolved` cutoff in both stores; contract test added.
- **H3 (real, fixed):** the reconciliation cursor carries across passes per store and resets when the set drains.

**Medium (all fixed):** stable-balance token switch refused while the old token holds a balance; `ProviderOrderId` wired through `SweepResolution` into both stores; msat→sat ceiling rewritten to not wrap; tag guard rejects `v0.1.4` for a `0.1.4.1` build (a real hole in the guard I added for 0.1.4.1); funded suite hard-fails on a seed leak after artifacts are written and the SDK is torn down; Postgres race test only counts SqlState 23505 as losing.

**Docs batch:** `type=flint`, `Plugins/Flint` paths (including Constants' own stale doc comment), registry name Flint, built-against 2.4.2, clone `cd` path, connection-string-handler rotation remarks.

**Passed on, with rationale:** whole-blob settings CAS (real but architectural — worth its own design pass), rewriting the token-idempotency test (the production guard lives in the SDK wrapper, exercised by the live regtest suites).

1,074 unit tests pass (10 new).


---

**Second commit (quorum review of this PR):** corrected the B3 adjudication as above, and persisted `ProviderOrderId` on the crash-recovery resolution path too (the initial-send path alone missed the crash-before-first-resolution window — the exact window that needs the handle). 1,076 unit tests pass (2 new broadcaster retry tests).