### PR TITLE
Release 0.1.5

### DIFF
--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -45,7 +45,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>0.1.4.1</Version>
+    <Version>0.1.5</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
-## [Unreleased]
+## [0.1.5] — 2026-08-21
 
 ### Security
 


### PR DESCRIPTION
Bumps `<Version>` to 0.1.5 and dates the changelog's Unreleased section, covering the third review pass and its quorum follow-ups (#27): fee-overflow saturation, the restored setup sweeping opt-in, the token write-off gate, the settlement push retry, packaged licence notices, and the rest of the Security/Fixed/Documentation entries. No code changes.

Will be tagged `v0.1.5` and published as a **pre-release** pending the security scan of the tag.