### PR TITLE
Let a store set its own Breez API key on the Advanced page

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/SparkAdvancedPageTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkAdvancedPageTests.cs
@@ -62,6 +62,77 @@ public class SparkAdvancedPageTests
     }
 
     [Fact]
+    public async Task Saving_an_api_key_override_stores_it_trimmed_and_restarts_the_wallet()
+    {
+        // The override is the revocation-resilience valve Breez suggested: the plugin-wide embedded key is
+        // shared by every install, and a merchant holding their own survives its revocation. Storing settings
+        // is what reconciles the running wallet, so the save is also the restart.
+        var h = SparkSurfaceHarness.Create(configureAttackerStore: true);
+
+        var result = await h.Mvc.AdvancedApiKey(
+            Store,
+            new SparkAdvancedViewModel { ApiKeyOverride = "  merchant-owned-key  " },
+            CancellationToken.None);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.Equal("merchant-owned-key", h.Settings.Settings[Store]!.ApiKeyOverride);
+        Assert.Single(h.Settings.Writes);
+    }
+
+    [Fact]
+    public async Task Clearing_the_api_key_override_returns_the_store_to_the_built_in_key()
+    {
+        var h = SparkSurfaceHarness.Create(configureAttackerStore: true);
+        h.Settings.Settings[Store]!.ApiKeyOverride = "merchant-owned-key";
+
+        var result = await h.Mvc.AdvancedApiKey(
+            Store,
+            new SparkAdvancedViewModel { ApiKeyOverride = "   " },
+            CancellationToken.None);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.Null(h.Settings.Settings[Store]!.ApiKeyOverride);
+    }
+
+    [Fact]
+    public async Task An_unchanged_api_key_does_not_bounce_the_wallet()
+    {
+        // Storing settings tears the SDK instance down and reconnects it. A no-op save must not pay that
+        // cost — or interrupt an in-flight receive — for nothing.
+        var h = SparkSurfaceHarness.Create(configureAttackerStore: true);
+        h.Settings.Settings[Store]!.ApiKeyOverride = "merchant-owned-key";
+
+        var result = await h.Mvc.AdvancedApiKey(
+            Store,
+            new SparkAdvancedViewModel { ApiKeyOverride = "merchant-owned-key" },
+            CancellationToken.None);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.Empty(h.Settings.Writes);
+    }
+
+    [Fact]
+    public async Task A_key_the_wallet_cannot_start_with_is_rolled_back()
+    {
+        // The store must not be left holding a key its wallet will not start with: the save would read as
+        // success while every checkout failed — the exact quiet failure the settings store's contract exists
+        // to surface.
+        var h = SparkSurfaceHarness.Create(configureAttackerStore: true);
+        h.Settings.Settings[Store]!.ApiKeyOverride = "old-key";
+        h.Settings.NextSetDeclinesWith = "the service provider rejected the API key";
+
+        var result = await h.Mvc.AdvancedApiKey(
+            Store,
+            new SparkAdvancedViewModel { ApiKeyOverride = "bad-key" },
+            CancellationToken.None);
+
+        Assert.IsType<ViewResult>(result);
+        Assert.False(h.Mvc.ModelState.IsValid);
+        // The revert re-applied the previous settings, so the old key is what is stored and running.
+        Assert.Equal("old-key", h.Settings.Settings[Store]!.ApiKeyOverride);
+    }
+
+    [Fact]
     public async Task An_invalid_combination_is_refused_and_nothing_is_written()
     {
         var h = SparkSurfaceHarness.Create(configureAttackerStore: true);

--- a/BTCPayServer.Plugins.Flint/Constants.cs
+++ b/BTCPayServer.Plugins.Flint/Constants.cs
@@ -289,7 +289,9 @@ public static class Constants
     /// Breez API keys are <b>per-application</b> identifiers, not per-user credentials — the same
     /// model a first-party mobile app uses. Shipping one plugin-wide key keeps merchant setup friction at zero
     /// and matches the Boltz <c>referralId="btcpay"</c> precedent. A merchant may still supply
-    /// their own via <c>SparkSettings.ApiKeyOverride</c>.
+    /// their own via <c>SparkSettings.ApiKeyOverride</c>, editable on the Advanced page — the
+    /// revocation-resilience valve Breez themselves suggested, so a revocation of this shared key
+    /// (never seen, but possible) costs a prepared merchant nothing.
     /// </para>
     /// <para>
     /// <b>The obfuscation is not encryption and is not security.</b> The mask is in this repository

--- a/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
+++ b/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
@@ -663,6 +663,69 @@ public class SparkController : Controller
     }
 
     /// <summary>
+    /// Saves the merchant's own Breez API key, or clears it back to the plugin's built-in one.
+    /// </summary>
+    /// <remarks>
+    /// The override exists for revocation resilience: every install shares the plugin's embedded key, and
+    /// Breez's own suggestion is to let a merchant hold their own so a revocation of the shared key — never
+    /// seen, but possible — costs them nothing. Storing the settings reconciles the running wallet, so the
+    /// new key is what the SDK connects with immediately; a key the SDK refuses to start with is rolled back
+    /// to the previous settings rather than left stored in front of a dead wallet.
+    /// </remarks>
+    [HttpPost("advanced/api-key")]
+    [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanModifyStoreSettings)]
+    public async Task<IActionResult> AdvancedApiKey(
+        [FromRoute] string storeId,
+        SparkAdvancedViewModel vm,
+        CancellationToken cancellationToken)
+    {
+        if (!ResolveStore(storeId, out var store))
+            return NotFound();
+
+        storeId = store.Id;
+
+        var previous = await _settingsStore.GetAsync(storeId).ConfigureAwait(false);
+        if (previous is null)
+            return await RedirectToSetupOrDeny(storeId).ConfigureAwait(false);
+
+        var trimmed = vm.ApiKeyOverride?.Trim();
+        var newKey = string.IsNullOrEmpty(trimmed) ? null : trimmed;
+
+        if (string.Equals(newKey, previous.ApiKeyOverride, StringComparison.Ordinal))
+        {
+            // Nothing changed; do not bounce the wallet for it.
+            return RedirectToAction(nameof(Advanced), new { storeId });
+        }
+
+        var updated = previous.Clone();
+        updated.ApiKeyOverride = newKey;
+
+        var applied = await _settingsStore.SetAsync(storeId, updated).ConfigureAwait(false);
+        if (!applied.WalletRunning)
+        {
+            // The store must not be left holding a key its wallet will not start with. The revert re-applies
+            // the previous settings, which brings the previous key's wallet back up.
+            await _settingsStore.SetAsync(storeId, previous).ConfigureAwait(false);
+            ModelState.AddModelError(
+                nameof(vm.ApiKeyOverride),
+                "The Spark wallet could not start with this API key"
+                + (applied.Reason is { } reason ? $": {reason}" : ".")
+                + " The previous key is back in effect.");
+
+            var status = await _statusReader.ReadAsync(storeId, cancellationToken).ConfigureAwait(false);
+            var model = await BuildAdvancedViewModel(storeId, status, input: null, cancellationToken)
+                .ConfigureAwait(false);
+            model.ApiKeyOverride = vm.ApiKeyOverride;
+            return View("Advanced", model);
+        }
+
+        TempData[WellKnownTempData.SuccessMessage] = newKey is null
+            ? "This store now uses the plugin's built-in Breez API key."
+            : "This store now uses its own Breez API key.";
+        return RedirectToAction(nameof(Advanced), new { storeId });
+    }
+
+    /// <summary>
     /// Fills in everything the Advanced page shows. <paramref name="input"/> is the merchant's rejected form
     /// on a re-render, or null to show what is stored.
     /// </summary>
@@ -678,6 +741,8 @@ public class SparkController : Controller
             input = current.Settings;
         }
 
+        var settings = await _settingsStore.GetAsync(storeId).ConfigureAwait(false);
+
         return new SparkAdvancedViewModel
         {
             StoreId = storeId,
@@ -685,7 +750,8 @@ public class SparkController : Controller
             WalletRunning = status.WalletRunning,
             IdentityPubkey = status.IdentityPubkey,
             StorageDirectory = status.StorageDirectoryFor(User),
-            Settings = input
+            Settings = input,
+            ApiKeyOverride = settings?.ApiKeyOverride
         };
     }
 

--- a/BTCPayServer.Plugins.Flint/Models/SparkAdvancedViewModel.cs
+++ b/BTCPayServer.Plugins.Flint/Models/SparkAdvancedViewModel.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using BTCPayServer.Plugins.Flint.Services;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
@@ -35,4 +36,12 @@ public class SparkAdvancedViewModel
     /// </summary>
     [ValidateNever]
     public SweepSettingsInput Settings { get; set; } = new();
+
+    /// <summary>
+    /// The merchant's own Breez API key, empty when the plugin's built-in one is in use. Not a secret in
+    /// Breez's model — displayed back rather than masked — but it is what the SDK connects with, so saving it
+    /// restarts the store's wallet.
+    /// </summary>
+    [Display(Name = "Breez API key")]
+    public string? ApiKeyOverride { get; set; }
 }

--- a/BTCPayServer.Plugins.Flint/SparkSettings.cs
+++ b/BTCPayServer.Plugins.Flint/SparkSettings.cs
@@ -149,8 +149,9 @@ public class SparkSettings
 /// </para>
 /// <para>
 /// <b>Neither property here has a write path, and that is deliberate.</b> Nothing binds them from the MVC
-/// forms or from Greenfield; like <c>ApiKeyOverride</c> they are operator-level overrides, reachable only by
-/// editing the store's settings blob. The defaults are the policy, both surfaces show what is in force
+/// forms or from Greenfield; they are operator-level overrides, reachable only by editing the store's
+/// settings blob. (<c>ApiKeyOverride</c> used to share this posture but is editable on the Advanced page
+/// now — it moves no money, which is exactly the line these two sit on the other side of.) The defaults are the policy, both surfaces show what is in force
 /// (deposit page and <c>GET .../spark/deposits</c>), and adding a form would put a fee ceiling that moves
 /// money in front of every merchant who does not need one. The consequence is that <b>every value here has to
 /// be safe against a blob nobody validated</b> — hence the clamping on the effective properties rather than at

--- a/BTCPayServer.Plugins.Flint/Views/Spark/Advanced.cshtml
+++ b/BTCPayServer.Plugins.Flint/Views/Spark/Advanced.cshtml
@@ -123,6 +123,31 @@
             <button type="submit" class="btn btn-primary" id="SparkSaveAdvancedSweep">Save</button>
         </form>
 
+        <form method="post" asp-action="AdvancedApiKey" asp-route-storeId="@Model.StoreId"
+              permission="@Policies.CanModifyStoreSettings">
+            <h3 class="mt-5 mb-3">Breez API key</h3>
+            <p class="text-secondary">
+                Every install of this plugin shares a built-in Breez API key. Setting your own here keeps this
+                store's wallet working even if that shared key is ever revoked or rate-limited — request one
+                for free from
+                <a href="https://breez.technology/request-api-key/#contact-us-form-sdk" target="_blank"
+                   rel="noreferrer noopener">Breez</a>.
+            </p>
+            <div class="row">
+                <div class="col-md-8 form-group">
+                    <label asp-for="ApiKeyOverride" class="form-label"></label>
+                    <input asp-for="ApiKeyOverride" class="form-control" autocomplete="off" spellcheck="false"
+                           placeholder="Using the plugin's built-in key" />
+                    <span asp-validation-for="ApiKeyOverride" class="text-danger"></span>
+                    <div class="form-text">
+                        Leave empty to use the built-in key. Saving restarts this store's Spark wallet so the
+                        change takes effect immediately; a key Spark refuses is rolled back.
+                    </div>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-primary" id="SparkSaveApiKey">Save API key</button>
+        </form>
+
         <div permission="@Policies.CanModifyStoreSettings">
             <h3 class="mt-5 mb-3">Remove</h3>
             <div id="danger-zone" class="d-flex flex-wrap align-items-center gap-3 mb-5 mt-2">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
+## [Unreleased]
+
+### Added
+
+- **A store can use its own Breez API key.** The Advanced page gains a field for it, with a link to
+  Breez's request form. The plugin's built-in key is shared by every install; on Breez's own suggestion,
+  a merchant holding their own key loses nothing if the shared key is ever revoked or rate-limited.
+  Saving restarts the store's wallet so the key takes effect immediately, and a key Spark refuses to
+  start with is rolled back rather than left stored in front of a dead wallet. Leaving the field empty
+  returns the store to the built-in key. (The setting itself predates this release; it was previously
+  reachable only by editing the store's settings blob.)
+
 ## [0.1.5] — 2026-08-21
 
 ### Security


### PR DESCRIPTION
Per Breez's suggestion: the plugin-wide embedded key is shared by every install, so give merchants a way to hold their own — if the shared key is ever revoked or rate-limited, a prepared store loses nothing.

`SparkSettings.ApiKeyOverride` already existed (and `SparkService` already prefers it over the embedded key); this adds the missing write path and UI:

- A **Breez API key** section on the Advanced page, with a link to [Breez's request form](https://breez.technology/request-api-key/#contact-us-form-sdk) (URL verified against the Spark SDK docs). Empty = built-in key.
- `POST advanced/api-key` under `CanModifyStoreSettings`: trims, no-ops on an unchanged key (no wallet bounce), stores through the settings store so reconciliation restarts the wallet with the new key immediately, and **rolls back to the previous settings when the wallet refuses to start** with the new key — the quiet-failure contract the settings store exists for.
- Stale doc comments claiming the override has no write path updated (Constants, SparkDepositSettings remarks).

Four new controller tests: trimmed save, clear-to-built-in, unchanged-key no-op, and refused-key rollback. 1,080 unit tests pass.