### PR TITLE
Gate Breez SDK update PRs on upstream releases, not tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,13 @@
 version: 2
 
 updates:
-  # Breez.Sdk.Spark and any other NuGet packages referenced directly by the plugin project.
-  # Pre-1.0 and ships frequent releases, some of them explicit prereleases (e.g. "0.20.0-dev1")
-  # — this repo pins stable only (see the comment on the PackageReference in the .csproj).
-  # No explicit `ignore` rule for that is configured: dependabot.yml's
-  # `ignore.update-types` only supports semver-major/minor/patch, not a "prerelease" type, and
-  # Dependabot's own default behaviour already only proposes stable-to-stable updates when the
-  # pinned version (0.19.2 here) isn't itself a prerelease — confirmed against community reports
-  # of the opposite problem (dependabot/feedback#451: prerelease-pinned projects not being
-  # offered further prereleases), not against a live run of this repo. Watch the first PR
-  # Dependabot opens here to confirm it holds; if it ever proposes a prerelease, an explicit
-  # `ignore: - dependency-name: "Breez.Sdk.Spark", versions: ["*-*"]`-style pattern would be the
-  # fallback (NuGet ignore version patterns are glob-style, not semver ranges).
+  # NuGet packages referenced directly by the plugin project — except Breez.Sdk.Spark, ignored
+  # below: Breez tags and pushes patch versions to NuGet with no GitHub Release and no notes
+  # (0.22.1 through 0.22.3 all shipped that way), and a Dependabot PR per push is churn, not
+  # signal. .github/workflows/breez-sdk-update.yml is the release-aware replacement — the same
+  # split as the btcpayserver submodule above, for the same reason — proposing a bump only for
+  # versions upstream has published a release for. A tag-only fix worth shipping early is bumped
+  # by hand.
   #
   # Also note: Dependabot's nuget updater resolves the project's ProjectReference to
   # ../btcpayserver/BTCPayServer/BTCPayServer.csproj, which lives in a git submodule; this is
@@ -32,6 +27,8 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      - dependency-name: "Breez.Sdk.Spark"
 
   # Test-project NuGet packages -- xunit.v3, and since the move to Microsoft.Testing.Platform that is the
   # whole list; the VSTest host and adapter it used to name here are gone. Separate entry because

--- a/.github/workflows/breez-sdk-update.yml
+++ b/.github/workflows/breez-sdk-update.yml
@@ -1,0 +1,145 @@
+name: Breez SDK update
+
+# Dependabot's nuget ecosystem proposes a PR for every Breez.Sdk.Spark version pushed to NuGet,
+# and Breez tags and pushes patch versions with no GitHub Release and no notes (0.22.1 through
+# 0.22.3 all shipped that way) — a PR per push is churn, not signal. This workflow is the
+# release-aware equivalent, mirroring btcpayserver-update.yml for the same reason that one
+# replaced Dependabot's gitsubmodule ecosystem: weekly plus on-demand, it looks for the newest
+# version breez/spark-sdk has a *published GitHub Release* for (that also exists on NuGet, so
+# the PR can restore), and opens a bump PR only then. Breez.Sdk.Spark is ignored in
+# dependabot.yml so the two do not both propose bumps. A tag-only fix worth shipping early is a
+# human decision: bump the PackageReference by hand, exactly as 0.22.2 and 0.22.3 were.
+#
+# Token: default GITHUB_TOKEN, with the same workflow_dispatch re-dispatch trick as
+# btcpayserver-update.yml so ci.yml actually runs on the PR this opens (GITHUB_TOKEN-authored
+# pushes do not fire pull_request workflows; workflow_dispatch is exempt from that rule).
+
+on:
+  schedule:
+    - cron: "0 6 * * 2"  # Tuesdays 06:00 UTC — offset from the Monday btcpayserver check
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Detect only: print the result and diff, but do not push or open a PR"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write  # to re-dispatch ci.yml on the bump branch, see above
+
+jobs:
+  check:
+    name: Check for a newer Breez SDK release
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+      current: ${{ steps.check.outputs.current }}
+      latest: ${{ steps.check.outputs.latest }}
+      release_url: ${{ steps.check.outputs.release_url }}
+    steps:
+      # No submodule checkout needed: the discovery script only reads the csproj and queries the
+      # GitHub and NuGet APIs, so this stays cheap enough to run unconditionally every week.
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Run discovery script
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          out="$(scripts/check-breez-sdk-update.sh)"
+          echo "Discovery result: $out"
+          {
+            echo "changed=$(jq -r .changed <<<"$out")"
+            echo "current=$(jq -r .current <<<"$out")"
+            echo "latest=$(jq -r .latest <<<"$out")"
+            echo "release_url=$(jq -r .release_url <<<"$out")"
+          } >> "$GITHUB_OUTPUT"
+
+  bump:
+    name: Open bump PR
+    needs: check
+    if: ${{ needs.check.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      CURRENT: ${{ needs.check.outputs.current }}
+      LATEST: ${{ needs.check.outputs.latest }}
+      RELEASE_URL: ${{ needs.check.outputs.release_url }}
+      DRY_RUN: ${{ github.event.inputs.dry_run }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump Breez.Sdk.Spark to ${{ needs.check.outputs.latest }}
+        run: |
+          set -euo pipefail
+          sed -i -E \
+            "s|(<PackageReference Include=\"Breez.Sdk.Spark\" Version=\")[0-9][0-9.]*(\")|\1$LATEST\2|" \
+            BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+          if ! grep -q "Include=\"Breez.Sdk.Spark\" Version=\"$LATEST\"" \
+            BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj; then
+            echo "error: the PackageReference did not end up at $LATEST; refusing to open a PR" >&2
+            exit 1
+          fi
+          git add BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+          git status --short
+
+      - name: Create branch and commit
+        id: commit
+        run: |
+          set -euo pipefail
+          branch="chore/breez-sdk-$LATEST"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN — diff only, not pushing:"
+            git --no-pager diff --cached
+            exit 0
+          fi
+
+          git switch -c "$branch"
+          git commit -m "Bump Breez.Sdk.Spark to $LATEST"
+          git push -f origin "$branch"
+
+      - name: Open or update PR
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.commit.outputs.branch }}
+        run: |
+          set -euo pipefail
+          title="Bump Breez.Sdk.Spark: $CURRENT -> $LATEST"
+          body="$(cat <<BODY
+          Bumps \`Breez.Sdk.Spark\` from \`$CURRENT\` to \`$LATEST\`, a version upstream has published
+          a GitHub Release for — tag-only NuGet pushes are deliberately not proposed (see
+          \`.github/workflows/breez-sdk-update.yml\`).
+
+          Upstream release notes: $RELEASE_URL
+
+          The SDK is pre-1.0 with no stability promise between releases: read the notes (when they
+          exist) and the API-surface diff before merging, per the pinning comment on the
+          PackageReference. CI on this PR — including the live and funded regtest suites — is the
+          merge gate, not a substitute for that read.
+          BODY
+          )"
+
+          open_count="$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')"
+          if [ "$open_count" = "0" ]; then
+            gh pr create --base main --head "$BRANCH" --title "$title" --body "$body"
+            echo "Opened PR for $BRANCH."
+          else
+            gh pr edit "$BRANCH" --title "$title" --body "$body"
+            echo "PR already open for $BRANCH; force-pushed branch updated it."
+          fi
+
+          # See the workflow-level comment: workflow_dispatch is exempt from GITHUB_TOKEN's
+          # loop-prevention rule, so this is what actually gets ci.yml to run on the PR.
+          gh workflow run ci.yml --ref "$BRANCH"

--- a/docs/ci-and-releases.md
+++ b/docs/ci-and-releases.md
@@ -34,9 +34,15 @@
     or offline against the `attestation.jsonl` bundle attached to the release. The reasoning, and
     what this deliberately does *not* protect against, is in the header comment of
     [`package.yml`](../.github/workflows/package.yml).
-- **Breez.Sdk.Spark / test / GitHub Actions version bumps** are handled by
+- **Test / GitHub Actions version bumps** are handled by
   [Dependabot](../.github/dependabot.yml) (`nuget` and `github-actions` ecosystems); CI on the PRs
   it opens is the gate.
+- **Breez.Sdk.Spark bumps** are *not* Dependabot's (it is ignored there): Breez pushes tag-only
+  patch versions to NuGet with no release entry, and a PR per push is churn.
+  **`.github/workflows/breez-sdk-update.yml`** runs weekly (and on manual dispatch, with a dry-run
+  option) and opens a bump PR only for a version upstream has published a GitHub Release for that
+  also exists on NuGet — see `scripts/check-breez-sdk-update.sh`. A tag-only fix worth shipping
+  early is bumped by hand, exactly as 0.22.2 and 0.22.3 were.
 - **`btcpayserver` submodule bumps** are *not* handled by Dependabot: its `gitsubmodule` ecosystem
   tracks the latest commit on a branch, not release tags, which is the wrong model for a submodule
   pinned to stable releases. Instead, **`.github/workflows/btcpayserver-update.yml`** runs weekly

--- a/scripts/check-breez-sdk-update.sh
+++ b/scripts/check-breez-sdk-update.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Discovers whether a newer Breez.Sdk.Spark version exists that upstream has published a
+# *GitHub Release* for — not merely tagged and pushed to NuGet. Prints a single-line JSON
+# object and exits 0 whether or not an update was found; it is the caller's job to decide
+# what to do with the result.
+#
+# Why release-gated rather than Dependabot: Breez tags and publishes patch versions with no
+# release entry and no notes (0.22.1 through 0.22.3 all shipped that way), and a PR per
+# NuGet push is churn this repo does not want. A version upstream stands behind with a
+# published release is the signal worth a PR. The trade-off is deliberate: a fix Breez ships
+# tag-only waits until they cut a release, or until a human bumps the pin by hand — which
+# remains possible and is how the tag-only 0.22.2 and 0.22.3 bumps happened.
+#
+# Requires: gh (authenticated — in Actions, GH_TOKEN from the default token), curl, jq.
+#
+# Usage: scripts/check-breez-sdk-update.sh
+# Output: {"current":"0.22.3","latest":"0.22.3","changed":false,"release_url":"..."}
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CSPROJ="$REPO_ROOT/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj"
+UPSTREAM="breez/spark-sdk"
+NUGET_INDEX="https://api.nuget.org/v3-flatcontainer/breez.sdk.spark/index.json"
+
+if [ ! -f "$CSPROJ" ]; then
+  echo "error: $CSPROJ not found" >&2
+  exit 1
+fi
+
+current="$(grep -oE '<PackageReference Include="Breez.Sdk.Spark" Version="[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?"' "$CSPROJ" \
+  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?' || true)"
+
+if [ -z "$current" ]; then
+  echo "error: could not find the Breez.Sdk.Spark PackageReference in $CSPROJ" >&2
+  exit 1
+fi
+
+# Published, non-draft, non-prerelease GitHub Releases whose tag is a plain stable version.
+# Breez's tags carry no v prefix, and their explicit prereleases ("0.20.0-dev1") are excluded
+# by the pattern as well as by the prerelease flag.
+releases=()
+while IFS= read -r line; do
+  [ -n "$line" ] && releases+=("$line")
+done < <(
+  gh api "repos/$UPSTREAM/releases?per_page=100" \
+    --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+    | sed -n 's#^v\{0,1\}\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)$#\1#p'
+)
+
+if [ "${#releases[@]}" -eq 0 ]; then
+  echo "error: no stable releases found on $UPSTREAM" >&2
+  exit 1
+fi
+
+# Plain numeric field sort, as in check-btcpayserver-update.sh — no reliance on GNU `sort -V`.
+latest="$(printf '%s\n' "${releases[@]}" | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1)"
+
+# The release must also be installable: a GitHub Release whose NuGet package has not landed
+# yet (or never will — releases cover more platforms than the .NET binding) must not produce
+# a PR whose restore fails. Reported as unchanged, and picked up once the package appears.
+if ! curl -fsSL "$NUGET_INDEX" | jq -e --arg v "$latest" '.versions | index($v)' > /dev/null; then
+  echo "note: $UPSTREAM release $latest has no matching NuGet package yet; treating as no update" >&2
+  latest="$current"
+fi
+
+# "changed" means latest is strictly newer than current: not equal, and the max of the two
+# (by the same numeric sort) is latest. A current pin *ahead* of the newest release — a
+# hand-applied tag-only bump, exactly how 0.22.2 and 0.22.3 arrived — therefore stays put.
+changed="false"
+if [ "$latest" != "$current" ]; then
+  max="$(printf '%s\n%s\n' "$current" "$latest" | sort -t. -k1,1n -k2,2n -k3,3n | tail -n1)"
+  if [ "$max" = "$latest" ]; then
+    changed="true"
+  fi
+fi
+
+printf '{"current":"%s","latest":"%s","changed":%s,"release_url":"https://github.com/%s/releases/tag/%s"}\n' \
+  "$current" "$latest" "$changed" "$UPSTREAM" "$latest"


### PR DESCRIPTION
Per request: no more update PRs for every Breez SDK tag/NuGet push — only versions upstream has published a **GitHub Release** for.

- `Breez.Sdk.Spark` is ignored in dependabot.yml (with the rationale in place of the old prerelease-behaviour note).
- New `.github/workflows/breez-sdk-update.yml` + `scripts/check-breez-sdk-update.sh`, mirroring the btcpayserver-update pair: weekly (Tuesdays, offset from the Monday submodule check) plus manual dispatch with a dry-run option; opens/updates a `chore/breez-sdk-<version>` PR and re-dispatches ci.yml onto it (same GITHUB_TOKEN loop-prevention workaround).
- The release must also exist on NuGet before a PR is proposed, so a GitHub Release without a package (their releases cover more platforms than the .NET binding) can't produce a PR that fails restore.
- A pin *ahead* of the newest release — a hand-applied tag-only bump, exactly how 0.22.2/0.22.3 arrived — stays put. Verified by running the discovery script live: `{"current":"0.22.3","latest":"0.22.0","changed":false}`.
- docs/ci-and-releases.md updated.

No plugin code touched; no release needed.