### PR TITLE
Never display the stored Breez API key on the Advanced page

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/SparkAdvancedPageTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkAdvancedPageTests.cs
@@ -80,7 +80,24 @@ public class SparkAdvancedPageTests
     }
 
     [Fact]
-    public async Task Clearing_the_api_key_override_returns_the_store_to_the_built_in_key()
+    public async Task The_built_in_key_button_is_what_clears_the_override()
+    {
+        // The stored key is never displayed, so an empty field is what an untouched form looks like — only
+        // the explicit button may mean "clear".
+        var h = SparkSurfaceHarness.Create(configureAttackerStore: true);
+        h.Settings.Settings[Store]!.ApiKeyOverride = "merchant-owned-key";
+
+        var result = await h.Mvc.AdvancedApiKey(
+            Store,
+            new SparkAdvancedViewModel { UseBuiltInKey = true },
+            CancellationToken.None);
+
+        Assert.IsType<RedirectToActionResult>(result);
+        Assert.Null(h.Settings.Settings[Store]!.ApiKeyOverride);
+    }
+
+    [Fact]
+    public async Task A_blank_submit_is_refused_and_never_echoes_the_stored_key()
     {
         var h = SparkSurfaceHarness.Create(configureAttackerStore: true);
         h.Settings.Settings[Store]!.ApiKeyOverride = "merchant-owned-key";
@@ -90,8 +107,16 @@ public class SparkAdvancedPageTests
             new SparkAdvancedViewModel { ApiKeyOverride = "   " },
             CancellationToken.None);
 
-        Assert.IsType<RedirectToActionResult>(result);
-        Assert.Null(h.Settings.Settings[Store]!.ApiKeyOverride);
+        var view = Assert.IsType<ViewResult>(result);
+        Assert.False(h.Mvc.ModelState.IsValid);
+        Assert.Equal("merchant-owned-key", h.Settings.Settings[Store]!.ApiKeyOverride);
+        Assert.Empty(h.Settings.Writes);
+
+        // The re-rendered model says an override exists, but never carries the key itself: the page has no
+        // reason to hand out a value nobody else should be using, secret or not.
+        var model = Assert.IsType<SparkAdvancedViewModel>(view.Model);
+        Assert.True(model.HasApiKeyOverride);
+        Assert.True(string.IsNullOrEmpty(model.ApiKeyOverride));
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
+++ b/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
@@ -689,7 +689,28 @@ public class SparkController : Controller
             return await RedirectToSetupOrDeny(storeId).ConfigureAwait(false);
 
         var trimmed = vm.ApiKeyOverride?.Trim();
-        var newKey = string.IsNullOrEmpty(trimmed) ? null : trimmed;
+        string? newKey;
+        if (vm.UseBuiltInKey)
+        {
+            newKey = null;
+        }
+        else if (string.IsNullOrEmpty(trimmed))
+        {
+            // The stored key is never displayed, so an empty field is what an untouched form looks like — it
+            // cannot be allowed to mean "clear", which is what the explicit button is for.
+            ModelState.AddModelError(
+                nameof(vm.ApiKeyOverride),
+                "Enter a key to save, or use the built-in-key button to remove the override.");
+
+            var current = await _statusReader.ReadAsync(storeId, cancellationToken).ConfigureAwait(false);
+            return View("Advanced",
+                await BuildAdvancedViewModel(storeId, current, input: null, cancellationToken)
+                    .ConfigureAwait(false));
+        }
+        else
+        {
+            newKey = trimmed;
+        }
 
         if (string.Equals(newKey, previous.ApiKeyOverride, StringComparison.Ordinal))
         {
@@ -751,7 +772,10 @@ public class SparkController : Controller
             IdentityPubkey = status.IdentityPubkey,
             StorageDirectory = status.StorageDirectoryFor(User),
             Settings = input,
-            ApiKeyOverride = settings?.ApiKeyOverride
+            // Presence only — the key itself never leaves the settings blob for this page. Nobody else should
+            // be using a store's key even though Breez does not treat it as a secret, so the page has no
+            // business printing it into the DOM.
+            HasApiKeyOverride = !string.IsNullOrEmpty(settings?.ApiKeyOverride)
         };
     }
 

--- a/BTCPayServer.Plugins.Flint/Models/SparkAdvancedViewModel.cs
+++ b/BTCPayServer.Plugins.Flint/Models/SparkAdvancedViewModel.cs
@@ -38,10 +38,22 @@ public class SparkAdvancedViewModel
     public SweepSettingsInput Settings { get; set; } = new();
 
     /// <summary>
-    /// The merchant's own Breez API key, empty when the plugin's built-in one is in use. Not a secret in
-    /// Breez's model — displayed back rather than masked — but it is what the SDK connects with, so saving it
-    /// restarts the store's wallet.
+    /// A replacement Breez API key, inbound only — <b>the stored key is never written into this model</b>.
+    /// Not a secret in Breez's model, but nobody else should be using this store's key either, so the page
+    /// has no reason to hand it out: the form shows only whether an override is set, an empty field to
+    /// replace it, and a button to return to the built-in key.
     /// </summary>
-    [Display(Name = "Breez API key")]
+    [Display(Name = "New Breez API key")]
     public string? ApiKeyOverride { get; set; }
+
+    /// <summary>Whether this store has its own key set. Display only; the key itself stays server-side.</summary>
+    [BindNever]
+    public bool HasApiKeyOverride { get; set; }
+
+    /// <summary>
+    /// True when the merchant pressed the "use built-in key" button, which is the only way to clear the
+    /// override: with the stored key never displayed, an empty field cannot be allowed to mean "clear" — it
+    /// is what the form looks like when nothing was touched.
+    /// </summary>
+    public bool UseBuiltInKey { get; set; }
 }

--- a/BTCPayServer.Plugins.Flint/Views/Spark/Advanced.cshtml
+++ b/BTCPayServer.Plugins.Flint/Views/Spark/Advanced.cshtml
@@ -133,19 +133,42 @@
                 <a href="https://breez.technology/request-api-key/#contact-us-form-sdk" target="_blank"
                    rel="noreferrer noopener">Breez</a>.
             </p>
+            <p id="SparkApiKeyState">
+                @if (Model.HasApiKeyOverride)
+                {
+                    <span class="badge bg-info">Own key</span>
+                    <span>This store uses its own API key. It is not displayed; enter a new one to replace it.</span>
+                }
+                else
+                {
+                    <span class="badge bg-secondary">Built-in key</span>
+                    <span>This store uses the plugin's built-in API key.</span>
+                }
+            </p>
             <div class="row">
                 <div class="col-md-8 form-group">
                     <label asp-for="ApiKeyOverride" class="form-label"></label>
                     <input asp-for="ApiKeyOverride" class="form-control" autocomplete="off" spellcheck="false"
-                           placeholder="Using the plugin's built-in key" />
+                           placeholder="@(Model.HasApiKeyOverride ? "Enter a key to replace the current one" : "Enter your own key")" />
                     <span asp-validation-for="ApiKeyOverride" class="text-danger"></span>
                     <div class="form-text">
-                        Leave empty to use the built-in key. Saving restarts this store's Spark wallet so the
-                        change takes effect immediately; a key Spark refuses is rolled back.
+                        Saving restarts this store's Spark wallet so the change takes effect immediately; a key
+                        Spark refuses is rolled back.
                     </div>
                 </div>
             </div>
-            <button type="submit" class="btn btn-primary" id="SparkSaveApiKey">Save API key</button>
+            <div class="d-flex gap-3">
+                <button type="submit" class="btn btn-primary" id="SparkSaveApiKey">
+                    @(Model.HasApiKeyOverride ? "Replace API key" : "Save API key")
+                </button>
+                @if (Model.HasApiKeyOverride)
+                {
+                    <button type="submit" name="UseBuiltInKey" value="true" class="btn btn-secondary"
+                            id="SparkUseBuiltInKey">
+                        Use the built-in key instead
+                    </button>
+                }
+            </div>
         </form>
 
         <div permission="@Policies.CanModifyStoreSettings">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/
 is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
 below — so a release that forgets this file fails the test suite.
 
+## [Unreleased]
+
+### Changed
+
+- **The Advanced page no longer displays the stored Breez API key.** The key is not a secret in Breez's
+  model, but nobody else should be using a store's key either, so the page has no reason to print it into
+  the DOM. The form now shows only whether an override is set; a new key replaces the current one, and an
+  explicit "use the built-in key" button clears it — an empty field is what an untouched form looks like,
+  so it no longer means "clear" and is refused instead.
+
 ## [0.1.5.1] — 2026-08-22
 
 ### Added


### PR DESCRIPTION
Follow-up to #29: the stored key is never written into the page model or DOM. The form shows presence only (an "Own key" / "Built-in key" badge), a blank field whose non-empty submit replaces the key, and an explicit **Use the built-in key instead** button that clears the override.

Because the stored key is no longer displayed, an empty field is what an untouched form looks like — so an empty submit is refused with a validation message instead of being read as "clear" (which is what it meant in #29).

Tests updated: clear now goes through the button; a new test pins that a blank submit is refused and that the re-rendered model carries `HasApiKeyOverride` but never the key itself. 1,081 unit tests pass.