### PR TITLE
feat: sweep webhooks, balance sync, sweep API improvements, server update webhook (v0.1.6.0-v0.1.8.0)

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkSurfaceHarness.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkSurfaceHarness.cs
@@ -272,7 +272,9 @@ public sealed class SparkSurfaceHarness
             settings,
             provisioner, seedResolver, statusReader, sweepSettings, sweepEngine,
             runtime, depositService, stableBalanceService,
-            NullLogger<GreenfieldSparkController>.Instance);
+            NullLogger<GreenfieldSparkController>.Instance,
+            // Server-level settings (GET/PUT /api/v1/server/spark) are not exercised by this harness.
+            null!);
 
         var store = authoriseStore is null ? null : new StoreData { Id = authoriseStore };
 

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkSurfaceHarness.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkSurfaceHarness.cs
@@ -271,7 +271,7 @@ public sealed class SparkSurfaceHarness
         var api = new GreenfieldSparkController(
             settings,
             provisioner, seedResolver, statusReader, sweepSettings, sweepEngine,
-            depositService, stableBalanceService,
+            runtime, depositService, stableBalanceService,
             NullLogger<GreenfieldSparkController>.Instance);
 
         var store = authoriseStore is null ? null : new StoreData { Id = authoriseStore };

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/StubHttpClientFactory.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/StubHttpClientFactory.cs
@@ -55,6 +55,14 @@ public sealed class StubHttpMessageHandler : HttpMessageHandler
     /// <summary>Completes when the first request arrives, so a test need not poll for it.</summary>
     public Task Started => _started.Task;
 
+    /// <summary>
+    /// Routes every request through <paramref name="respond"/>, letting a test inspect the request and
+    /// decide the response. Use when the default factory methods do not expose enough control.
+    /// </summary>
+    public static StubHttpMessageHandler Capture(
+        Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> respond) =>
+        new(respond);
+
     /// <summary>Answers every request with <paramref name="body"/> as <c>200 application/json</c>.</summary>
     public static StubHttpMessageHandler Returning(string body) =>
         new((_, _) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/StubHttpClientFactory.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/StubHttpClientFactory.cs
@@ -7,7 +7,7 @@ namespace BTCPayServer.Plugins.Flint.Tests.Fakes;
 /// An <see cref="IHttpClientFactory"/> that hands out one client over a handler a test controls.
 /// </summary>
 /// <remarks>
-/// The alternative — letting the catalogue reach the real endpoint — would make the suite depend on a third
+/// The alternative - letting the catalogue reach the real endpoint - would make the suite depend on a third
 /// party's uptime to answer a question about this plugin's own caching, and would make "the fetch failed" a
 /// scenario nobody could arrange on purpose.
 /// </remarks>
@@ -71,6 +71,34 @@ public sealed class StubHttpMessageHandler : HttpMessageHandler
         new((_, _) => Task.FromException<HttpResponseMessage>(
             new HttpRequestException("no route to host")));
 
+    /// <summary>
+    /// Returns responses from <paramref name="statuses"/> in order, then repeats the last one for any
+    /// subsequent requests. Useful for testing retry logic: pass e.g. 503, 503, 200 to get two failures
+    /// followed by a success.
+    /// </summary>
+    public static StubHttpMessageHandler Sequence(params HttpStatusCode[] statuses)
+    {
+        var index = 0;
+        return new StubHttpMessageHandler((_, _) =>
+        {
+            var i = Math.Min(Interlocked.Increment(ref index) - 1, statuses.Length - 1);
+            return Task.FromResult(new HttpResponseMessage(statuses[i]));
+        });
+    }
+
+    /// <summary>
+    /// Fails the first request with a network exception, then returns 200 for every request after.
+    /// The inverse of <see cref="OnceThenOffline"/>: useful for testing retry logic where the
+    /// first attempt hits a transient network error and the second one succeeds.
+    /// </summary>
+    public static StubHttpMessageHandler FailOnceThenOK()
+    {
+        var called = 0;
+        return new StubHttpMessageHandler((_, _) => Interlocked.Increment(ref called) == 1
+            ? Task.FromException<HttpResponseMessage>(new HttpRequestException("connection refused"))
+            : Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
+    }
+
     /// <summary>Answers the first request and refuses every one after it: an endpoint that goes away.</summary>
     public static StubHttpMessageHandler OnceThenOffline(string body)
     {
@@ -88,7 +116,7 @@ public sealed class StubHttpMessageHandler : HttpMessageHandler
     /// Answers with a body that starts like the real one and then never stops.
     /// </summary>
     /// <remarks>
-    /// Chunked, so there is no <c>Content-Length</c> to check — which is why the ceiling has to be applied while
+    /// Chunked, so there is no <c>Content-Length</c> to check - which is why the ceiling has to be applied while
     /// reading rather than off a header. This is the shape of the failure worth defending against: not a large
     /// response, but one that has no end.
     /// </remarks>
@@ -190,7 +218,7 @@ public static class RecordedPayloads
     /// <remarks>
     /// <para>
     /// Every route object is verbatim from the live response, field for field. It is a <em>subset</em>: all 114
-    /// routes whose source chain is Spark — which is everything the projection can possibly keep — plus twenty
+    /// routes whose source chain is Spark - which is everything the projection can possibly keep - plus twenty
     /// sourced elsewhere, so the source filter has something to filter. Eight of those twenty are the tokenised
     /// equities that reach Robinhood Chain from other sources and never from Spark; they are in the recording
     /// on purpose, because they are what an unfiltered projection would put in a merchant's sweep picker. The

--- a/BTCPayServer.Plugins.Flint.Tests/FundedRegtest/SparkFundedRegtestTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/FundedRegtest/SparkFundedRegtestTests.cs
@@ -232,7 +232,7 @@ public class SparkFundedRegtestTests
             MaxFeePercent = 25.0
         });
 
-        var run = await engine.RunAsync(_wallet.StoreId, SweepTrigger.Manual, Ct);
+        var run = await engine.RunAsync(_wallet.StoreId, SweepTrigger.Manual, cancellationToken: Ct);
         Assert.True(
             run.Kind is SweepOutcomeKind.Swept,
             $"the sweep did not go out: {run.Kind} — {run.Reason}");
@@ -257,7 +257,7 @@ public class SparkFundedRegtestTests
         var confirmed = await PollAsync(
             async () =>
             {
-                await engine.RunAsync(_wallet.StoreId, SweepTrigger.Automatic, Ct);
+                await engine.RunAsync(_wallet.StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
                 var current = await records.GetAsync(_wallet.StoreId, sent.IdempotencyKey, Ct);
                 return current?.Status is SweepRecordStatus.Confirmed ? current : null;
             },
@@ -354,7 +354,7 @@ public class SparkFundedRegtestTests
         var resolved = await PollAsync(
             async () =>
             {
-                await engine.RunAsync(_wallet.StoreId, SweepTrigger.Automatic, Ct);
+                await engine.RunAsync(_wallet.StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
                 var current = await records.GetAsync(_wallet.StoreId, idempotencyKey, Ct);
                 return current?.Status is SweepRecordStatus.Sent or SweepRecordStatus.Confirmed ? current : null;
             },

--- a/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkStoreScopeTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkStoreScopeTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Microsoft.AspNetCore.Mvc.Routing;
 using BTCPayServer.Client.Models;
 using BTCPayServer.Plugins.Flint.Controllers;
 using BTCPayServer.Plugins.Flint.Data;
@@ -279,9 +280,13 @@ public class GreenfieldSparkStoreScopeTests
     [Fact]
     public void The_no_authorised_store_theory_covers_every_action_on_the_controller()
     {
+        // Server-level endpoints (no {storeId} in route) do not use ResolveStore and are not
+        // covered by this theory; they are gated by CanModifyServerSettings instead.
         var actions = typeof(GreenfieldSparkController)
             .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
             .Where(m => typeof(Task<IActionResult>).IsAssignableFrom(m.ReturnType))
+            .Where(m => m.GetCustomAttributes<HttpMethodAttribute>()
+                .Any(a => a.Template?.Contains("{storeId}", StringComparison.Ordinal) == true))
             .Select(m => m.Name)
             .ToList();
 

--- a/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkStoreScopeTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkStoreScopeTests.cs
@@ -228,6 +228,7 @@ public class GreenfieldSparkStoreScopeTests
     [InlineData("deposit-claim")]
     [InlineData("stable-get")]
     [InlineData("stable-put")]
+    [InlineData("sync")]
     public async Task Every_endpoint_refuses_when_no_store_was_authorised_at_all(string endpoint)
     {
         // The other half of the guard: HttpContext carries no authorised store, which is what a future filter
@@ -256,6 +257,7 @@ public class GreenfieldSparkStoreScopeTests
                 SparkSurfaceHarness.AttackerStore, CancellationToken.None),
             "stable-put" => await h.Api.UpdateStableBalance(
                 SparkSurfaceHarness.AttackerStore, new StableBalanceInput(), CancellationToken.None),
+            "sync" => await h.Api.SyncBalance(SparkSurfaceHarness.AttackerStore, CancellationToken.None),
             _ => await h.Api.Sweep(SparkSurfaceHarness.AttackerStore, null, CancellationToken.None)
         };
 

--- a/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkStoreScopeTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkStoreScopeTests.cs
@@ -229,6 +229,7 @@ public class GreenfieldSparkStoreScopeTests
     [InlineData("stable-get")]
     [InlineData("stable-put")]
     [InlineData("sync")]
+    [InlineData("sweep-record")]
     public async Task Every_endpoint_refuses_when_no_store_was_authorised_at_all(string endpoint)
     {
         // The other half of the guard: HttpContext carries no authorised store, which is what a future filter
@@ -258,6 +259,7 @@ public class GreenfieldSparkStoreScopeTests
             "stable-put" => await h.Api.UpdateStableBalance(
                 SparkSurfaceHarness.AttackerStore, new StableBalanceInput(), CancellationToken.None),
             "sync" => await h.Api.SyncBalance(SparkSurfaceHarness.AttackerStore, CancellationToken.None),
+            "sweep-record" => await h.Api.GetSweepRecord(SparkSurfaceHarness.AttackerStore, "key", CancellationToken.None),
             _ => await h.Api.Sweep(SparkSurfaceHarness.AttackerStore, null, CancellationToken.None)
         };
 

--- a/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkSweepTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/GreenfieldSparkSweepTests.cs
@@ -325,8 +325,8 @@ public class GreenfieldSparkSweepTests
         h.Settings.Settings[Store]!.Sweep = new SweepSettings { Enabled = true, BalanceThresholdSats = 1 };
         h.WalletOf(Store).BalanceSats = 1_000;
         var engine = h.SweepEngine;
-        await engine.RunAsync(Store, SweepTrigger.Automatic, CancellationToken.None);
-        await engine.RunAsync(Store, SweepTrigger.Automatic, CancellationToken.None);
+        await engine.RunAsync(Store, SweepTrigger.Automatic, cancellationToken: CancellationToken.None);
+        await engine.RunAsync(Store, SweepTrigger.Automatic, cancellationToken: CancellationToken.None);
 
         var configuration = AssertOk<SparkSweepConfigurationData>(
             await h.Api.GetSweepConfiguration(Store, 0, 25, CancellationToken.None));

--- a/BTCPayServer.Plugins.Flint.Tests/SparkApiContractTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkApiContractTests.cs
@@ -87,15 +87,22 @@ public class SparkApiContractTests
             var authorize = method.GetCustomAttributes<AuthorizeAttribute>().Single();
             Assert.Equal(AuthenticationSchemes.Greenfield, authorize.AuthenticationSchemes);
 
-            var expected = verb is "get"
-                ? Policies.CanViewStoreSettings
-                : Policies.CanModifyStoreSettings;
+            var isServerLevel = path.StartsWith("/api/v1/server/", StringComparison.Ordinal);
+            string expected;
+            if (isServerLevel)
+                expected = Policies.CanModifyServerSettings;
+            else if (verb is "get")
+                expected = Policies.CanViewStoreSettings;
+            else
+                expected = Policies.CanModifyStoreSettings;
 
             Assert.Equal(expected, policy);
 
             // Reads may not require a write permission and writes may not accept a read one.
+            var requiresWrite = policy == Policies.CanModifyStoreSettings
+                                || policy == Policies.CanModifyServerSettings;
             Assert.True(
-                verb is "get" || policy == Policies.CanModifyStoreSettings,
+                verb is "get" || requiresWrite,
                 $"{verb.ToUpperInvariant()} {path} changes state but is gated on {policy}");
         }
     }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkApiContractTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkApiContractTests.cs
@@ -230,7 +230,8 @@ public class SparkApiContractTests
         { "SparkSweepResultData", typeof(SparkSweepResultData) },
         { "SparkSweepPreviewData", typeof(SparkSweepPreviewData) },
         { "SparkSweepDestinationData", typeof(SparkSweepDestinationData) },
-        { "SparkSweepQuoteData", typeof(SparkSweepQuoteData) }
+        { "SparkSweepQuoteData", typeof(SparkSweepQuoteData) },
+        { "SparkBalanceSyncData", typeof(SparkBalanceSyncData) }
     };
 
     [Theory]

--- a/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkCrossChainSweepTests.cs
@@ -38,7 +38,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
 
@@ -83,7 +83,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000, configure: s => s.CrossChainSlippageBps = 25);
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(25u, Assert.Single(h.Sdk.CrossChainSendCalls).MaxSlippageBps);
     }
@@ -93,7 +93,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000, configure: s => s.CrossChainSlippageBps = null);
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(
             SweepSettings.DefaultCrossChainSlippageBps,
@@ -113,7 +113,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var record = result.Record!;
         Assert.True(record.IdempotencyKeyAccepted);
@@ -133,7 +133,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         var key = result.Record!.IdempotencyKey;
 
         var added = h.Log.Entries.IndexOf($"sweep:add:{key}");
@@ -176,7 +176,7 @@ public class SparkCrossChainSweepTests
         // exactly why the quote has to be checked rather than trusted to fit.
         h.Sdk.CrossChainOverpayBps = 1_500;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.CrossChainOverpayExceedsBalance, result.Record!.RefusalCode);
@@ -196,7 +196,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 200_000, configure: s => s.ReserveSats = 5_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         var send = Assert.Single(h.Sdk.CrossChainSendCalls);
@@ -231,7 +231,7 @@ public class SparkCrossChainSweepTests
         var h = Harness(balanceSats: 500_000);
         h.Sdk.CrossChainConfigured = false;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.CrossChainUnavailable, result.Record!.RefusalCode);
@@ -284,7 +284,7 @@ public class SparkCrossChainSweepTests
             s.EvmAsset = "USDT0";
         });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.NoCrossChainRoute, result.Record!.RefusalCode);
@@ -308,7 +308,7 @@ public class SparkCrossChainSweepTests
         var h = Harness(balanceSats: 500_000, configure: s => s.EvmChain = "polygon");
 
         // Polygon carries only USDT0 in the route table, and the store asked for USDT.
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.NoCrossChainRoute, result.Record!.RefusalCode);
@@ -338,7 +338,7 @@ public class SparkCrossChainSweepTests
                 s.BalanceThresholdSats = 1;
             });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.BelowMinimumSweep, result.Record!.RefusalCode);
@@ -365,7 +365,7 @@ public class SparkCrossChainSweepTests
         // 3.4% spread against a 0.1% ceiling.
         h.Sdk.CrossChainFeeBps = 340;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.FeeAboveLimit, result.Record!.RefusalCode);
@@ -378,7 +378,7 @@ public class SparkCrossChainSweepTests
         var h = Harness(balanceSats: 500_000, configure: s => s.MaxFeePercent = 1.0);
         h.Sdk.CrossChainFeeBps = 34;
 
-        Assert.Equal(SweepOutcomeKind.Swept, (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct)).Kind);
+        Assert.Equal(SweepOutcomeKind.Swept, (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct)).Kind);
     }
 
     /// <summary>
@@ -403,7 +403,7 @@ public class SparkCrossChainSweepTests
         // that what refuses this is the fee ceiling and not something else.
         h.Sdk.CrossChainFeeBps = 500;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.FeeAboveLimit, result.Record!.RefusalCode);
@@ -435,7 +435,7 @@ public class SparkCrossChainSweepTests
         // 20%: comfortably inside the merchant's stated 90% ceiling.
         h.Sdk.CrossChainFeeBps = 2_000;
 
-        var refused = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var refused = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, refused.Kind);
         Assert.Equal(SweepRefusalCode.CrossChainValueUnverifiable, refused.Record!.RefusalCode);
@@ -448,7 +448,7 @@ public class SparkCrossChainSweepTests
 
         Assert.Equal(
             SweepOutcomeKind.Swept,
-            (await allowed.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct)).Kind);
+            (await allowed.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct)).Kind);
     }
 
     /// <summary>
@@ -466,7 +466,7 @@ public class SparkCrossChainSweepTests
         // A negative spread: estimatedOut above assetAmountIn.
         h.Sdk.CrossChainFeeBps = -100;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.CrossChainQuoteUnusable, result.Record!.RefusalCode);
@@ -493,7 +493,7 @@ public class SparkCrossChainSweepTests
         // follows is unambiguously the fee guard running against the committed quote.
         var widening = new WideningFee(h.Sdk, whenQuoted: 34, thenBps: 500);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.True(widening.Widened, "the pre-flight quote was never taken, so the test proved nothing");
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
@@ -528,7 +528,7 @@ public class SparkCrossChainSweepTests
         h.Sdk.CrossChainRate = (100_000_000, 500_000);
         h.Sdk.CrossChainFeeBps = 34;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.CrossChainValueUnverifiable, result.Record!.RefusalCode);
@@ -548,7 +548,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         Assert.Equal(new[] { (StoreId, "USD") }, h.Oracle.Calls.Distinct());
@@ -569,7 +569,7 @@ public class SparkCrossChainSweepTests
         // 10^40 base units of a 6-decimal token: 10^34 whole dollars, far beyond what a decimal can carry.
         var h = Harness(balanceSats: 500_000, stableBalance: BigInteger.Pow(10, 40));
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.CrossChainValueUnverifiable, result.Record!.RefusalCode);
@@ -591,7 +591,7 @@ public class SparkCrossChainSweepTests
         var h = Harness(balanceSats: 500_000);
         h.Oracle.Unavailable = true;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.CrossChainValueUnverifiable, result.Record!.RefusalCode);
@@ -613,7 +613,7 @@ public class SparkCrossChainSweepTests
         h.Oracle.Unavailable = true;
 
         Assert.Equal(
-            SweepOutcomeKind.Swept, (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct)).Kind);
+            SweepOutcomeKind.Swept, (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct)).Kind);
         Assert.Empty(h.Oracle.Calls);
     }
 
@@ -630,7 +630,7 @@ public class SparkCrossChainSweepTests
         // Half the dollars in, delivered out.
         h.Sdk.CrossChainFeeBps = 5_000;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.CrossChainValueUnverifiable, result.Record!.RefusalCode);
@@ -654,7 +654,7 @@ public class SparkCrossChainSweepTests
             "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f", 8,
             [SparkCrossChainSource.Bitcoin], "route:orchestra:arbitrum:WBTC"));
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.CrossChainValueUnverifiable, result.Record!.RefusalCode);
@@ -679,7 +679,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000, stableBalance: 35_600_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
 
@@ -716,7 +716,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 1_000, stableBalance: 35_600_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         // The sats balance is far below anything, and the quote's amountIn is long.MaxValue. Neither matters.
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
@@ -737,7 +737,7 @@ public class SparkCrossChainSweepTests
         // $5 held against a $20 floor.
         var h = Harness(balanceSats: 500_000, stableBalance: 5_000_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.BelowMinimumSweep, result.Record!.RefusalCode);
@@ -759,7 +759,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000, stableBalance: 35_600_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         Assert.Null(Assert.Single(h.Sdk.CrossChainSendCalls).IdempotencyKey);
@@ -821,7 +821,7 @@ public class SparkCrossChainSweepTests
                 s.BalanceThresholdSats = 1;
             });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.StableBalanceHoldsTheFunds, result.Record!.RefusalCode);
@@ -846,7 +846,7 @@ public class SparkCrossChainSweepTests
         var h = Harness(balanceSats: 500_000, stableBalance: 35_600_000);
         h.Records.RefuseQuoteWrites = true;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         // The send was reached and vetoed inside the approval callback, so nothing was issued.
@@ -878,7 +878,7 @@ public class SparkCrossChainSweepTests
                 s.BalanceThresholdSats = 1;
             });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.BelowMinimumSweep, result.Record!.RefusalCode);
@@ -899,7 +899,7 @@ public class SparkCrossChainSweepTests
                 s.MaxFeePercent = 20;
             });
 
-        Assert.Equal(SweepOutcomeKind.Swept, (await exit.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct)).Kind);
+        Assert.Equal(SweepOutcomeKind.Swept, (await exit.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct)).Kind);
     }
 
     /// <summary>
@@ -987,7 +987,7 @@ public class SparkCrossChainSweepTests
                 SparkCrossChainProvider.Orchestra, SparkConversionStatus.Completed,
                 "q_arbitrum_35244000", "order-1", 35_100_000, Evm, "arbitrum", "USDT", 6)));
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var resolved = await h.Records.GetAsync(StoreId, row.IdempotencyKey, Ct);
         Assert.Equal(SweepRecordStatus.Confirmed, resolved!.Status);
@@ -1027,7 +1027,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000, stableBalance: 35_600_000);
 
-        var sent = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var sent = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         Assert.Equal(SweepOutcomeKind.Swept, sent.Kind);
 
         var key = sent.Record!.IdempotencyKey;
@@ -1061,7 +1061,7 @@ public class SparkCrossChainSweepTests
         h.Sdk.TokenBalances.Clear();
         h.Sdk.BalanceSats = 0;
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var recovered = await h.Records.GetAsync(StoreId, key, Ct);
         Assert.Equal(SweepRecordStatus.Sent, recovered!.Status);
@@ -1119,7 +1119,7 @@ public class SparkCrossChainSweepTests
                 1, 0, Origin.AddSeconds(10 + i), null, null, null, null, null));
         }
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var resolved = await h.Records.GetAsync(StoreId, "row-oldest", Ct);
         Assert.Equal(SweepRecordStatus.Confirmed, resolved!.Status);
@@ -1155,13 +1155,13 @@ public class SparkCrossChainSweepTests
             Ct);
 
         // Inside the grace period: still blocking, nothing sent.
-        var first = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var first = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         Assert.Equal(SweepOutcomeKind.InFlight, first.Kind);
         Assert.Empty(h.Sdk.CrossChainSendCalls);
 
         // Past it: written off, with a message that does not claim the money is safe.
         h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromMinutes(1));
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var closed = await h.Records.GetAsync(StoreId, "row-key-2", Ct);
         Assert.Equal(SweepRecordStatus.Failed, closed!.Status);
@@ -1203,7 +1203,7 @@ public class SparkCrossChainSweepTests
             Ct);
 
         h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromMinutes(1));
-        var blocked = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var blocked = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.InFlight, blocked.Kind);
         Assert.Empty(h.Sdk.CrossChainSendCalls);
@@ -1211,7 +1211,7 @@ public class SparkCrossChainSweepTests
 
         // ...and past the escalation window it closes with a reason naming what was observed.
         h.Time.Advance(SparkSweepEngine.ShortfallWriteOffAge);
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var closed = await h.Records.GetAsync(StoreId, "row-key-3", Ct);
         Assert.Equal(SweepRecordStatus.Failed, closed!.Status);
@@ -1245,7 +1245,7 @@ public class SparkCrossChainSweepTests
             },
             Ct);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.InFlight, result.Kind);
         Assert.Empty(h.Sdk.CrossChainSendCalls);
@@ -1286,7 +1286,7 @@ public class SparkCrossChainSweepTests
             new SparkConversionState(
                 SparkCrossChainProvider.Orchestra, SparkConversionStatus.Pending, "q_something", "order-2")));
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Contains(key, h.Sdk.GetPaymentCalls);
         var resolved = await h.Records.GetAsync(StoreId, key, Ct);
@@ -1321,7 +1321,7 @@ public class SparkCrossChainSweepTests
         var h = Harness(balanceSats: 500_000, stableBalance: 35_600_000);
         h.Sdk.NullProviderQuoteIdAfterPrepares = keptPrepares;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.QuoteFailed, result.Record!.RefusalCode);
@@ -1356,7 +1356,7 @@ public class SparkCrossChainSweepTests
         var h = Harness(balanceSats: 500_000);
         h.Sdk.NullProviderQuoteIdAfterPrepares = 0;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         Assert.Equal(SweepRecordStatus.Sent, result.Record!.Status);
@@ -1404,7 +1404,7 @@ public class SparkCrossChainSweepTests
             new SparkConversionState(
                 SparkCrossChainProvider.Orchestra, SparkConversionStatus.RefundNeeded, "q_stuck", "order-3")));
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(1, h.Sdk.RefundPendingConversionsCalls);
 
@@ -1427,7 +1427,7 @@ public class SparkCrossChainSweepTests
     {
         var h = Harness(balanceSats: 500_000);
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(0, h.Sdk.RefundPendingConversionsCalls);
     }
@@ -1446,7 +1446,7 @@ public class SparkCrossChainSweepTests
         var h = Harness(balanceSats: 500_000, stableBalance: 35_600_000);
         h.Sdk.FailCrossChainSendWith = new SdkException.NetworkException("@v1=connection reset");
 
-        var first = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var first = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Unresolved, first.Kind);
         Assert.Equal(SweepRecordStatus.Pending, h.Records.Records[first.Record!.IdempotencyKey].Status);
@@ -1456,7 +1456,7 @@ public class SparkCrossChainSweepTests
         h.Sdk.FailCrossChainSendWith = null;
         h.Sdk.CrossChainSendCalls.Clear();
 
-        var second = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var second = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.InFlight, second.Kind);
         Assert.Empty(h.Sdk.CrossChainSendCalls);

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
@@ -116,7 +116,7 @@ public class SparkSweepEngineTests
     {
         var h = CreateHarness(new SweepSettings { Enabled = true, ReserveSats = 50_000 }, balanceSats: 500_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
 
@@ -152,7 +152,7 @@ public class SparkSweepEngineTests
         // from; without it a sweep is money that arrived with no explanation.
         var h = CreateHarness();
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var labeled = Assert.Single(h.Labeler.Labeled);
         Assert.Equal(StoreId, labeled.StoreId);
@@ -165,7 +165,7 @@ public class SparkSweepEngineTests
     {
         var h = CreateHarness(balanceSats: 10_000);
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Empty(h.Labeler.Labeled);
     }
@@ -181,7 +181,7 @@ public class SparkSweepEngineTests
         await h.Records.AddAsync(NewPending(key), Ct);
         h.Sdk.Seed(CompletedExit(key, 450_000, 2_190));
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var labeled = Assert.Single(h.Labeler.Labeled);
         Assert.Equal("txid-recovered", labeled.TxId);
@@ -194,7 +194,7 @@ public class SparkSweepEngineTests
         // counters — which would pass just as happily with the two writes reversed.
         var h = CreateHarness();
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var key = Assert.Single(h.Sdk.OnchainSendCalls).IdempotencyKey;
         Assert.Equal(
@@ -221,7 +221,7 @@ public class SparkSweepEngineTests
         // GetPayment(key) is later asked for.
         var h = CreateHarness();
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.True(Guid.TryParse(Assert.Single(h.Sdk.OnchainSendCalls).IdempotencyKey, out _));
     }
@@ -234,7 +234,7 @@ public class SparkSweepEngineTests
         // count cannot express it — swapping the two calls would leave SyncCount == 1 and the balance stale.
         var h = CreateHarness();
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var sync = h.Log.Entries.IndexOf("sdk:sync");
         var read = h.Log.Entries.IndexOf("sdk:getinfo:synced");
@@ -248,7 +248,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness();
         h.Sdk.NextOnchainSendStatus = SparkPaymentStatus.Completed;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         Assert.Equal(SweepRecordStatus.Confirmed, h.Records.Single()!.Status);
@@ -259,13 +259,13 @@ public class SparkSweepEngineTests
     {
         var h = CreateHarness();
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         // The first sweep left the wallet on its reserve of zero, so top it back up and resolve the first record so
         // it stops blocking.
         h.Sdk.BalanceSats = 500_000;
         h.Sdk.NextOnchainSendStatus = SparkPaymentStatus.Completed;
         h.Time.Advance(TimeSpan.FromMinutes(1));
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(2, h.Sdk.OnchainSendCalls.Count);
         Assert.Equal(FakeSweepAddressSource.RegtestAddresses[0], h.Sdk.OnchainSendCalls[0].Address);
@@ -308,7 +308,7 @@ public class SparkSweepEngineTests
             ReserveSats = reserveSats
         });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         var record = h.Records.Single()!;
@@ -335,7 +335,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness(new SweepSettings { Enabled = true, ReserveSats = 50_000 });
         h.Sdk.NextOnchainSendStatus = SparkPaymentStatus.Completed;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         Assert.Equal(SweepRecordStatus.Confirmed, h.Records.Single()!.Status);
@@ -354,7 +354,7 @@ public class SparkSweepEngineTests
             ReserveSats = 10_000
         });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         var send = Assert.Single(h.Sdk.OnchainSendCalls);
@@ -374,7 +374,7 @@ public class SparkSweepEngineTests
             ConfirmationSpeed = SweepConfirmationSpeed.Slow
         });
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SparkOnchainSpeed.Slow, Assert.Single(h.Sdk.OnchainSendCalls).Speed);
         // 1,950 rather than the medium tier's 2,190. A numeric cast between the two enums would have bought Fast.
@@ -390,7 +390,7 @@ public class SparkSweepEngineTests
     {
         var h = CreateHarness(new SweepSettings { Enabled = false });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Skipped, result.Kind);
         Assert.Empty(h.Sdk.OnchainSendCalls);
@@ -405,7 +405,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness(
             new SweepSettings { Enabled = true, BalanceThresholdSats = 200_000 }, balanceSats: 150_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Skipped, result.Kind);
         Assert.Contains("150,000 sat has not passed the 200,000 sat sweep threshold", result.Reason);
@@ -420,7 +420,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness(
             new SweepSettings { Enabled = false, BalanceThresholdSats = 10_000_000 }, balanceSats: 500_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         Assert.Equal(SweepTrigger.Manual, h.Records.Single()!.Trigger);
@@ -434,7 +434,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness(
             new SweepSettings { Enabled = true, MinimumSweepSats = 100_000 }, balanceSats: 20_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Contains("below this store's 100,000 sat minimum", result.Reason);
@@ -451,7 +451,7 @@ public class SparkSweepEngineTests
             new SweepSettings { Enabled = true, BalanceThresholdSats = 1, MinimumSweepSats = 100_000 },
             balanceSats: 20_000);
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(0, h.Addresses.ReservedCount);
         Assert.Empty(h.Sdk.OnchainQuoteCalls);
@@ -471,7 +471,7 @@ public class SparkSweepEngineTests
             },
             balanceSats: 100_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Contains("2,190 sat exit fee is 2.24%", result.Reason);
@@ -494,7 +494,7 @@ public class SparkSweepEngineTests
             MaxFeeFlatSats = 1_000
         });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Contains("above the 1,000 sat limit", result.Reason);
@@ -512,7 +512,7 @@ public class SparkSweepEngineTests
         h.Sdk.OnchainTiersAtSend = new SparkOnchainFeeQuote(
             "SparkCoopExitFeeQuote:later", Origin, 40_000, 50_000, 60_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         // 2,190 on the pre-flight quote cleared the 1% ceiling on 447,810; 50,000 does not.
@@ -536,11 +536,11 @@ public class SparkSweepEngineTests
         // last-moment fee spike would stop the store sweeping until a human intervened.
         var h = CreateHarness(new SweepSettings { Enabled = true, MaxFeePercent = 1.0 });
         h.Sdk.OnchainTiersAtSend = new SparkOnchainFeeQuote("q", Origin, 40_000, 50_000, 60_000);
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         h.Sdk.OnchainTiersAtSend = null;
         h.Time.Advance(TimeSpan.FromMinutes(2));
-        var second = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var second = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, second.Kind);
     }
@@ -575,7 +575,7 @@ public class SparkSweepEngineTests
             ReserveSats = 500
         });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Contains("reserve is only 500 sat", result.Reason);
@@ -590,7 +590,7 @@ public class SparkSweepEngineTests
             Result = SweepAddressResult.NoWallet("This store has no Bitcoin wallet.")
         });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal("This store has no Bitcoin wallet.", result.Reason);
@@ -604,7 +604,7 @@ public class SparkSweepEngineTests
     {
         var h = CreateHarness(walletRunning: false);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Contains("Spark wallet is not running", result.Reason);
@@ -620,7 +620,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness();
         h.Settings.Settings[StoreId]!.Sweep = null!;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         // Sweeping defaults to off, so the pass declines rather than sweeping on defaults nobody chose.
         Assert.Equal(SweepOutcomeKind.Skipped, result.Kind);
@@ -647,7 +647,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness(
             new SweepSettings { Enabled = true, BalanceThresholdSats = 0 }, balanceSats: 150_000);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Skipped, result.Kind);
         Assert.Contains("200,000 sat sweep threshold", result.Reason);
@@ -660,7 +660,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness();
         h.Settings.Settings.Remove(StoreId);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Skipped, result.Kind);
         Assert.Empty(h.Records.Records);
@@ -688,7 +688,7 @@ public class SparkSweepEngineTests
             // Leaf-optimisation drift: a few sats either way, every pass. This is what defeated a de-duplication
             // keyed on the rendered sentence.
             h.Sdk.BalanceSats = 500_000 + (pass % 7) - 3;
-            messages.Add((await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct)).Reason);
+            messages.Add((await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct)).Reason);
         }
 
         var record = Assert.Single(h.Records.Records).Value;
@@ -718,7 +718,7 @@ public class SparkSweepEngineTests
         for (var pass = 0; pass < 5; pass++)
         {
             h.Time.Advance(TimeSpan.FromMinutes(2));
-            await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+            await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         }
 
         Assert.Equal(5, Assert.Single(h.Records.Records).Value.AttemptCount);
@@ -732,12 +732,12 @@ public class SparkSweepEngineTests
         // something else happened once.
         var h = CreateHarness(new SweepSettings { Enabled = true, MaxFeePercent = 0.1 });
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         h.Time.Advance(TimeSpan.FromMinutes(2));
         // A manual attempt, which always files its own row.
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
         h.Time.Advance(TimeSpan.FromMinutes(2));
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(2, h.Records.Records.Count);
         var automatic = h.Records.Records.Values.Single(r => r.Trigger is SweepTrigger.Automatic);
@@ -751,9 +751,9 @@ public class SparkSweepEngineTests
         // itself and recurred a week later is visible as two episodes instead of one endless tally.
         var h = CreateHarness(new SweepSettings { Enabled = true, MaxFeePercent = 0.1 });
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         h.Time.Advance(SparkSweepEngine.RefusalCoalescingWindow + TimeSpan.FromMinutes(1));
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(2, h.Records.Records.Count);
         Assert.All(h.Records.Records.Values, r => Assert.Equal(1, r.AttemptCount));
@@ -764,10 +764,10 @@ public class SparkSweepEngineTests
     {
         var h = CreateHarness(new SweepSettings { Enabled = true, MaxFeePercent = 0.1 });
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         h.Time.Advance(TimeSpan.FromMinutes(2));
         h.Addresses.Result = SweepAddressResult.NoWallet("no wallet here");
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(2, h.Records.Records.Count);
         Assert.Equal(
@@ -785,9 +785,9 @@ public class SparkSweepEngineTests
             Result = SweepAddressResult.NoWallet("This store has no Bitcoin wallet.")
         });
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         h.Time.Advance(TimeSpan.FromMinutes(1));
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.Equal(2, h.Records.Records.Count);
         Assert.Contains(h.Records.Records.Values, r => r.Trigger is SweepTrigger.Manual);
@@ -805,7 +805,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness();
         h.Sdk.ExpireNextQuotes = 1;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
         Assert.Equal(2, h.Sdk.OnchainSendCalls.Count);
@@ -821,7 +821,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness();
         h.Sdk.ExpireNextQuotes = 5;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         // Two attempts, then the outcome is left unknown for the next pass to resolve rather than hammered.
         Assert.Equal(SweepOutcomeKind.Unresolved, result.Kind);
@@ -839,7 +839,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness(new SweepSettings { Enabled = true, DrainWhenSweeping = false, ReserveSats = 5_000 });
         h.Sdk.BalanceOnSend = 1_000;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Failed, result.Kind);
         var record = h.Records.Single();
@@ -864,7 +864,7 @@ public class SparkSweepEngineTests
             },
             balanceSats: 294);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Contains("below the 294 sat on-chain minimum", result.Reason);
@@ -889,7 +889,7 @@ public class SparkSweepEngineTests
             },
             balanceSats: 293);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Empty(h.Sdk.OnchainQuoteCalls);
@@ -914,7 +914,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness();
         h.Sdk.FailOnchainSendWith = failure;
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Failed, result.Kind);
         var record = h.Records.Single();
@@ -927,7 +927,7 @@ public class SparkSweepEngineTests
         h.Time.Advance(TimeSpan.FromMinutes(2));
         Assert.Equal(
             SweepOutcomeKind.Swept,
-            (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct)).Kind);
+            (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct)).Kind);
     }
 
     public static TheoryData<string, Exception> FailuresThatProvablySentNothing() => new()
@@ -968,7 +968,7 @@ public class SparkSweepEngineTests
         h.Sdk.FailOnchainSendWith = new ObjectDisposedException(
             "SparkSdkClient", "The Spark wallet for store S has been shut down.");
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Unresolved, result.Kind);
         var record = h.Records.Single();
@@ -982,7 +982,7 @@ public class SparkSweepEngineTests
         h.Time.Advance(TimeSpan.FromMinutes(2));
         Assert.NotEqual(
             SweepOutcomeKind.Swept,
-            (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct)).Kind);
+            (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct)).Kind);
     }
 
     [Fact]
@@ -993,7 +993,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness();
         h.Sdk.FailOnchainSendWith = new SdkException.NetworkException("@v1=connection reset");
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Unresolved, result.Kind);
         var record = h.Records.Single();
@@ -1015,7 +1015,7 @@ public class SparkSweepEngineTests
         await h.Records.AddAsync(NewPending(key), Ct);
         h.Sdk.Seed(CompletedExit(key, 450_000, 2_190));
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         // Nothing is re-sent: the record was resolved by asking, not by retrying.
         Assert.Empty(h.Sdk.OnchainSendCalls);
@@ -1036,7 +1036,7 @@ public class SparkSweepEngineTests
         await h.Records.AddAsync(NewPending(key), Ct);
         h.Sdk.Seed(CompletedExit(key, 450_000, 2_190) with { Status = SparkPaymentStatus.Pending });
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var record = await h.Records.GetAsync(StoreId, key, Ct);
         Assert.Equal(SweepRecordStatus.Sent, record!.Status);
@@ -1051,14 +1051,14 @@ public class SparkSweepEngineTests
         // complete" as "it did not happen". The later passes are given a fresh balance so they genuinely do sweep —
         // otherwise the "never under the original key" half of this test would be checking an empty sequence.
         var h = CreateHarness();
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         var key = Assert.Single(h.Sdk.OnchainSendCalls).IdempotencyKey;
 
         for (var pass = 0; pass < 3; pass++)
         {
             h.Time.Advance(TimeSpan.FromMinutes(10));
             h.Sdk.BalanceSats = 500_000;
-            await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+            await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         }
 
         var record = await h.Records.GetAsync(StoreId, key, Ct);
@@ -1079,12 +1079,12 @@ public class SparkSweepEngineTests
         // Stated directly rather than left as a side effect of another test: a Sent exit's funds have already left
         // the balance, so holding new sweeps behind it would strand every later receive.
         var h = CreateHarness();
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         Assert.Equal(SweepRecordStatus.Sent, h.Records.Single()!.Status);
 
         h.Sdk.BalanceSats = 500_000;
         h.Time.Advance(TimeSpan.FromMinutes(2));
-        var second = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var second = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, second.Kind);
     }
@@ -1105,7 +1105,7 @@ public class SparkSweepEngineTests
         await h.Records.AddAsync(NewPending(key), Ct);
         h.Sdk.Seed(CompletedExit(key, 1_234, 7) with { Direction = direction, Method = method });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.InFlight, result.Kind);
         var record = await h.Records.GetAsync(StoreId, key, Ct);
@@ -1135,7 +1135,7 @@ public class SparkSweepEngineTests
         await h.Records.AddAsync(NewPending(exitKey), Ct);
         h.Sdk.Seed(CompletedExit(exitKey, 1_234, 7) with { Method = SparkPaymentMethod.Token });
 
-        var blocked = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var blocked = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         // Rejected: a Token payment is not what a cooperative exit produces, so the row keeps blocking.
         Assert.Equal(SweepOutcomeKind.InFlight, blocked.Kind);
@@ -1155,7 +1155,7 @@ public class SparkSweepEngineTests
                 SparkCrossChainProvider.Orchestra, SparkConversionStatus.Completed, "q_1", "order-1", 35_600_000)
         });
 
-        await crossChainHarness.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await crossChainHarness.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var resolved = await crossChainHarness.Records.GetAsync(StoreId, crossChainKey, Ct);
         Assert.Equal(SweepRecordStatus.Confirmed, resolved!.Status);
@@ -1181,7 +1181,7 @@ public class SparkSweepEngineTests
         // The SDK knows nothing about it — the send may be in flight on an uncancellable call right now.
 
         h.Time.Advance(SparkSweepEngine.UnresolvedGrace - TimeSpan.FromSeconds(1));
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.InFlight, result.Kind);
         Assert.Empty(h.Sdk.OnchainSendCalls);
@@ -1196,7 +1196,7 @@ public class SparkSweepEngineTests
         await h.Records.AddAsync(NewPending(key), Ct);
 
         h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromSeconds(1));
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var record = await h.Records.GetAsync(StoreId, key, Ct);
         Assert.Equal(SweepRecordStatus.Failed, record!.Status);
@@ -1213,7 +1213,7 @@ public class SparkSweepEngineTests
     {
         // What makes retrying with the same key safe, and therefore what makes the crash-recovery design work.
         var h = CreateHarness();
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         var send = Assert.Single(h.Sdk.OnchainSendCalls);
         var balanceAfterFirst = h.Sdk.BalanceSats;
 
@@ -1235,7 +1235,7 @@ public class SparkSweepEngineTests
         await h.Records.AddAsync(NewPending(key), Ct);
 
         h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromSeconds(1));
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.InFlight, result.Kind);
         Assert.Equal(SweepRecordStatus.Pending, (await h.Records.GetAsync(StoreId, key, Ct))!.Status);
@@ -1261,12 +1261,12 @@ public class SparkSweepEngineTests
         // Inside the escalation window the shortfall blocks...
         h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromSeconds(1));
         Assert.Equal(
-            SweepOutcomeKind.InFlight, (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct)).Kind);
+            SweepOutcomeKind.InFlight, (await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct)).Kind);
         Assert.Equal(SweepRecordStatus.Pending, (await h.Records.GetAsync(StoreId, key, Ct))!.Status);
 
         // ...and past it, the row closes and sweeping is free again.
         h.Time.Advance(SparkSweepEngine.ShortfallWriteOffAge);
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var record = await h.Records.GetAsync(StoreId, key, Ct);
         Assert.Equal(SweepRecordStatus.Failed, record!.Status);
@@ -1293,7 +1293,7 @@ public class SparkSweepEngineTests
         h.Sdk.OnSync = sdk => sdk.PaymentsById[key] = CompletedExit(key, 450_000, 2_190);
 
         h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromSeconds(1));
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var record = await h.Records.GetAsync(StoreId, key, Ct);
         Assert.NotEqual(SweepRecordStatus.Failed, record!.Status);
@@ -1313,7 +1313,7 @@ public class SparkSweepEngineTests
         h.Sdk.OnSync = _ => throw new SdkException.NetworkException("@v1=offline");
 
         h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromSeconds(1));
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.InFlight, result.Kind);
         Assert.Equal(SweepRecordStatus.Pending, (await h.Records.GetAsync(StoreId, key, Ct))!.Status);
@@ -1330,7 +1330,7 @@ public class SparkSweepEngineTests
         h.Sdk.FailWith = new SdkException.NetworkException("@v1=offline");
         h.Time.Advance(SparkSweepEngine.UnresolvedGrace + TimeSpan.FromMinutes(1));
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.InFlight, result.Kind);
         Assert.Equal(SweepRecordStatus.Pending, (await h.Records.GetAsync(StoreId, key, Ct))!.Status);
@@ -1360,14 +1360,14 @@ public class SparkSweepEngineTests
             new FakeSweepTransactionLabeler(), h.Time,
             NullLogger<SparkSweepEngine>.Instance);
 
-        var first = engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var first = engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         await reached.Task;
 
         // Bounded, so that a missing guard fails this test instead of hanging the whole run: without it the second
         // pass would queue behind the first on an address source that cannot return until the second pass has
         // already returned, and the suite would simply stop.
         var second = await engine
-            .RunAsync(StoreId, SweepTrigger.Manual, Ct)
+            .RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct)
             .WaitAsync(TimeSpan.FromSeconds(10), Ct);
 
         gate.SetResult();
@@ -1386,10 +1386,10 @@ public class SparkSweepEngineTests
         h.Records.FailAddWith = new InvalidOperationException("database down");
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct));
+            () => h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct));
 
         h.Records.FailAddWith = null;
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Swept, result.Kind);
     }
@@ -1429,7 +1429,7 @@ public class SparkSweepEngineTests
             new SweepSettings { Enabled = true, MinimumSweepSats = 100_000 }, balanceSats: 20_000);
 
         var preview = await h.Engine.PreviewAsync(StoreId, Ct);
-        var run = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        var run = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.False(preview.CanSweep);
         Assert.Equal(run.Reason, preview.RefusalReason);
@@ -1467,10 +1467,10 @@ public class SparkSweepEngineTests
         // contained it, which made that assertion unfalsifiable.
         h.Settings.Settings[StoreId]!.ProtectedMnemonic = $"CA-protected-blob::{mnemonic}";
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
         await h.Engine.PreviewAsync(StoreId, Ct);
         h.Settings.Settings[StoreId]!.Sweep.Enabled = false;
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.NotEmpty(h.Logger.Lines);
         Assert.DoesNotContain("abandon", h.Logger.AllText);
@@ -1488,7 +1488,7 @@ public class SparkSweepEngineTests
             Result = SweepAddressResult.NoWallet("This store has no Bitcoin wallet.")
         });
 
-        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Contains("refusing to sweep (NoDestination) — This store has no Bitcoin wallet.", h.Logger.AllText);
     }
@@ -1505,7 +1505,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness(new SweepSettings { Enabled = true, BalanceThresholdSats = 1 });
         arrange(h);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.False(string.IsNullOrWhiteSpace(result.Reason));
@@ -1577,11 +1577,11 @@ public class SparkSweepEngineTests
         // The split matters to a merchant: one means "your balance moved", the other means "Spark is unhappy".
         var funds = CreateHarness();
         funds.Sdk.FailQuoteWith = new SdkException.SparkException("@v1=Tree service error: insufficient funds");
-        var fundsResult = await funds.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var fundsResult = await funds.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         var broken = CreateHarness();
         broken.Sdk.FailQuoteWith = new SdkException.SparkException("@v1=service provider is unhappy");
-        var brokenResult = await broken.Engine.RunAsync(StoreId, SweepTrigger.Automatic, Ct);
+        var brokenResult = await broken.Engine.RunAsync(StoreId, SweepTrigger.Automatic, cancellationToken: Ct);
 
         Assert.Contains("insufficient funds", fundsResult.Reason);
         Assert.Contains("may have been spent", fundsResult.Reason);
@@ -1598,7 +1598,7 @@ public class SparkSweepEngineTests
         h.Sdk.FailQuoteWith = new SdkException.SparkException("@v1=service provider is unhappy");
 
         var preview = await h.Engine.PreviewAsync(StoreId, Ct);
-        var run = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        var run = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.False(preview.CanSweep);
         Assert.Equal(run.Reason, preview.RefusalReason);
@@ -1610,7 +1610,7 @@ public class SparkSweepEngineTests
         var h = CreateHarness();
         h.Sdk.FailWith = new SdkException.NetworkException("@v1=offline");
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Contains("balance could not be read", result.Reason);
@@ -1639,7 +1639,7 @@ public class SparkSweepEngineTests
         // question the button press answers, and this is the button a merchant actually clicks.
         var h = CreateHarness(new SweepSettings { Enabled = false, MaxFeePercent = 0.1 });
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.FeeAboveLimit, h.Records.Single()!.RefusalCode);
@@ -1658,7 +1658,7 @@ public class SparkSweepEngineTests
             },
             balanceSats: 500);
 
-        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, Ct);
+        var result = await h.Engine.RunAsync(StoreId, SweepTrigger.Manual, cancellationToken: Ct);
 
         Assert.Equal(SweepOutcomeKind.Refused, result.Kind);
         Assert.Equal(SweepRefusalCode.BelowDustFloor, h.Records.Single()!.RefusalCode);

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSweepEngineTests.cs
@@ -5,6 +5,7 @@ using BTCPayServer.Plugins.Flint.Sdk;
 using BTCPayServer.Plugins.Flint.Services;
 using BTCPayServer.Plugins.Flint.Tests.Fakes;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Globalization;
 using Network = NBitcoin.Network;
 using Xunit;
 
@@ -313,12 +314,12 @@ public class SparkSweepEngineTests
         var record = h.Records.Single()!;
         Assert.Equal(expectedRecipientSats, record.RecipientAmountSats);
         Assert.Equal(
-            $"Sweep of {expectedRecipientSats:N0} sat accepted for a 2,190 sat fee. It confirms on-chain shortly.",
+            $"Sweep of {expectedRecipientSats.ToString("N0", CultureInfo.InvariantCulture)} sat accepted for a 2,190 sat fee. It confirms on-chain shortly.",
             result.Reason);
 
         // The sentence and the row must never disagree: they are the same fact shown in two places, and the
         // merchant has no way to tell which one is lying.
-        Assert.Contains($"{record.RecipientAmountSats:N0} sat", result.Reason);
+        Assert.Contains($"{record.RecipientAmountSats.ToString("N0", CultureInfo.InvariantCulture)} sat", result.Reason);
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSweepWebhookNotifierTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSweepWebhookNotifierTests.cs
@@ -95,4 +95,65 @@ public class SparkSweepWebhookNotifierTests
 
         Assert.Equal(0, handler.Requests);
     }
+
+    // --- NotifyFailureAsync ---
+
+    [Fact]
+    public async Task Failure_delivers_on_first_attempt()
+    {
+        var handler = StubHttpMessageHandler.Returning("ok");
+        var notifier = Notifier(handler);
+
+        await notifier.NotifyFailureAsync(
+            "https://example.com/hook", "store-1", SweepTrigger.Automatic, "Spark rejected", null);
+
+        Assert.Equal(1, handler.Requests);
+    }
+
+    [Fact]
+    public async Task Failure_includes_record_fields_when_available()
+    {
+        string? captured = null;
+        var handler = StubHttpMessageHandler.Capture(async (req, _) =>
+        {
+            captured = await req.Content!.ReadAsStringAsync();
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        });
+        var notifier = Notifier(handler);
+        var record = MinimalRecord();
+
+        await notifier.NotifyFailureAsync(
+            "https://example.com/hook", "store-1", SweepTrigger.Manual, "Spark rejected", record);
+
+        Assert.NotNull(captured);
+        Assert.Contains("sweep.failed", captured);
+        Assert.Contains(record.IdempotencyKey, captured);
+        Assert.Contains(record.DestinationAddress, captured);
+    }
+
+    [Fact]
+    public async Task Failure_retries_on_server_error_and_succeeds()
+    {
+        var handler = StubHttpMessageHandler.Sequence(
+            HttpStatusCode.ServiceUnavailable,
+            HttpStatusCode.OK);
+        var notifier = Notifier(handler);
+
+        await notifier.NotifyFailureAsync(
+            "https://example.com/hook", "store-1", SweepTrigger.Automatic, "Spark rejected", null);
+
+        Assert.Equal(2, handler.Requests);
+    }
+
+    [Fact]
+    public async Task Failure_skips_invalid_url()
+    {
+        var handler = StubHttpMessageHandler.Returning("ok");
+        var notifier = Notifier(handler);
+
+        await notifier.NotifyFailureAsync(
+            "ftp://example.com/hook", "store-1", SweepTrigger.Automatic, "Spark rejected", null);
+
+        Assert.Equal(0, handler.Requests);
+    }
 }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSweepWebhookNotifierTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSweepWebhookNotifierTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+public class SparkSweepWebhookNotifierTests
+{
+    private static readonly TimeSpan[] NoDelay = [TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero];
+
+    private static SweepRecord MinimalRecord() => new()
+    {
+        IdempotencyKey = "test-key",
+        StoreId = "store-1",
+        TxId = "abc123",
+        AmountSats = 50_000,
+        FeeSats = 1_500,
+        DestinationAddress = "bc1qtest",
+        DestinationMode = SweepDestinationMode.StoreWallet,
+        Trigger = SweepTrigger.Manual,
+        CompletedAt = DateTimeOffset.UtcNow,
+    };
+
+    private static SparkSweepWebhookNotifier Notifier(StubHttpMessageHandler handler) =>
+        new(new StubHttpClientFactory(handler), NullLogger<SparkSweepWebhookNotifier>.Instance, NoDelay);
+
+    [Fact]
+    public async Task Delivers_on_first_attempt()
+    {
+        var handler = StubHttpMessageHandler.Returning("ok");
+        var notifier = Notifier(handler);
+
+        await notifier.NotifyAsync("https://example.com/hook", "store-1", MinimalRecord());
+
+        Assert.Equal(1, handler.Requests);
+    }
+
+    [Fact]
+    public async Task Retries_on_server_error_and_succeeds()
+    {
+        // First request: 503, second: 200.
+        var handler = StubHttpMessageHandler.Sequence(
+            HttpStatusCode.ServiceUnavailable,
+            HttpStatusCode.OK);
+        var notifier = Notifier(handler);
+
+        await notifier.NotifyAsync("https://example.com/hook", "store-1", MinimalRecord());
+
+        Assert.Equal(2, handler.Requests);
+    }
+
+    [Fact]
+    public async Task Retries_on_network_error_and_succeeds()
+    {
+        var handler = StubHttpMessageHandler.FailOnceThenOK();
+        var notifier = Notifier(handler);
+
+        await notifier.NotifyAsync("https://example.com/hook", "store-1", MinimalRecord());
+
+        Assert.Equal(2, handler.Requests);
+    }
+
+    [Fact]
+    public async Task Does_not_retry_on_client_error()
+    {
+        var handler = StubHttpMessageHandler.Sequence(HttpStatusCode.NotFound);
+        var notifier = Notifier(handler);
+
+        await notifier.NotifyAsync("https://example.com/hook", "store-1", MinimalRecord());
+
+        Assert.Equal(1, handler.Requests);
+    }
+
+    [Fact]
+    public async Task Gives_up_after_max_attempts()
+    {
+        var handler = StubHttpMessageHandler.Failing(HttpStatusCode.ServiceUnavailable);
+        var notifier = Notifier(handler);
+
+        await notifier.NotifyAsync("https://example.com/hook", "store-1", MinimalRecord());
+
+        Assert.Equal(SparkSweepWebhookNotifier.MaxAttempts, handler.Requests);
+    }
+
+    [Fact]
+    public async Task Skips_invalid_url()
+    {
+        var handler = StubHttpMessageHandler.Returning("ok");
+        var notifier = Notifier(handler);
+
+        await notifier.NotifyAsync("ftp://example.com/hook", "store-1", MinimalRecord());
+
+        Assert.Equal(0, handler.Requests);
+    }
+}

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -62,7 +62,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>0.1.6.1</Version>
+    <Version>0.1.6.2</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -62,7 +62,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>0.1.7.0</Version>
+    <Version>0.1.8.0</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -48,12 +48,12 @@
 
     Product is the *display* name and nothing else. The plugin's identity is Identifier
     (Constants.PluginIdentifier, "BTCPayServer.Plugins.Flint"), which names its directory on disk and is
-    what every existing install is keyed by — renaming that would orphan them, so the two must not be
+    what every existing install is keyed by - renaming that would orphan them, so the two must not be
     conflated. Note that BaseBTCPayServerPlugin falls back to the assembly name when Product is absent:
     delete this line and the plugin silently starts calling itself "BTCPayServer.Plugins.Flint" in the
     registry. SparkBrandingTests holds both ends of that.
 
-    Version is the *single* source of truth for the plugin's version — there is deliberately no
+    Version is the *single* source of truth for the plugin's version - there is deliberately no
     version constant in Constants.cs and no hard-coded version anywhere else. (The Boltz plugin is
     the cautionary tale: three version sources that drifted apart.) The only other place the number
     appears is the newest heading in CHANGELOG.md, and PluginVersionTests asserts the two agree, so
@@ -62,7 +62,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>1.1.0</Version>
+    <Version>0.1.6.0</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -147,7 +147,7 @@
     EF PackageReference at all.
 
     Everything below exists solely to author migrations, and is opt-in via -p:EfMigrations=true so
-    that no ordinary Debug or Release build — and therefore no packaged plugin — is affected.
+    that no ordinary Debug or Release build - and therefore no packaged plugin - is affected.
   -->
   <ItemGroup Condition="'$(EfMigrations)' == 'true'">
     <!--

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -62,7 +62,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>0.1.6.0</Version>
+    <Version>0.1.6.1</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -62,7 +62,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>0.1.6.2</Version>
+    <Version>0.1.7.0</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/BTCPayServer.Plugins.Flint/Controllers/GreenfieldSparkController.cs
+++ b/BTCPayServer.Plugins.Flint/Controllers/GreenfieldSparkController.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Logging;
+using NBitcoin;
 using Newtonsoft.Json.Serialization;
 
 namespace BTCPayServer.Plugins.Flint.Controllers;
@@ -378,6 +379,32 @@ public class GreenfieldSparkController : ControllerBase
     /// are not reported as an error status.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// One sweep record, by its idempotency key.
+    /// </summary>
+    [Authorize(Policy = Policies.CanViewStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+    [HttpGet("~/api/v1/stores/{storeId}/spark/sweep/{idempotencyKey}")]
+    public async Task<IActionResult> GetSweepRecord(
+        [FromRoute] string storeId,
+        [FromRoute] string idempotencyKey,
+        CancellationToken cancellationToken)
+    {
+        if (!ResolveStore(storeId, out var store))
+            return StoreNotFound();
+
+        if (await _settingsStore.GetAsync(store.Id).ConfigureAwait(false) is null)
+            return NotConfigured();
+
+        var record = await _sweepSettings
+            .ReadRecordAsync(store.Id, idempotencyKey, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (record is null)
+            return NotFound(new { Code = "sweep-record-not-found", Message = "No sweep record with that idempotency key." });
+
+        return Ok(SparkSweepRecordData.From(record));
+    }
+
     [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
     [HttpPost("~/api/v1/stores/{storeId}/spark/sweep")]
     public async Task<IActionResult> Sweep(
@@ -400,8 +427,26 @@ public class GreenfieldSparkController : ControllerBase
             return Ok(ToModel(preview));
         }
 
+        if (request?.DestinationAddress is not null)
+        {
+            try
+            {
+                BitcoinAddress.Create(request.DestinationAddress, _sweepSettings.Network);
+            }
+            catch
+            {
+                return this.CreateAPIError(422, "invalid-destination",
+                    $"'{request.DestinationAddress}' is not a valid Bitcoin address on {_sweepSettings.Network.ChainName}.");
+            }
+        }
+
         var result = await _sweepEngine
-            .RunAsync(store.Id, SweepTrigger.Manual, cancellationToken)
+            .RunAsync(
+                store.Id,
+                SweepTrigger.Manual,
+                force: request?.Force ?? false,
+                destinationOverride: request?.DestinationAddress,
+                cancellationToken)
             .ConfigureAwait(false);
 
         return Ok(SparkSweepResultData.From(result));

--- a/BTCPayServer.Plugins.Flint/Controllers/GreenfieldSparkController.cs
+++ b/BTCPayServer.Plugins.Flint/Controllers/GreenfieldSparkController.cs
@@ -13,6 +13,7 @@ using BTCPayServer.Plugins.Flint.Data;
 using BTCPayServer.Plugins.Flint.Models;
 using BTCPayServer.Plugins.Flint.Sdk;
 using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
@@ -90,6 +91,7 @@ public class GreenfieldSparkController : ControllerBase
     private readonly SparkDepositService _deposits;
     private readonly SparkStableBalanceService _stableBalance;
     private readonly ILogger<GreenfieldSparkController> _logger;
+    private readonly SettingsRepository _serverSettingsRepository;
 
     public GreenfieldSparkController(
         ISparkStoreSettingsStore settingsStore,
@@ -101,7 +103,8 @@ public class GreenfieldSparkController : ControllerBase
         ISparkStoreRuntime runtime,
         SparkDepositService deposits,
         SparkStableBalanceService stableBalance,
-        ILogger<GreenfieldSparkController> logger)
+        ILogger<GreenfieldSparkController> logger,
+        SettingsRepository serverSettingsRepository)
     {
         _settingsStore = settingsStore;
         _provisioner = provisioner;
@@ -113,6 +116,7 @@ public class GreenfieldSparkController : ControllerBase
         _deposits = deposits;
         _stableBalance = stableBalance;
         _logger = logger;
+        _serverSettingsRepository = serverSettingsRepository;
     }
 
     #region Status
@@ -697,6 +701,52 @@ public class GreenfieldSparkController : ControllerBase
             BalanceSats = info.BalanceSats,
             SyncedAt = DateTimeOffset.UtcNow
         });
+    }
+
+    #endregion
+
+    #region Server settings
+
+    /// <summary>Flint server-level settings (shared across all stores).</summary>
+    [Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+    [HttpGet("~/api/v1/server/spark")]
+    public async Task<IActionResult> GetServerSettings(CancellationToken cancellationToken)
+    {
+        var settings = await _serverSettingsRepository
+            .GetSettingAsync<SparkServerSettings>()
+            .ConfigureAwait(false) ?? new SparkServerSettings();
+
+        return Ok(new SparkServerSettingsData { UpdateWebhookUrl = settings.UpdateWebhookUrl });
+    }
+
+    /// <summary>Update Flint server-level settings.</summary>
+    [Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+    [HttpPut("~/api/v1/server/spark")]
+    public async Task<IActionResult> UpdateServerSettings(
+        [FromBody] SparkServerSettingsRequest? request,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(request?.UpdateWebhookUrl))
+        {
+            if (!Uri.TryCreate(request.UpdateWebhookUrl, UriKind.Absolute, out var uri)
+                || uri.Scheme is not ("http" or "https"))
+            {
+                return this.CreateAPIError(422, "invalid-update-webhook-url",
+                    $"'{request.UpdateWebhookUrl}' is not a valid http/https URL.");
+            }
+        }
+
+        var settings = await _serverSettingsRepository
+            .GetSettingAsync<SparkServerSettings>()
+            .ConfigureAwait(false) ?? new SparkServerSettings();
+
+        settings.UpdateWebhookUrl = string.IsNullOrWhiteSpace(request?.UpdateWebhookUrl)
+            ? null
+            : request.UpdateWebhookUrl;
+
+        await _serverSettingsRepository.UpdateSetting(settings).ConfigureAwait(false);
+
+        return Ok(new SparkServerSettingsData { UpdateWebhookUrl = settings.UpdateWebhookUrl });
     }
 
     #endregion

--- a/BTCPayServer.Plugins.Flint/Controllers/GreenfieldSparkController.cs
+++ b/BTCPayServer.Plugins.Flint/Controllers/GreenfieldSparkController.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Abstractions.Constants;
+using BTCPayServer.Plugins.Flint;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Client;
 using BTCPayServer.Data;
@@ -83,6 +85,7 @@ public class GreenfieldSparkController : ControllerBase
     private readonly SparkStoreStatusReader _statusReader;
     private readonly SparkSweepSettingsService _sweepSettings;
     private readonly SparkSweepEngine _sweepEngine;
+    private readonly ISparkStoreRuntime _runtime;
     private readonly SparkDepositService _deposits;
     private readonly SparkStableBalanceService _stableBalance;
     private readonly ILogger<GreenfieldSparkController> _logger;
@@ -94,6 +97,7 @@ public class GreenfieldSparkController : ControllerBase
         SparkStoreStatusReader statusReader,
         SparkSweepSettingsService sweepSettings,
         SparkSweepEngine sweepEngine,
+        ISparkStoreRuntime runtime,
         SparkDepositService deposits,
         SparkStableBalanceService stableBalance,
         ILogger<GreenfieldSparkController> logger)
@@ -104,6 +108,7 @@ public class GreenfieldSparkController : ControllerBase
         _statusReader = statusReader;
         _sweepSettings = sweepSettings;
         _sweepEngine = sweepEngine;
+        _runtime = runtime;
         _deposits = deposits;
         _stableBalance = stableBalance;
         _logger = logger;
@@ -606,6 +611,51 @@ public class GreenfieldSparkController : ControllerBase
 
     #endregion
 
+    #region Balance sync
+
+    /// <summary>
+    /// Forces a wallet sync and returns the current Spark balance.
+    /// </summary>
+    /// <remarks>
+    /// The balance reported by other endpoints is read from the SDK cache without forcing a sync and may lag
+    /// settlement by up to 20 seconds. This endpoint forces an explicit sync before reading, so the returned
+    /// value is current at call time. It does not trigger or preview a sweep.
+    /// </remarks>
+    [Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Greenfield)]
+    [HttpPost("~/api/v1/stores/{storeId}/spark/sync")]
+    public async Task<IActionResult> SyncBalance([FromRoute] string storeId, CancellationToken cancellationToken)
+    {
+        if (!ResolveStore(storeId, out var store))
+            return StoreNotFound();
+
+        if (await _settingsStore.GetAsync(store.Id).ConfigureAwait(false) is null)
+            return NotConfigured();
+
+        var sdk = await _runtime.GetSdkClientAsync(store.Id).ConfigureAwait(false);
+
+        if (sdk is null)
+        {
+            return Ok(new SparkBalanceSyncData
+            {
+                WalletRunning = false,
+                BalanceSats = 0,
+                SyncedAt = DateTimeOffset.UtcNow
+            });
+        }
+
+        await sdk.SyncWalletAsync(cancellationToken).ConfigureAwait(false);
+        var info = await sdk.GetInfoAsync(ensureSynced: true, cancellationToken).ConfigureAwait(false);
+
+        return Ok(new SparkBalanceSyncData
+        {
+            WalletRunning = true,
+            BalanceSats = info.BalanceSats,
+            SyncedAt = DateTimeOffset.UtcNow
+        });
+    }
+
+    #endregion
+
     #region Mapping
 
     private SparkStatusData ToModel(SparkStoreStatus status) => new()
@@ -622,19 +672,40 @@ public class GreenfieldSparkController : ControllerBase
         StorageDirectory = status.StorageDirectoryFor(User)
     };
 
-    private SparkSweepConfigurationData ToModel(SparkSweepSettingsView view, SparkSweepHistoryPage history) => new()
+    private SparkSweepConfigurationData ToModel(SparkSweepSettingsView view, SparkSweepHistoryPage history)
     {
-        Settings = view.Settings,
-        WalletRunning = view.WalletRunning,
-        BalanceSats = view.BalanceSats,
-        StoreWalletStatus = view.StoreWalletStatus,
-        StoreWalletReason = view.StoreWalletReason,
-        Network = _sweepSettings.Network.ChainName.ToString(),
-        Total = history.Total,
-        Skip = history.Skip,
-        Count = history.Count,
-        History = history.Records.Select(SparkSweepRecordData.From).ToList()
-    };
+        var warnings = new List<string>();
+        var networkName = _sweepSettings.Network.ChainName.ToString();
+        if (networkName == "Mainnet")
+        {
+            var threshold = view.Settings.BalanceThresholdSats;
+            var minSweep = view.Settings.MinimumSweepSats;
+            if (threshold < SweepSettings.DefaultBalanceThresholdSats)
+                warnings.Add(
+                    $"Balance threshold ({threshold:N0} sats) is below the " +
+                    $"{SweepSettings.DefaultBalanceThresholdSats:N0}-sat recommended minimum; " +
+                    "mainnet exit fees will represent a higher share of the swept amount.");
+            if (minSweep < SweepSettings.DefaultMinimumSweepSats)
+                warnings.Add(
+                    $"Minimum sweep amount ({minSweep:N0} sats) is below the " +
+                    $"{SweepSettings.DefaultMinimumSweepSats:N0}-sat recommended floor; " +
+                    "fee defaults were measured on regtest and are higher on mainnet.");
+        }
+        return new SparkSweepConfigurationData
+        {
+            Settings = view.Settings,
+            WalletRunning = view.WalletRunning,
+            BalanceSats = view.BalanceSats,
+            StoreWalletStatus = view.StoreWalletStatus,
+            StoreWalletReason = view.StoreWalletReason,
+            Network = networkName,
+            Total = history.Total,
+            Skip = history.Skip,
+            Count = history.Count,
+            History = history.Records.Select(SparkSweepRecordData.From).ToList(),
+            Warnings = warnings
+        };
+    }
 
     private static SparkSweepPreviewData ToModel(SweepPreview preview) => new()
     {

--- a/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
+++ b/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
@@ -538,7 +538,7 @@ public class SparkController : Controller
             return await RedirectToSetupOrDeny(storeId).ConfigureAwait(false);
 
         var result = await _sweepEngine
-            .RunAsync(storeId, SweepTrigger.Manual, cancellationToken)
+            .RunAsync(storeId, SweepTrigger.Manual, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         TempData[result.Succeeded ? WellKnownTempData.SuccessMessage : WellKnownTempData.ErrorMessage] =

--- a/BTCPayServer.Plugins.Flint/Models/SparkApiModels.cs
+++ b/BTCPayServer.Plugins.Flint/Models/SparkApiModels.cs
@@ -210,6 +210,30 @@ public class SparkSweepConfigurationData
 
     /// <summary>The requested page of sweep history, newest first.</summary>
     public IReadOnlyList<SparkSweepRecordData> History { get; set; } = [];
+
+    /// <summary>
+    /// Advisory warnings about the current sweep configuration.
+    /// Empty when there is nothing worth flagging. On mainnet, low thresholds or fee ceilings
+    /// produce entries here; the defaults were measured on regtest and may need adjustment.
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; set; } = [];
+}
+
+/// <summary>
+/// Response to <c>POST /api/v1/stores/{storeId}/spark/sync</c>: the balance after a forced wallet sync.
+/// </summary>
+public class SparkBalanceSyncData
+{
+    /// <summary>
+    /// Spark balance in satoshi after forcing a wallet sync. Zero when the wallet is not running.
+    /// </summary>
+    public long BalanceSats { get; set; }
+
+    /// <summary>Whether a Spark wallet is live for this store.</summary>
+    public bool WalletRunning { get; set; }
+
+    /// <summary>When the sync was performed, UTC.</summary>
+    public DateTimeOffset SyncedAt { get; set; }
 }
 
 /// <summary>

--- a/BTCPayServer.Plugins.Flint/Models/SparkApiModels.cs
+++ b/BTCPayServer.Plugins.Flint/Models/SparkApiModels.cs
@@ -922,3 +922,27 @@ public sealed record SparkCrossChainQuoteData(
         quote.ExpiresAt,
         quote.ProviderQuoteId);
 }
+
+#region Server settings
+
+/// <summary>Flint server-level settings, shared across all stores on this BTCPay instance.</summary>
+public class SparkServerSettingsData
+{
+    /// <summary>
+    /// When set, Flint POSTs a <c>plugin.update-available</c> event here whenever a newer version is
+    /// detected on the plugin registry. The check runs once per day.
+    /// </summary>
+    public string? UpdateWebhookUrl { get; set; }
+}
+
+/// <summary>Request body for <c>PUT /api/v1/server/spark</c>.</summary>
+public class SparkServerSettingsRequest
+{
+    /// <summary>
+    /// The URL to call when a plugin update is available, or null/empty to disable the notification.
+    /// Must be a valid http or https URL when non-empty.
+    /// </summary>
+    public string? UpdateWebhookUrl { get; set; }
+}
+
+#endregion

--- a/BTCPayServer.Plugins.Flint/Models/SparkApiModels.cs
+++ b/BTCPayServer.Plugins.Flint/Models/SparkApiModels.cs
@@ -459,6 +459,20 @@ public class SparkSweepRequest
     /// re-checks the fee ceiling against the number it actually commits to.
     /// </remarks>
     public bool Preview { get; set; }
+
+    /// <summary>
+    /// When true, sweeps whatever is above the reserve even if it is below the configured minimum sweep amount.
+    /// The absolute protocol minimum (<c>Constants.MinimumOnchainSendSats</c>) is still enforced.
+    /// Ignored when <see cref="Preview"/> is true.
+    /// </summary>
+    public bool Force { get; set; }
+
+    /// <summary>
+    /// A Bitcoin address to sweep to instead of the store's configured destination.
+    /// Validated against the current network. Ignored when <see cref="Preview"/> is true.
+    /// Not compatible with stores configured for EVM cross-chain sweeps.
+    /// </summary>
+    public string? DestinationAddress { get; set; }
 }
 
 /// <summary>

--- a/BTCPayServer.Plugins.Flint/Models/SparkSweepViewModel.cs
+++ b/BTCPayServer.Plugins.Flint/Models/SparkSweepViewModel.cs
@@ -83,6 +83,9 @@ public class SweepSettingsInput
     public long CrossChainMinimumStableUnits { get; set; } =
         SweepSettings.DefaultCrossChainMinimumStableUnits;
 
+    [Display(Name = "Sweep webhook URL (optional)")]
+    public string? SweepWebhookUrl { get; set; }
+
     public static SweepSettingsInput From(SweepSettings settings) => new()
     {
         EvmAddress = settings.EvmAddress,
@@ -101,7 +104,8 @@ public class SweepSettingsInput
         MaxFeeFlatSats = settings.MaxFeeFlatSats,
         DrainWhenSweeping = settings.DrainWhenSweeping,
         DestinationMode = settings.DestinationMode,
-        StaticAddress = settings.StaticAddress
+        StaticAddress = settings.StaticAddress,
+        SweepWebhookUrl = settings.SweepWebhookUrl
     };
 
     /// <summary>
@@ -138,6 +142,7 @@ public class SweepSettingsInput
         settings.EvmAsset = crossChain ? EvmAsset?.Trim() : null;
         settings.CrossChainSlippageBps = crossChain ? CrossChainSlippageBps : null;
         settings.CrossChainMinimumStableUnits = CrossChainMinimumStableUnits;
+        settings.SweepWebhookUrl = string.IsNullOrWhiteSpace(SweepWebhookUrl) ? null : SweepWebhookUrl.Trim();
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint/Resources/swagger.json
+++ b/BTCPayServer.Plugins.Flint/Resources/swagger.json
@@ -508,6 +508,47 @@
                     }
                 ]
             }
+        },
+        "/api/v1/stores/{storeId}/spark/sync": {
+            "post": {
+                "tags": [
+                    "Spark"
+                ],
+                "summary": "Force a wallet sync and return the current balance",
+                "description": "The status endpoint caches balance for up to 20 seconds. `POST /spark/sync` forces an explicit sync before reading — use it when you need the current balance immediately rather than a cached value. `walletRunning: false` means no Spark wallet is live for this store; `balanceSats` will be 0 in that case.",
+                "operationId": "Spark_SyncBalance",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/StoreId"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The balance after a forced wallet sync",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SparkBalanceSyncData"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "If you are authenticated but forbidden to modify the specified store"
+                    },
+                    "404": {
+                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store"
+                    }
+                },
+                "security": [
+                    {
+                        "API_Key": [
+                            "btcpay.store.canmodifystoresettings"
+                        ],
+                        "Basic": []
+                    }
+                ]
+            }
         }
     },
     "components": {
@@ -700,6 +741,11 @@
                         "type": "integer",
                         "format": "int64",
                         "description": "Smallest cross-chain sweep to make from a stablecoin balance, in **whole units** of that token — 20 means twenty dollars. Used only when Stable Balance is on, because only then is the amount not in satoshi."
+                    },
+                    "sweepWebhookUrl": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Optional HTTP(S) URL that receives a POST after each successful sweep. The payload includes `storeId`, `idempotencyKey`, `txId`, `amountSats`, `feeSats`, `destination`, `destinationMode`, `trigger`, and `completedAt`. Delivery failures are logged and never retried."
                     }
                 }
             },
@@ -752,6 +798,13 @@
                         "description": "The requested page of sweep history, newest first.",
                         "items": {
                             "$ref": "#/components/schemas/SparkSweepRecordData"
+                        }
+                    },
+                    "warnings": {
+                        "type": "array",
+                        "description": "Advisory warnings about the current sweep configuration. On mainnet, entries appear when the balance threshold or minimum sweep amount are below the recommended defaults (which were measured on regtest).",
+                        "items": {
+                            "type": "string"
                         }
                     }
                 }
@@ -1542,6 +1595,27 @@
                     "BitcoinAddress",
                     "EvmAddress"
                 ]
+            },
+            "SparkBalanceSyncData": {
+                "type": "object",
+                "additionalProperties": false,
+                "description": "The Spark balance after a forced wallet sync.",
+                "properties": {
+                    "walletRunning": {
+                        "type": "boolean",
+                        "description": "Whether a Spark wallet is live for this store."
+                    },
+                    "balanceSats": {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "Spark balance in satoshi after forcing a wallet sync. Zero when the wallet is not running."
+                    },
+                    "syncedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "When the sync was performed, UTC."
+                    }
+                }
             }
         }
     }

--- a/BTCPayServer.Plugins.Flint/Resources/swagger.json
+++ b/BTCPayServer.Plugins.Flint/Resources/swagger.json
@@ -599,6 +599,83 @@
           }
         ]
       }
+    },
+    "/api/v1/server/spark": {
+      "get": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Get Flint server-level settings",
+        "description": "Returns the server-level Flint configuration shared across all stores on this BTCPay instance. Currently contains the `updateWebhookUrl` for plugin update notifications.",
+        "operationId": "Spark_GetServerSettings",
+        "responses": {
+          "200": {
+            "description": "The server-level Flint settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkServerSettingsData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to modify server settings"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.server.canmodifyserversettings"
+            ],
+            "Basic": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Update Flint server-level settings",
+        "description": "Replaces the server-level Flint configuration. Set `updateWebhookUrl` to an http/https URL to receive a `plugin.update-available` notification when a new Flint version is detected on the plugin registry (checked once per day). Clear it by sending `null` or an empty string.",
+        "operationId": "Spark_UpdateServerSettings",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SparkServerSettingsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The stored server-level settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkServerSettingsData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to modify server settings"
+          },
+          "422": {
+            "description": "The update webhook URL is not a valid http/https URL"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.server.canmodifyserversettings"
+            ],
+            "Basic": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -1674,6 +1751,30 @@
             "type": "string",
             "format": "date-time",
             "description": "When the sync was performed, UTC."
+          }
+        }
+      },
+      "SparkServerSettingsData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Flint server-level settings, shared across all stores on this BTCPay instance.",
+        "properties": {
+          "updateWebhookUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "When set, Flint POSTs a plugin.update-available event here whenever a newer version is detected on the plugin registry. The check runs once per day."
+          }
+        }
+      },
+      "SparkServerSettingsRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Request body for PUT /api/v1/server/spark.",
+        "properties": {
+          "updateWebhookUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "The URL to call when a plugin update is available, or null/empty to disable the notification. Must be a valid http or https URL when non-empty."
           }
         }
       }

--- a/BTCPayServer.Plugins.Flint/Resources/swagger.json
+++ b/BTCPayServer.Plugins.Flint/Resources/swagger.json
@@ -1,1622 +1,1682 @@
 {
-    "tags": [
-        {
-            "name": "Spark",
-            "description": "Nodeless Lightning for a store, powered by the Breez Spark SDK: set the store's Spark wallet up, read its state, configure automatic on-chain sweeps, and sweep now. Every sweep is a cooperative exit through the Spark service provider; the plugin has no unilateral-exit path."
-        }
-    ],
-    "paths": {
-        "/api/v1/stores/{storeId}/spark": {
-            "get": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Get the store's Spark status",
-                "description": "Whether the store has Spark configured, whether its wallet is running, its indicative balance, its Spark identity, the Spark network's published status, where its seed came from, and what its Lightning payment method currently points at. Answers 200 with `configured: false` for a store that has never set Spark up — that is a state, not an error.",
-                "operationId": "Spark_GetStatus",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The store's Spark status",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SparkStatusData"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to view the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, or the request named a store it was not authorised for"
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canviewstoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            },
-            "post": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Set the store's Spark wallet up",
-                "description": "Configures the store's Spark wallet from a chosen seed source, confirms the wallet is running, and then points the store's Lightning payment method at it. Calling this on a store that already has Spark configured replaces its seed, carrying over its sweep configuration.\n\n**A generated recovery phrase is returned exactly once, in this response, and never again.** There is no endpoint that reads a seed back. Persist it before doing anything else.\n\nAll three seed sources are gated on the server's hot-wallet policy (`AllowHotWalletForAll`, or being a server administrator) — including reusing the store's existing on-chain seed, because that copies key material into a second wallet.\n\nThe seed is stored encrypted on this server, and whoever operates the server can decrypt it and spend the store's Lightning funds. Provisioning a store here places those funds in the server operator's custody; a tenant who does not operate the server should not put a seed here.",
-                "operationId": "Spark_Provision",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SparkProvisionRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "The store is configured. `mnemonic` is set only when `seedSource` was `generate`.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SparkProvisionResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden to modify the specified store, or a server administrator has not allowed non-admins to create hot wallets on this server (`hot-wallet-not-allowed`)",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ProblemDetails"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "The store was not found, or the request named a store it was not authorised for"
-                    },
-                    "422": {
-                        "description": "The seed source was not recognised, the recovery phrase was not usable, or the wallet could not be started — in which case nothing was left behind",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canmodifystoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            },
-            "delete": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Remove the store's Spark wallet",
-                "description": "Destroys this server's copy of the store's Spark keys and clears the store's Lightning payment-method configuration — but only when that configuration still points at this store's Spark wallet. Another Lightning node's connection string is left untouched.\n\nThe SDK storage directory is kept. After this call the merchant's recovery phrase is the only way to reach any remaining funds.",
-                "operationId": "Spark_Remove",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The store's Spark configuration was removed"
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to modify the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store (`spark-not-configured`)"
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canmodifystoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            }
-        },
-        "/api/v1/stores/{storeId}/spark/sweep": {
-            "get": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Get the store's sweep configuration and history",
-                "description": "The automatic-sweep configuration in force, plus a page of sweep records newest first. The history includes sweeps that did not happen: a `Refused` record carries the stable `refusalCode`, the sentence a merchant would read, and an `attemptCount` — a recurring automatic refusal is folded onto one row per cause per day rather than filed once per pass.",
-                "operationId": "Spark_GetSweepConfiguration",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    },
-                    {
-                        "name": "skip",
-                        "in": "query",
-                        "required": false,
-                        "description": "How many records to skip. Negative values are clamped to zero.",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32",
-                            "default": 0
-                        }
-                    },
-                    {
-                        "name": "count",
-                        "in": "query",
-                        "required": false,
-                        "description": "How many records to return. Clamped to 1..100.",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32",
-                            "default": 25
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The store's sweep configuration and history",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SparkSweepConfigurationData"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to view the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store (`spark-not-configured`)"
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canviewstoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            },
-            "put": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Replace the store's sweep configuration",
-                "description": "A full replacement: a field the body omits takes its default rather than keeping its current value. Read the configuration first and send it back modified.\n\nValidated by exactly the rules the settings page is validated by. **No configuration accepted here switches the fee guard off** — clearing `maxFeePercent` without setting `maxFeeFlatSats` is refused, a `maxFeeFlatSats` above `minimumSweepSats` is refused, and whatever is stored, the engine applies a hard backstop no configuration can lift at the moment money would move.",
-                "operationId": "Spark_UpdateSweepConfiguration",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SparkSweepSettings"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "The configuration now in force, re-read from storage",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SparkSweepConfigurationData"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to modify the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store (`spark-not-configured`)"
-                    },
-                    "422": {
-                        "description": "The configuration was refused and nothing was written",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/ValidationProblemDetails"
-                                }
-                            }
-                        }
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canmodifystoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            },
-            "post": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Sweep the store's Spark balance on-chain now, or quote a sweep",
-                "description": "Runs the same engine method the periodic task runs, with the trigger set to manual. A manual trigger relaxes only the automatic-sweep switch and the balance threshold; every safety and economic guard — the minimum sweep, the fee ceiling, the dust floor, the destination rules, the single-flight lock, and the refusal to send while an earlier sweep's fate is unknown — applies identically. The sweep is recorded with its idempotency key before the send.\n\nWith `preview: true` nothing is sent, no address is reserved from the store's wallet, and no record is written; the response is a live quote that expires in about a minute.\n\n**Always a cooperative exit.** No parameter selects a unilateral exit.\n\n**A 200 means the engine reached a decision, not that money moved.** Read `outcome`: only `Swept` means a cooperative exit was accepted. `Refused`, `Skipped` and `InFlight` are routine steady states of an engine designed to decline, so they are not reported as an error status — a store whose fee ceiling sits below the current exit fee stays on `Refused` indefinitely and nothing is wrong.",
-                "operationId": "Spark_Sweep",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "requestBody": {
-                    "required": false,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SparkSweepRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "The engine's decision — a `SparkSweepResultData` for a real sweep, a `SparkSweepPreviewData` when `preview` was true",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "oneOf": [
-                                        {
-                                            "$ref": "#/components/schemas/SparkSweepResultData"
-                                        },
-                                        {
-                                            "$ref": "#/components/schemas/SparkSweepPreviewData"
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to modify the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store (`spark-not-configured`)"
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canmodifystoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            }
-        },
-        "/api/v1/stores/{storeId}/spark/deposit": {
-            "get": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Get the store's on-chain deposit address and unclaimed deposits",
-                "description": "The static Bitcoin address that tops the store's Spark wallet up, plus anything sent to it that has not been credited. The address is stable across calls and safe to save; it is also the string to render as a QR code, since the plugin returns no image.\n\nFunds credit after **three confirmations**, and only then does Spark attempt the claim — budget half an hour or more, not seconds.\n\n**Read `deposits`, not only `address`.** A claim is capped by a fee ceiling, and a deposit needing more than the ceiling allows is *not* retried at a lower price: it sits unclaimed indefinitely and appears nowhere else. An entry with `isMature: false` is merely waiting for confirmations and needs nobody; one with `needsAttention: true` is stuck and needs the claim endpoint. Spark's own default ceiling of 1 sat/vB is below the mainnet floor essentially always, which is why the plugin overrides it with a rate that tracks the mempool.",
-                "operationId": "Spark_GetDeposits",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The deposit address and unclaimed deposits",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SparkDepositData"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to view the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for it"
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canviewstoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            }
-        },
-        "/api/v1/stores/{storeId}/spark/deposit/claim": {
-            "post": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Claim an on-chain deposit Spark could not claim itself",
-                "description": "Claims one matured deposit whose automatic claim was refused on fee grounds.\n\nOmit `maxFeeSats` for the ordinary case: Spark reports the fee the claim actually needs on the very error that stranded the deposit, and that is what will be used.\n\n**Guarded beyond the store's configured ceiling.** Whatever `maxManualClaimFeeSats` says, the plugin refuses to spend more than half a deposit on claiming it — a rate-based cap knows nothing about the size of the deposit it is paid out of, and this is the only place the two are compared.\n\n**A 200 means the plugin reached a decision, not that a claim was broadcast.** Read `status`: only `Claimed` did anything. A refusal spends nothing and leaves the deposit claimable.",
-                "operationId": "Spark_ClaimDeposit",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "requestBody": {
-                    "required": false,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/SparkClaimDepositRequest"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "The plugin's decision",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SparkClaimDepositResponse"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to modify the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for it"
-                    },
-                    "422": {
-                        "description": "The request did not name a deposit"
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canmodifystoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            }
-        },
-        "/api/v1/stores/{storeId}/spark/stable-balance": {
-            "get": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Get the store's Stable Balance configuration and state",
-                "description": "`desiredActive` is what the store asked for; `activeLabel` is what its wallet reports. **The two can legitimately disagree** — Spark caches the active label per wallet, so a store whose recovery phrase was replaced starts deactivated whatever its setting says. The plugin reports the disagreement rather than reconciling it, because converging them converts the merchant's balance. `needsReapply` says when they differ; `PUT` converges them.\n\n`balance.isFreezable` is **true for USDB**: the issuer can freeze it. That is a real counterparty on top of Spark's own operators.\n\nMainnet only; `available` is false everywhere else.",
-                "operationId": "Spark_GetStableBalance",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The store's Stable Balance state",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SparkStableBalanceData"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to view the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for it"
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canviewstoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            },
-            "put": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Replace the store's Stable Balance configuration",
-                "description": "**This moves money.** Enabling queues a conversion of the store's Bitcoin balance into the configured stablecoin; disabling queues the reverse. Both run on Spark's own background worker, both take a spread, and **no SDK event reports either one** — the only way to observe the result is to read this resource again later.\n\nA full replacement, as `PUT` implies: an omitted field takes its default, it does not keep its current value. A `null` or `{}` body therefore means off.\n\n`disclosureAcknowledged` must be true to enable. Holding a store's balance in USDB adds a regulated issuer who can freeze it; the API enforces the same acknowledgement the settings page does, because a disclosure one surface skips is a disclosure with a documented bypass.\n\nMainnet only. Elsewhere this is refused rather than stored, because Spark would accept the configuration and then silently never convert anything.\n\nThe token identifier is checked against Spark before it is stored.",
-                "operationId": "Spark_UpdateStableBalance",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "requestBody": {
-                    "required": false,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/StableBalanceInput"
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "The stored configuration and the wallet's state",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SparkStableBalanceData"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to modify the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for it"
-                    },
-                    "422": {
-                        "description": "The configuration was refused, or Spark would not apply it"
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canmodifystoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            }
-        },
-        "/api/v1/stores/{storeId}/spark/sync": {
-            "post": {
-                "tags": [
-                    "Spark"
-                ],
-                "summary": "Force a wallet sync and return the current balance",
-                "description": "The status endpoint caches balance for up to 20 seconds. `POST /spark/sync` forces an explicit sync before reading — use it when you need the current balance immediately rather than a cached value. `walletRunning: false` means no Spark wallet is live for this store; `balanceSats` will be 0 in that case.",
-                "operationId": "Spark_SyncBalance",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/StoreId"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The balance after a forced wallet sync",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/SparkBalanceSyncData"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "If you are authenticated but forbidden to modify the specified store"
-                    },
-                    "404": {
-                        "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store"
-                    }
-                },
-                "security": [
-                    {
-                        "API_Key": [
-                            "btcpay.store.canmodifystoresettings"
-                        ],
-                        "Basic": []
-                    }
-                ]
-            }
-        }
-    },
-    "components": {
-        "schemas": {
-            "SparkStatusData": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "configured": {
-                        "type": "boolean",
-                        "description": "False when this store has never set Spark up. Everything below is then meaningless."
-                    },
-                    "seedSource": {
-                        "$ref": "#/components/schemas/SparkSeedSource"
-                    },
-                    "walletRunning": {
-                        "type": "boolean",
-                        "description": "Whether a Spark wallet is live for this store right now. False while `configured` is true means the store looks set up and takes no payments — a seed the server can no longer decrypt, a second store on the same wallet, or an unsupported chain."
-                    },
-                    "identityPubkey": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The wallet's Spark identity public key, or null when it is not running or has not synced. Public by design — it does publicly link this wallet to anything else sharing its seed."
-                    },
-                    "balanceSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "Spark balance in satoshi. **Indicative only**: read from the SDK's cache without forcing a sync, it lags settlement by around 20 seconds and drifts by a few sats around the SDK's background leaf optimisation. Never reconcile against it and never derive an accounting figure from it."
-                    },
-                    "walletError": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Set when the wallet is running but could not be read."
-                    },
-                    "networkStatus": {
-                        "nullable": true,
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/SparkNetworkStatusData"
-                            }
-                        ]
-                    },
-                    "lightningWiring": {
-                        "$ref": "#/components/schemas/SparkLightningWiringState"
-                    },
-                    "lightningEnabledForCheckout": {
-                        "type": "boolean",
-                        "description": "False when a Lightning payment method exists but is excluded from checkout."
-                    },
-                    "storageDirectory": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Absolute path of this store's SDK storage directory on the server. Null unless the caller is a server administrator: it describes the host's filesystem rather than the store, and every role that can view store settings can reach this endpoint."
-                    }
-                }
-            },
-            "SparkNetworkStatusData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "Spark's own published service status. Read without a wallet; null in a response means it could not be read.",
-                "properties": {
-                    "status": {
-                        "type": "string",
-                        "description": "`Operational`, `Degraded`, `Partial`, `Major` or `Unknown`.",
-                        "example": "Operational"
-                    },
-                    "lastUpdated": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "When the Spark operators last published that status."
-                    },
-                    "isOperational": {
-                        "type": "boolean",
-                        "description": "True only for an explicitly operational network. `Unknown` is not treated as healthy."
-                    }
-                }
-            },
-            "SparkProvisionRequest": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "seedSource": {
-                        "type": "string",
-                        "description": "Where the seed comes from. `generate` mints a new phrase and returns it once in the response. `import` uses the phrase in `mnemonic`. `hotWallet` reuses the store's on-chain BTCPay wallet seed, which requires that wallet to be a hot wallet with a stored recovery phrase.",
-                        "enum": [
-                            "generate",
-                            "import",
-                            "hotWallet"
-                        ]
-                    },
-                    "mnemonic": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The BIP39 recovery phrase, for `import` only. Never echoed back — not in a success response, not in a validation error, not in a log line."
-                    }
-                }
-            },
-            "SparkProvisionResponse": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "mnemonic": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The generated recovery phrase — **returned exactly once, here, and never again**. Set only when the request asked for `generate`; null for `import` (you already hold it) and for `hotWallet` (it is the store's on-chain seed, which this API will not hand out). There is no endpoint that reads a seed back, so if this value is not persisted now the store's funds depend entirely on the server's data directory surviving. Do not log it."
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/SparkStatusData"
-                    }
-                }
-            },
-            "SparkSweepSettings": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "A store's automatic-sweep configuration. Off until a merchant or an API caller opts in.",
-                "properties": {
-                    "enabled": {
-                        "type": "boolean",
-                        "description": "Whether the periodic task may sweep this store. A manual sweep works either way."
-                    },
-                    "balanceThresholdSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Balance at which an automatic sweep is considered. Defaults to 200,000 sat, which makes a default-configured sweep cost roughly 1% in exit fees at regtest fee levels.",
-                        "default": 200000
-                    },
-                    "reserveSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Amount left on Spark after a sweep, to keep receiving cheaply. With `drainWhenSweeping` false the exit fee is charged on top of the swept amount, so the reserve is also what pays it — a reserve smaller than the fee is refused rather than allowed to overdraw.",
-                        "default": 0
-                    },
-                    "minimumSweepSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Smallest amount worth sweeping. A cooperative exit costs a flat fee independent of the amount, so this is the guard against paying 40% of a small balance to move it. Cannot be below the 294 sat on-chain minimum.",
-                        "default": 100000
-                    },
-                    "confirmationSpeed": {
-                        "$ref": "#/components/schemas/SparkSweepConfirmationSpeed"
-                    },
-                    "maxFeePercent": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "Ceiling on the exit fee as a percentage of the amount delivered, 0 to 100. Zero disables the percentage guard, in which case `maxFeeFlatSats` must be set — there is no configuration with no fee ceiling at all.",
-                        "default": 3.0
-                    },
-                    "maxFeeFlatSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "Optional absolute ceiling on the exit fee. When both guards are set the stricter one wins. Must not exceed `minimumSweepSats`, otherwise it would permit a sweep costing more than it delivers."
-                    },
-                    "drainWhenSweeping": {
-                        "type": "boolean",
-                        "description": "Take the exit fee out of the swept amount rather than charging it on top. **This is a cooperative exit either way** — it selects the SDK's `FeesIncluded` fee policy and has nothing to do with a unilateral exit, which this plugin does not implement.",
-                        "default": true
-                    },
-                    "destinationMode": {
-                        "$ref": "#/components/schemas/SparkSweepDestinationMode"
-                    },
-                    "staticAddress": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The fixed Bitcoin address used in `StaticAddress` mode, validated against this server's chain on save and again before every send. Cleared when the mode is `StoreWallet`."
-                    },
-                    "evmAddress": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The EVM address a cross-chain sweep delivers to. **An address carries no chain** — Spark's own parser returns no chain id for a bare one — so `evmChain` is a separate choice and getting it wrong sends funds somewhere unreachable."
-                    },
-                    "evmChain": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Destination chain, e.g. `arbitrum`. Checked against the live route table before every sweep."
-                    },
-                    "evmAsset": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Destination asset, e.g. `USDT`. Matched **exactly**: `USDT0` is a different asset and will not be substituted."
-                    },
-                    "crossChainSlippageBps": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "Cross-chain slippage in basis points, 10–500. Null uses 50. A *different* setting from the Stable Balance conversion slippage; Spark's own fallback here is 100, which is ten times looser."
-                    },
-                    "crossChainMinimumStableUnits": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Smallest cross-chain sweep to make from a stablecoin balance, in **whole units** of that token — 20 means twenty dollars. Used only when Stable Balance is on, because only then is the amount not in satoshi."
-                    },
-                    "sweepWebhookUrl": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Optional HTTP(S) URL that receives a POST after each successful sweep. The payload includes `storeId`, `idempotencyKey`, `txId`, `amountSats`, `feeSats`, `destination`, `destinationMode`, `trigger`, and `completedAt`. Delivery failures are logged and never retried."
-                    }
-                }
-            },
-            "SparkSweepConfigurationData": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "settings": {
-                        "$ref": "#/components/schemas/SparkSweepSettings"
-                    },
-                    "walletRunning": {
-                        "type": "boolean"
-                    },
-                    "balanceSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "Indicative — see `SparkStatusData.balanceSats`."
-                    },
-                    "storeWalletStatus": {
-                        "$ref": "#/components/schemas/SparkSweepAddressStatus"
-                    },
-                    "storeWalletReason": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Why the store's own wallet is not usable as a destination, when it is not."
-                    },
-                    "network": {
-                        "type": "string",
-                        "description": "The chain a static destination address is validated against.",
-                        "example": "Mainnet"
-                    },
-                    "total": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "Total number of sweep records for this store."
-                    },
-                    "skip": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "The offset actually used, after clamping."
-                    },
-                    "count": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "The page size actually used, after clamping."
-                    },
-                    "history": {
-                        "type": "array",
-                        "description": "The requested page of sweep history, newest first.",
-                        "items": {
-                            "$ref": "#/components/schemas/SparkSweepRecordData"
-                        }
-                    },
-                    "warnings": {
-                        "type": "array",
-                        "description": "Advisory warnings about the current sweep configuration. On mainnet, entries appear when the balance threshold or minimum sweep amount are below the recommended defaults (which were measured on regtest).",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                }
-            },
-            "SparkSweepRecordData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "One sweep attempt, including the ones that were refused.",
-                "properties": {
-                    "idempotencyKey": {
-                        "type": "string",
-                        "description": "The UUID this sweep was sent under, which the SDK adopts as its own payment id. Written before the send, which is what makes a crashed sweep resolvable rather than a guess."
-                    },
-                    "destinationAddress": {
-                        "type": "string",
-                        "description": "Where it went. Empty for a refusal that never resolved a destination."
-                    },
-                    "destinationMode": {
-                        "$ref": "#/components/schemas/SparkSweepDestinationMode"
-                    },
-                    "amountSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Amount asked of the SDK. Not necessarily what the destination receives."
-                    },
-                    "recipientAmountSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "What the destination receives, after the fee when `feesIncluded` is true."
-                    },
-                    "feesIncluded": {
-                        "type": "boolean"
-                    },
-                    "confirmationSpeed": {
-                        "$ref": "#/components/schemas/SparkSweepConfirmationSpeed"
-                    },
-                    "quotedFeeSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Fee the quote promised when the row was written."
-                    },
-                    "feeSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "Fee actually paid, or null until Spark reports the payment."
-                    },
-                    "feePercent": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "The fee as a percentage of what the destination receives."
-                    },
-                    "balanceAtDecisionSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "The Spark balance this sweep was decided from, read after an explicit sync."
-                    },
-                    "txId": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "On-chain txid of the cooperative exit, or null until Spark reports one."
-                    },
-                    "trigger": {
-                        "$ref": "#/components/schemas/SparkSweepTrigger"
-                    },
-                    "status": {
-                        "$ref": "#/components/schemas/SparkSweepRecordStatus"
-                    },
-                    "refusalCode": {
-                        "$ref": "#/components/schemas/SparkSweepRefusalCode"
-                    },
-                    "error": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Why this sweep was refused or failed, in words fit for a merchant. Never contains secrets. **Not an identity** — it embeds live figures, so use `refusalCode` to decide whether two refusals are the same refusal."
-                    },
-                    "attemptCount": {
-                        "type": "integer",
-                        "format": "int32",
-                        "description": "How many times this row's outcome has been reached. One for a sweep; more for a recurring refusal, which is folded onto a single row per cause per day."
-                    },
-                    "createdAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "completedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "nullable": true
-                    },
-                    "lastSeenAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "nullable": true,
-                        "description": "When a recurring refusal was last reached. Null while it has only happened once."
-                    },
-                    "destinationKind": {
-                        "$ref": "#/components/schemas/SparkSweepDestinationKind"
-                    },
-                    "amount": {
-                        "type": "string",
-                        "description": "The amount sent, rendered with its own unit. Read this rather than `amountSats`, which is **zero and meaningless** on a sweep funded from a stablecoin balance."
-                    },
-                    "destinationChain": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "destinationAsset": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "provider": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Which bridge provider carried it. Recorded because provider availability is not stable."
-                    },
-                    "providerQuoteId": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The provider's quote id, written before the send. On a token-funded sweep this is the **only** thing identifying the send: Spark rejects an idempotency key on any transfer with a token leg."
-                    },
-                    "idempotencyKeyAccepted": {
-                        "type": "boolean",
-                        "description": "Whether `idempotencyKey` is also a Spark payment id. False when the send had a token leg — looking a payment up by the key would then return nothing, which read as evidence would say the sweep never happened."
-                    },
-                    "sourceTokenIdentifier": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "sourceAmountBaseUnits": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The amount sent in the source token's base units, as a decimal string."
-                    },
-                    "estimatedOutBaseUnits": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "deliveredAmountBaseUnits": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "What actually arrived, in destination-asset base units. Null until the provider reports delivery — which arrives through **no event**."
-                    },
-                    "delivered": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "What arrived, or is expected to, as a readable quantity with its asset."
-                    },
-                    "conversionStatus": {
-                        "$ref": "#/components/schemas/SparkConversionStatus"
-                    }
-                }
-            },
-            "SparkSweepRequest": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "Deliberately carries no amount, destination or fee tier: the engine re-derives those from the store's stored configuration and a live quote, so a request cannot change where a merchant's money goes.",
-                "properties": {
-                    "preview": {
-                        "type": "boolean",
-                        "description": "True to quote the sweep without sending it. A dry run reserves no address and writes no record.",
-                        "default": false
-                    }
-                }
-            },
-            "SparkSweepResultData": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "outcome": {
-                        "$ref": "#/components/schemas/SparkSweepOutcomeKind"
-                    },
-                    "succeeded": {
-                        "type": "boolean",
-                        "description": "True exactly when `outcome` is `Swept`."
-                    },
-                    "reason": {
-                        "type": "string",
-                        "description": "Always set, always fit for a merchant to read."
-                    },
-                    "refusalCode": {
-                        "$ref": "#/components/schemas/SparkSweepRefusalCode"
-                    },
-                    "record": {
-                        "nullable": true,
-                        "description": "The record this pass created or resolved. Null for a `Skipped` outcome, where nothing happened and nothing is written.",
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/SparkSweepRecordData"
-                            }
-                        ]
-                    }
-                }
-            },
-            "SparkSweepPreviewData": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "canSweep": {
-                        "type": "boolean",
-                        "description": "True when the engine would proceed. False means `refusalReason` is set."
-                    },
-                    "refusalReason": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "balanceSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Spark balance the plan was made from, after an explicit sync."
-                    },
-                    "sweepableSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Balance minus the configured reserve, whether or not it is worth sweeping."
-                    },
-                    "amountSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "Amount that would be asked of the SDK. Null when there would be no sweep."
-                    },
-                    "recipientAmountSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "What the destination would receive at the store's chosen tier."
-                    },
-                    "destination": {
-                        "nullable": true,
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/SparkSweepDestinationData"
-                            }
-                        ]
-                    },
-                    "quote": {
-                        "nullable": true,
-                        "allOf": [
-                            {
-                                "$ref": "#/components/schemas/SparkSweepQuoteData"
-                            }
-                        ]
-                    },
-                    "settings": {
-                        "$ref": "#/components/schemas/SparkSweepSettings"
-                    },
-                    "crossChainQuote": {
-                        "$ref": "#/components/schemas/SparkCrossChainQuoteData"
-                    },
-                    "amount": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "What would be sent, rendered with its own unit. Read this rather than `amountSats` when Stable Balance may be on."
-                    }
-                }
-            },
-            "SparkSweepDestinationData": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "address": {
-                        "type": "string"
-                    },
-                    "mode": {
-                        "$ref": "#/components/schemas/SparkSweepDestinationMode"
-                    },
-                    "rotates": {
-                        "type": "boolean",
-                        "description": "True when a real sweep would reserve a fresh address rather than reuse this one."
-                    }
-                }
-            },
-            "SparkSweepQuoteData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "A live cooperative-exit quote. **An estimate**: it expires in about a minute, and a real sweep re-quotes and re-checks the fee ceiling against the number it commits to.",
-                "properties": {
-                    "feeSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "The fee at the tier the store's configuration selects."
-                    },
-                    "feesIncluded": {
-                        "type": "boolean"
-                    },
-                    "totalDebitedSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "What would leave the Spark balance in total."
-                    },
-                    "feePercentOfRecipientAmount": {
-                        "type": "number",
-                        "format": "double",
-                        "description": "The fee as a percentage of what the destination receives — the number that makes a flat exit fee honest."
-                    },
-                    "slowFeeSats": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "mediumFeeSats": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "fastFeeSats": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "expiresAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    }
-                }
-            },
-            "SparkSeedSource": {
-                "type": "string",
-                "description": "Where a store's Spark seed came from. Reusing the on-chain hot-wallet seed means one compromise reaches both balances, and the Spark identity pubkey publicly links them.",
-                "enum": [
-                    "Generated",
-                    "Imported",
-                    "HotWallet"
-                ]
-            },
-            "SparkLightningWiringState": {
-                "type": "string",
-                "description": "What a store's Lightning payment method points at. `StaleSpark` is this store's Spark wallet under a superseded payment key — still ours, and dead. `OtherStoreSpark` is another store's Spark wallet — refused at save time, and cleared at startup with the victim's payment key rotated.",
-                "enum": [
-                    "StoreNotFound",
-                    "NotConfigured",
-                    "InternalNode",
-                    "OtherNode",
-                    "Spark",
-                    "StaleSpark",
-                    "OtherStoreSpark"
-                ]
-            },
-            "SparkSweepDestinationMode": {
-                "type": "string",
-                "description": "`StoreWallet` takes a fresh, labelled address from the store's BTC derivation scheme and rotates it every sweep. `StaticAddress` uses one fixed address, for stores with no on-chain BTCPay wallet. `EvmAddress` delivers a stablecoin to an address on an EVM chain through a bridge provider; mainnet only, because Spark refuses to start a wallet configured for cross-chain sending on any other network.",
-                "enum": [
-                    "StoreWallet",
-                    "StaticAddress",
-                    "EvmAddress"
-                ]
-            },
-            "SparkSweepConfirmationSpeed": {
-                "type": "string",
-                "description": "Which of the SDK's three cooperative-exit fee tiers to use.",
-                "enum": [
-                    "Slow",
-                    "Medium",
-                    "Fast"
-                ]
-            },
-            "SparkSweepAddressStatus": {
-                "type": "string",
-                "description": "Whether the store has an on-chain BTCPay wallet to sweep into.",
-                "enum": [
-                    "Available",
-                    "NoOnchainWallet",
-                    "Unavailable"
-                ]
-            },
-            "SparkSweepTrigger": {
-                "type": "string",
-                "description": "What set a sweep in motion. Both run the identical engine path.",
-                "enum": [
-                    "Automatic",
-                    "Manual"
-                ]
-            },
-            "SparkSweepRecordStatus": {
-                "type": "string",
-                "description": "`Pending` means the outcome is not yet known and is resolved against the SDK rather than by retrying blind. `Refused` means the plugin declined and nothing was sent.",
-                "enum": [
-                    "Pending",
-                    "Sent",
-                    "Confirmed",
-                    "Failed",
-                    "Refused"
-                ]
-            },
-            "SparkSweepOutcomeKind": {
-                "type": "string",
-                "description": "What one pass of the sweep engine did. Only `Swept` means a cooperative exit was accepted. `Unresolved` means the send's fate is unknown and nothing further will be sent until the SDK answers.",
-                "enum": [
-                    "Swept",
-                    "InFlight",
-                    "Skipped",
-                    "Refused",
-                    "Failed",
-                    "Unresolved"
-                ]
-            },
-            "SparkSweepRefusalCode": {
-                "type": "string",
-                "description": "The stable identity of a reason the plugin declined to sweep. Use this rather than the message, which embeds live figures.",
-                "enum": [
-                    "None",
-                    "WalletNotRunning",
-                    "BalanceUnreadable",
-                    "NothingAboveReserve",
-                    "BelowMinimumSweep",
-                    "NoDestination",
-                    "QuoteFailed",
-                    "InsufficientFunds",
-                    "BelowDustFloor",
-                    "ReserveBelowFee",
-                    "FeeAboveLimit",
-                    "CrossChainUnavailable",
-                    "NoCrossChainRoute",
-                    "CrossChainOverpayExceedsBalance",
-                    "StableBalanceHoldsTheFunds",
-                    "CrossChainQuoteUnusable",
-                    "CrossChainValueUnverifiable"
-                ]
-            },
-            "SparkDepositData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "The store's on-chain deposit address and everything sent to it that has not been credited.",
-                "properties": {
-                    "address": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The static Bitcoin deposit address, or null when it could not be read. Stable across calls and safe to save."
-                    },
-                    "addressError": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Why the address could not be read."
-                    },
-                    "walletRunning": {
-                        "type": "boolean"
-                    },
-                    "deposits": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/SparkDepositEntryData"
-                        },
-                        "description": "Unclaimed deposits. Entries with `needsAttention` true are stuck and will never arrive without a claim."
-                    },
-                    "recommendedFees": {
-                        "$ref": "#/components/schemas/SparkRecommendedFeesData"
-                    },
-                    "claimFeeLeewaySatPerVbyte": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Headroom over the network-recommended rate that automatic claims are allowed, after clamping to the plugin's maximum of 100. The plugin configures Spark's ceiling as 'network-recommended plus this', never as a fixed rate — Spark's own default is a fixed 1 sat/vB, below the mainnet floor essentially always. Read-only: there is no endpoint that sets it, and a rate is the only bound on an automatic claim, since Spark offers no cap relative to the size of the deposit."
-                    },
-                    "maxManualClaimFeeSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Ceiling on a manual claim, in satoshi. Read-only: there is no endpoint that sets it."
-                    },
-                    "claimPolicyLooksTooLow": {
-                        "type": "boolean",
-                        "description": "True when the configured ceiling already looks too low for the current fee market, so a deposit arriving now may not be claimed automatically."
-                    }
-                }
-            },
-            "SparkDepositEntryData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "One on-chain deposit Spark knows about and has not credited.",
-                "properties": {
-                    "txId": {
-                        "type": "string"
-                    },
-                    "vout": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "amountSats": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "isMature": {
-                        "type": "boolean",
-                        "description": "False while the deposit is still waiting for its third confirmation. Nothing needs doing."
-                    },
-                    "needsAttention": {
-                        "type": "boolean",
-                        "description": "True when the deposit has matured and its claim failed. Spark will not retry it."
-                    },
-                    "claimError": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Why the claim failed."
-                    },
-                    "requiredFeeSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "What the claim would actually cost. The value the claim endpoint uses when none is supplied."
-                    },
-                    "requiredFeeRateSatPerVbyte": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true
-                    }
-                }
-            },
-            "SparkRecommendedFeesData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "Mempool fee rates in sat/vB.",
-                "properties": {
-                    "fastestFee": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "halfHourFee": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "hourFee": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "economyFee": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "minimumFee": {
-                        "type": "integer",
-                        "format": "int64"
-                    }
-                }
-            },
-            "SparkClaimDepositRequest": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "Which deposit to claim, and at what ceiling.",
-                "properties": {
-                    "txId": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "Transaction id of the deposit, as reported by the deposit endpoint."
-                    },
-                    "vout": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Output index of the deposit."
-                    },
-                    "maxFeeSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "Ceiling for this claim, in satoshi. Omit to use the fee Spark said the claim needs — the right answer almost always. No value lifts the backstop that refuses to spend more than half a deposit on claiming it."
-                    }
-                }
-            },
-            "SparkClaimDepositResponse": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "The plugin's decision about a manual claim. Only `Claimed` broadcast anything.",
-                "properties": {
-                    "status": {
-                        "$ref": "#/components/schemas/SparkClaimStatus"
-                    },
-                    "succeeded": {
-                        "type": "boolean",
-                        "description": "True exactly when `status` is `Claimed`."
-                    },
-                    "message": {
-                        "type": "string",
-                        "description": "Always set, always fit for a merchant to read."
-                    },
-                    "feeSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "The ceiling the claim was issued at."
-                    }
-                }
-            },
-            "SparkStableBalanceData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "The store's Stable Balance configuration and what its wallet is actually doing.",
-                "properties": {
-                    "desiredActive": {
-                        "type": "boolean",
-                        "description": "What the store asked for."
-                    },
-                    "activeLabel": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The label the wallet reports as active, or null when stable balance is off there. **This, not `desiredActive`, is what the wallet is doing.**"
-                    },
-                    "needsReapply": {
-                        "type": "boolean",
-                        "description": "True when the setting and the wallet disagree. Reported rather than reconciled, because converging them converts the balance."
-                    },
-                    "available": {
-                        "type": "boolean",
-                        "description": "False on any network but mainnet, where the feature cannot work at all."
-                    },
-                    "walletRunning": {
-                        "type": "boolean"
-                    },
-                    "walletError": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "balance": {
-                        "$ref": "#/components/schemas/SparkTokenBalanceData"
-                    },
-                    "conversionMinimumSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "Spark's own floor on a Bitcoin-to-token conversion. A configured `autoConvertThresholdSats` below this is clamped *up* to it rather than honoured."
-                    },
-                    "settings": {
-                        "$ref": "#/components/schemas/StableBalanceInput"
-                    },
-                    "message": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "What the last write did, when this is a write's response."
-                    }
-                }
-            },
-            "SparkTokenBalanceData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "A token balance the wallet holds.",
-                "properties": {
-                    "identifier": {
-                        "type": "string"
-                    },
-                    "ticker": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "baseUnits": {
-                        "type": "string",
-                        "description": "**Base units as a decimal string, not satoshi and not a quantity.** $35.60 of a 6-decimal token is `\"35600000\"`. A string because the value is a u128 and an 18-decimal token overflows every JSON number a client is likely to parse it into."
-                    },
-                    "amount": {
-                        "type": "string",
-                        "description": "The same figure as a human-readable quantity, e.g. `35.6`."
-                    },
-                    "decimals": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "isFreezable": {
-                        "type": "boolean",
-                        "description": "Whether the issuer can freeze this balance. **True for USDB.** The counterparty risk a merchant accepts by holding one."
-                    }
-                }
-            },
-            "StableBalanceInput": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "A store's Stable Balance configuration. A `PUT` replaces the whole thing.",
-                "properties": {
-                    "enabled": {
-                        "type": "boolean",
-                        "description": "Whether the store wants its balance held in a stablecoin. Changing this converts the balance, in the background, with nothing to report when it finishes."
-                    },
-                    "disclosureAcknowledged": {
-                        "type": "boolean",
-                        "description": "Confirmation that the freezable-issuer warning has been read. **Required to enable.**"
-                    },
-                    "tokenIdentifier": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The token identifier. Defaults to mainnet USDB, which the plugin supplies because Spark ships no default for it. Checked against Spark before it is stored."
-                    },
-                    "label": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The label the wallet activates by. An arbitrary display string with no protocol meaning — not a ticker and not the identifier."
-                    },
-                    "maxSlippageBps": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Conversion slippage tolerance in basis points; Spark's own default is 10. A *different* setting from the cross-chain slippage on the sweep configuration, which defaults to 100 if unset."
-                    },
-                    "autoConvertThresholdSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "nullable": true,
-                        "description": "Balance at which Spark auto-converts. Null leaves Spark's own minimum in force; a value below that minimum is raised to it rather than honoured."
-                    }
-                }
-            },
-            "SparkCrossChainQuoteData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "A live cross-chain quote. **An estimate**: it expires in about a minute, and a real sweep re-quotes and re-checks the fee ceiling against the number it commits to. There is **no arrival estimate** — Spark exposes none, so nothing here can offer one.",
-                "properties": {
-                    "provider": {
-                        "type": "string",
-                        "description": "Which bridge provider would carry it, e.g. `Orchestra`."
-                    },
-                    "chain": {
-                        "type": "string"
-                    },
-                    "chainId": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "asset": {
-                        "type": "string"
-                    },
-                    "assetDecimals": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Read from the route rather than assumed: 6 on every Orchestra USDT route except BSC, which is 18."
-                    },
-                    "amountInSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "**Larger than the amount being sent.** The provider overpays the source leg to absorb its fee and slippage, so a sweep sized to exactly the sweepable balance cannot be funded. The pad is not derivable from a slippage setting; read it here."
-                    },
-                    "assetAmountIn": {
-                        "type": "string",
-                        "description": "Gross destination-asset base units, as a decimal string."
-                    },
-                    "estimatedOut": {
-                        "type": "string",
-                        "description": "Destination-asset base units expected to arrive, as a decimal string."
-                    },
-                    "estimatedOutAmount": {
-                        "type": "string",
-                        "description": "The same figure as a readable quantity with its asset."
-                    },
-                    "feeAmount": {
-                        "type": "string",
-                        "description": "In **destination-asset base units**, not satoshi."
-                    },
-                    "serviceFeeAmount": {
-                        "type": "string",
-                        "description": "In `serviceFeeAsset`'s base units — which may be a *third* asset again; USDC was observed on a USDT route. Do not add this to `feeAmount`."
-                    },
-                    "serviceFeeAsset": {
-                        "type": "string",
-                        "nullable": true
-                    },
-                    "sourceTransferFeeSats": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "expiresAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "providerQuoteId": {
-                        "type": "string",
-                        "nullable": true,
-                        "description": "The provider's own quote id, persisted before the send. On a sweep funded from a stablecoin balance this is the only thing that identifies the send afterwards."
-                    }
-                }
-            },
-            "SparkClaimStatus": {
-                "type": "string",
-                "description": "`Claimed` broadcast a claim. `Refused` means the plugin declined and spent nothing. `Failed` means Spark attempted it and reported an error. `Unavailable` means the store has no running wallet.",
-                "enum": [
-                    "Claimed",
-                    "Unavailable",
-                    "Refused",
-                    "Failed"
-                ]
-            },
-            "SparkConversionStatus": {
-                "type": "string",
-                "description": "How far a bridge provider or conversion has got. **No SDK event reports any transition here** — every value is discovered by polling. `RefundNeeded` is the one that needs a human: Spark is holding funds it could not convert, and the plugin requests a refund on the next sweep pass.",
-                "enum": [
-                    "Pending",
-                    "Completed",
-                    "Failed",
-                    "RefundNeeded",
-                    "Refunded",
-                    "Unknown"
-                ]
-            },
-            "SparkSweepDestinationKind": {
-                "type": "string",
-                "description": "Which rail a sweep used. `BitcoinAddress` is a cooperative exit; `EvmAddress` is a cross-chain send through a bridge provider — still an ordinary Spark transfer at the point money leaves the wallet, so there is no unilateral exit either way.",
-                "enum": [
-                    "BitcoinAddress",
-                    "EvmAddress"
-                ]
-            },
-            "SparkBalanceSyncData": {
-                "type": "object",
-                "additionalProperties": false,
-                "description": "The Spark balance after a forced wallet sync.",
-                "properties": {
-                    "walletRunning": {
-                        "type": "boolean",
-                        "description": "Whether a Spark wallet is live for this store."
-                    },
-                    "balanceSats": {
-                        "type": "integer",
-                        "format": "int64",
-                        "description": "Spark balance in satoshi after forcing a wallet sync. Zero when the wallet is not running."
-                    },
-                    "syncedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "When the sync was performed, UTC."
-                    }
-                }
-            }
-        }
+  "tags": [
+    {
+      "name": "Spark",
+      "description": "Nodeless Lightning for a store, powered by the Breez Spark SDK: set the store's Spark wallet up, read its state, configure automatic on-chain sweeps, and sweep now. Every sweep is a cooperative exit through the Spark service provider; the plugin has no unilateral-exit path."
     }
+  ],
+  "paths": {
+    "/api/v1/stores/{storeId}/spark": {
+      "get": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Get the store's Spark status",
+        "description": "Whether the store has Spark configured, whether its wallet is running, its indicative balance, its Spark identity, the Spark network's published status, where its seed came from, and what its Lightning payment method currently points at. Answers 200 with `configured: false` for a store that has never set Spark up — that is a state, not an error.",
+        "operationId": "Spark_GetStatus",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The store's Spark status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkStatusData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to view the specified store"
+          },
+          "404": {
+            "description": "The store was not found, or the request named a store it was not authorised for"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canviewstoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Set the store's Spark wallet up",
+        "description": "Configures the store's Spark wallet from a chosen seed source, confirms the wallet is running, and then points the store's Lightning payment method at it. Calling this on a store that already has Spark configured replaces its seed, carrying over its sweep configuration.\n\n**A generated recovery phrase is returned exactly once, in this response, and never again.** There is no endpoint that reads a seed back. Persist it before doing anything else.\n\nAll three seed sources are gated on the server's hot-wallet policy (`AllowHotWalletForAll`, or being a server administrator) — including reusing the store's existing on-chain seed, because that copies key material into a second wallet.",
+        "operationId": "Spark_Provision",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SparkProvisionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The store is configured. `mnemonic` is set only when `seedSource` was `generate`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkProvisionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden to modify the specified store, or a server administrator has not allowed non-admins to create hot wallets on this server (`hot-wallet-not-allowed`)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The store was not found, or the request named a store it was not authorised for"
+          },
+          "422": {
+            "description": "The seed source was not recognised, the recovery phrase was not usable, or the wallet could not be started — in which case nothing was left behind",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canmodifystoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Remove the store's Spark wallet",
+        "description": "Destroys this server's copy of the store's Spark keys and clears the store's Lightning payment-method configuration — but only when that configuration still points at this store's Spark wallet. Another Lightning node's connection string is left untouched.\n\nThe SDK storage directory is kept. After this call the merchant's recovery phrase is the only way to reach any remaining funds.",
+        "operationId": "Spark_Remove",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The store's Spark configuration was removed"
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to modify the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store (`spark-not-configured`)"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canmodifystoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stores/{storeId}/spark/sweep": {
+      "get": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Get the store's sweep configuration and history",
+        "description": "The automatic-sweep configuration in force, plus a page of sweep records newest first. The history includes sweeps that did not happen: a `Refused` record carries the stable `refusalCode`, the sentence a merchant would read, and an `attemptCount` — a recurring automatic refusal is folded onto one row per cause per day rather than filed once per pass.",
+        "operationId": "Spark_GetSweepConfiguration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "required": false,
+            "description": "How many records to skip. Negative values are clamped to zero.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "required": false,
+            "description": "How many records to return. Clamped to 1..100.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The store's sweep configuration and history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkSweepConfigurationData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to view the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store (`spark-not-configured`)"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canviewstoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Replace the store's sweep configuration",
+        "description": "A full replacement: a field the body omits takes its default rather than keeping its current value. Read the configuration first and send it back modified.\n\nValidated by exactly the rules the settings page is validated by. **No configuration accepted here switches the fee guard off** — clearing `maxFeePercent` without setting `maxFeeFlatSats` is refused, a `maxFeeFlatSats` above `minimumSweepSats` is refused, and whatever is stored, the engine applies a hard backstop no configuration can lift at the moment money would move.",
+        "operationId": "Spark_UpdateSweepConfiguration",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SparkSweepSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The configuration now in force, re-read from storage",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkSweepConfigurationData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to modify the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store (`spark-not-configured`)"
+          },
+          "422": {
+            "description": "The configuration was refused and nothing was written",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canmodifystoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Sweep the store's Spark balance on-chain now, or quote a sweep",
+        "description": "Runs the same engine method the periodic task runs, with the trigger set to manual. A manual trigger relaxes only the automatic-sweep switch and the balance threshold; every safety and economic guard — the minimum sweep, the fee ceiling, the dust floor, the destination rules, the single-flight lock, and the refusal to send while an earlier sweep's fate is unknown — applies identically. The sweep is recorded with its idempotency key before the send.\n\nWith `preview: true` nothing is sent, no address is reserved from the store's wallet, and no record is written; the response is a live quote that expires in about a minute.\n\n**Always a cooperative exit.** No parameter selects a unilateral exit.\n\n**A 200 means the engine reached a decision, not that money moved.** Read `outcome`: only `Swept` means a cooperative exit was accepted. `Refused`, `Skipped` and `InFlight` are routine steady states of an engine designed to decline, so they are not reported as an error status — a store whose fee ceiling sits below the current exit fee stays on `Refused` indefinitely and nothing is wrong.",
+        "operationId": "Spark_Sweep",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SparkSweepRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The engine's decision — a `SparkSweepResultData` for a real sweep, a `SparkSweepPreviewData` when `preview` was true",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/SparkSweepResultData"
+                    },
+                    {
+                      "$ref": "#/components/schemas/SparkSweepPreviewData"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to modify the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store (`spark-not-configured`)"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canmodifystoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stores/{storeId}/spark/deposit": {
+      "get": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Get the store's on-chain deposit address and unclaimed deposits",
+        "description": "The static Bitcoin address that tops the store's Spark wallet up, plus anything sent to it that has not been credited. The address is stable across calls and safe to save; it is also the string to render as a QR code, since the plugin returns no image.\n\nFunds credit after **three confirmations**, and only then does Spark attempt the claim — budget half an hour or more, not seconds.\n\n**Read `deposits`, not only `address`.** A claim is capped by a fee ceiling, and a deposit needing more than the ceiling allows is *not* retried at a lower price: it sits unclaimed indefinitely and appears nowhere else. An entry with `isMature: false` is merely waiting for confirmations and needs nobody; one with `needsAttention: true` is stuck and needs the claim endpoint. Spark's own default ceiling of 1 sat/vB is below the mainnet floor essentially always, which is why the plugin overrides it with a rate that tracks the mempool.",
+        "operationId": "Spark_GetDeposits",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The deposit address and unclaimed deposits",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkDepositData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to view the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for it"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canviewstoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stores/{storeId}/spark/deposit/claim": {
+      "post": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Claim an on-chain deposit Spark could not claim itself",
+        "description": "Claims one matured deposit whose automatic claim was refused on fee grounds.\n\nOmit `maxFeeSats` for the ordinary case: Spark reports the fee the claim actually needs on the very error that stranded the deposit, and that is what will be used.\n\n**Guarded beyond the store's configured ceiling.** Whatever `maxManualClaimFeeSats` says, the plugin refuses to spend more than half a deposit on claiming it — a rate-based cap knows nothing about the size of the deposit it is paid out of, and this is the only place the two are compared.\n\n**A 200 means the plugin reached a decision, not that a claim was broadcast.** Read `status`: only `Claimed` did anything. A refusal spends nothing and leaves the deposit claimable.",
+        "operationId": "Spark_ClaimDeposit",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SparkClaimDepositRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The plugin's decision",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkClaimDepositResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to modify the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for it"
+          },
+          "422": {
+            "description": "The request did not name a deposit"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canmodifystoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stores/{storeId}/spark/stable-balance": {
+      "get": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Get the store's Stable Balance configuration and state",
+        "description": "`desiredActive` is what the store asked for; `activeLabel` is what its wallet reports. **The two can legitimately disagree** — Spark caches the active label per wallet, so a store whose recovery phrase was replaced starts deactivated whatever its setting says. The plugin reports the disagreement rather than reconciling it, because converging them converts the merchant's balance. `needsReapply` says when they differ; `PUT` converges them.\n\n`balance.isFreezable` is **true for USDB**: the issuer can freeze it. That is a real counterparty on top of Spark's own operators.\n\nMainnet only; `available` is false everywhere else.",
+        "operationId": "Spark_GetStableBalance",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The store's Stable Balance state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkStableBalanceData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to view the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for it"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canviewstoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Replace the store's Stable Balance configuration",
+        "description": "**This moves money.** Enabling queues a conversion of the store's Bitcoin balance into the configured stablecoin; disabling queues the reverse. Both run on Spark's own background worker, both take a spread, and **no SDK event reports either one** — the only way to observe the result is to read this resource again later.\n\nA full replacement, as `PUT` implies: an omitted field takes its default, it does not keep its current value. A `null` or `{}` body therefore means off.\n\n`disclosureAcknowledged` must be true to enable. Holding a store's balance in USDB adds a regulated issuer who can freeze it; the API enforces the same acknowledgement the settings page does, because a disclosure one surface skips is a disclosure with a documented bypass.\n\nMainnet only. Elsewhere this is refused rather than stored, because Spark would accept the configuration and then silently never convert anything.\n\nThe token identifier is checked against Spark before it is stored.",
+        "operationId": "Spark_UpdateStableBalance",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StableBalanceInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The stored configuration and the wallet's state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkStableBalanceData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to modify the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for it"
+          },
+          "422": {
+            "description": "The configuration was refused, or Spark would not apply it"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canmodifystoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stores/{storeId}/spark/sync": {
+      "post": {
+        "tags": [
+          "Spark"
+        ],
+        "summary": "Force a wallet sync and return the current balance",
+        "description": "The status endpoint caches balance for up to 20 seconds. `POST /spark/sync` forces an explicit sync before reading — use it when you need the current balance immediately rather than a cached value. `walletRunning: false` means no Spark wallet is live for this store; `balanceSats` will be 0 in that case.",
+        "operationId": "Spark_SyncBalance",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The balance after a forced wallet sync",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkBalanceSyncData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to modify the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, or Spark is not set up for this store"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canmodifystoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/api/v1/stores/{storeId}/spark/sweep/{idempotencyKey}": {
+      "get": {
+        "summary": "Get a sweep record by its idempotency key",
+        "description": "Returns the record for a single sweep, identified by the idempotency key the engine assigned it when the sweep was initiated.",
+        "operationId": "Spark_GetSweepRecord",
+        "tags": [
+          "Spark"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/StoreId"
+          },
+          {
+            "name": "idempotencyKey",
+            "in": "path",
+            "required": true,
+            "description": "The idempotency key returned in `idempotencyKey` on the sweep result.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The sweep record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SparkSweepRecordData"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If you are authenticated but forbidden to view the specified store"
+          },
+          "404": {
+            "description": "The store was not found, the request named a store it was not authorised for, Spark is not set up for this store (`spark-not-configured`), or no sweep record with that idempotency key exists (`sweep-record-not-found`)"
+          }
+        },
+        "security": [
+          {
+            "API_Key": [
+              "btcpay.store.canviewstoresettings"
+            ],
+            "Basic": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SparkStatusData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "configured": {
+            "type": "boolean",
+            "description": "False when this store has never set Spark up. Everything below is then meaningless."
+          },
+          "seedSource": {
+            "$ref": "#/components/schemas/SparkSeedSource"
+          },
+          "walletRunning": {
+            "type": "boolean",
+            "description": "Whether a Spark wallet is live for this store right now. False while `configured` is true means the store looks set up and takes no payments — a seed the server can no longer decrypt, a second store on the same wallet, or an unsupported chain."
+          },
+          "identityPubkey": {
+            "type": "string",
+            "nullable": true,
+            "description": "The wallet's Spark identity public key, or null when it is not running or has not synced. Public by design — it does publicly link this wallet to anything else sharing its seed."
+          },
+          "balanceSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Spark balance in satoshi. **Indicative only**: read from the SDK's cache without forcing a sync, it lags settlement by around 20 seconds and drifts by a few sats around the SDK's background leaf optimisation. Never reconcile against it and never derive an accounting figure from it."
+          },
+          "walletError": {
+            "type": "string",
+            "nullable": true,
+            "description": "Set when the wallet is running but could not be read."
+          },
+          "networkStatus": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SparkNetworkStatusData"
+              }
+            ]
+          },
+          "lightningWiring": {
+            "$ref": "#/components/schemas/SparkLightningWiringState"
+          },
+          "lightningEnabledForCheckout": {
+            "type": "boolean",
+            "description": "False when a Lightning payment method exists but is excluded from checkout."
+          },
+          "storageDirectory": {
+            "type": "string",
+            "nullable": true,
+            "description": "Absolute path of this store's SDK storage directory on the server. Null unless the caller is a server administrator: it describes the host's filesystem rather than the store, and every role that can view store settings can reach this endpoint."
+          }
+        }
+      },
+      "SparkNetworkStatusData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Spark's own published service status. Read without a wallet; null in a response means it could not be read.",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "`Operational`, `Degraded`, `Partial`, `Major` or `Unknown`.",
+            "example": "Operational"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the Spark operators last published that status."
+          },
+          "isOperational": {
+            "type": "boolean",
+            "description": "True only for an explicitly operational network. `Unknown` is not treated as healthy."
+          }
+        }
+      },
+      "SparkProvisionRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "seedSource": {
+            "type": "string",
+            "description": "Where the seed comes from. `generate` mints a new phrase and returns it once in the response. `import` uses the phrase in `mnemonic`. `hotWallet` reuses the store's on-chain BTCPay wallet seed, which requires that wallet to be a hot wallet with a stored recovery phrase.",
+            "enum": [
+              "generate",
+              "import",
+              "hotWallet"
+            ]
+          },
+          "mnemonic": {
+            "type": "string",
+            "nullable": true,
+            "description": "The BIP39 recovery phrase, for `import` only. Never echoed back — not in a success response, not in a validation error, not in a log line."
+          }
+        }
+      },
+      "SparkProvisionResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mnemonic": {
+            "type": "string",
+            "nullable": true,
+            "description": "The generated recovery phrase — **returned exactly once, here, and never again**. Set only when the request asked for `generate`; null for `import` (you already hold it) and for `hotWallet` (it is the store's on-chain seed, which this API will not hand out). There is no endpoint that reads a seed back, so if this value is not persisted now the store's funds depend entirely on the server's data directory surviving. Do not log it."
+          },
+          "status": {
+            "$ref": "#/components/schemas/SparkStatusData"
+          }
+        }
+      },
+      "SparkSweepSettings": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "A store's automatic-sweep configuration. Off until a merchant or an API caller opts in.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the periodic task may sweep this store. A manual sweep works either way."
+          },
+          "balanceThresholdSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Balance at which an automatic sweep is considered. Defaults to 200,000 sat, which makes a default-configured sweep cost roughly 1% in exit fees at regtest fee levels.",
+            "default": 200000
+          },
+          "reserveSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Amount left on Spark after a sweep, to keep receiving cheaply. With `drainWhenSweeping` false the exit fee is charged on top of the swept amount, so the reserve is also what pays it — a reserve smaller than the fee is refused rather than allowed to overdraw.",
+            "default": 0
+          },
+          "minimumSweepSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Smallest amount worth sweeping. A cooperative exit costs a flat fee independent of the amount, so this is the guard against paying 40% of a small balance to move it. Cannot be below the 294 sat on-chain minimum.",
+            "default": 100000
+          },
+          "confirmationSpeed": {
+            "$ref": "#/components/schemas/SparkSweepConfirmationSpeed"
+          },
+          "maxFeePercent": {
+            "type": "number",
+            "format": "double",
+            "description": "Ceiling on the exit fee as a percentage of the amount delivered, 0 to 100. Zero disables the percentage guard, in which case `maxFeeFlatSats` must be set — there is no configuration with no fee ceiling at all.",
+            "default": 3.0
+          },
+          "maxFeeFlatSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Optional absolute ceiling on the exit fee. When both guards are set the stricter one wins. Must not exceed `minimumSweepSats`, otherwise it would permit a sweep costing more than it delivers."
+          },
+          "drainWhenSweeping": {
+            "type": "boolean",
+            "description": "Take the exit fee out of the swept amount rather than charging it on top. **This is a cooperative exit either way** — it selects the SDK's `FeesIncluded` fee policy and has nothing to do with a unilateral exit, which this plugin does not implement.",
+            "default": true
+          },
+          "destinationMode": {
+            "$ref": "#/components/schemas/SparkSweepDestinationMode"
+          },
+          "staticAddress": {
+            "type": "string",
+            "nullable": true,
+            "description": "The fixed Bitcoin address used in `StaticAddress` mode, validated against this server's chain on save and again before every send. Cleared when the mode is `StoreWallet`."
+          },
+          "evmAddress": {
+            "type": "string",
+            "nullable": true,
+            "description": "The EVM address a cross-chain sweep delivers to. **An address carries no chain** — Spark's own parser returns no chain id for a bare one — so `evmChain` is a separate choice and getting it wrong sends funds somewhere unreachable."
+          },
+          "evmChain": {
+            "type": "string",
+            "nullable": true,
+            "description": "Destination chain, e.g. `arbitrum`. Checked against the live route table before every sweep."
+          },
+          "evmAsset": {
+            "type": "string",
+            "nullable": true,
+            "description": "Destination asset, e.g. `USDT`. Matched **exactly**: `USDT0` is a different asset and will not be substituted."
+          },
+          "crossChainSlippageBps": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Cross-chain slippage in basis points, 10–500. Null uses 50. A *different* setting from the Stable Balance conversion slippage; Spark's own fallback here is 100, which is ten times looser."
+          },
+          "crossChainMinimumStableUnits": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Smallest cross-chain sweep to make from a stablecoin balance, in **whole units** of that token — 20 means twenty dollars. Used only when Stable Balance is on, because only then is the amount not in satoshi."
+          },
+          "sweepWebhookUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Optional HTTP(S) URL that receives a POST after each successful sweep. The payload includes `storeId`, `idempotencyKey`, `txId`, `amountSats`, `feeSats`, `destination`, `destinationMode`, `trigger`, and `completedAt`. Delivery failures are logged and never retried."
+          }
+        }
+      },
+      "SparkSweepConfigurationData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "settings": {
+            "$ref": "#/components/schemas/SparkSweepSettings"
+          },
+          "walletRunning": {
+            "type": "boolean"
+          },
+          "balanceSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Indicative — see `SparkStatusData.balanceSats`."
+          },
+          "storeWalletStatus": {
+            "$ref": "#/components/schemas/SparkSweepAddressStatus"
+          },
+          "storeWalletReason": {
+            "type": "string",
+            "nullable": true,
+            "description": "Why the store's own wallet is not usable as a destination, when it is not."
+          },
+          "network": {
+            "type": "string",
+            "description": "The chain a static destination address is validated against.",
+            "example": "Mainnet"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Total number of sweep records for this store."
+          },
+          "skip": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The offset actually used, after clamping."
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The page size actually used, after clamping."
+          },
+          "history": {
+            "type": "array",
+            "description": "The requested page of sweep history, newest first.",
+            "items": {
+              "$ref": "#/components/schemas/SparkSweepRecordData"
+            }
+          },
+          "warnings": {
+            "type": "array",
+            "description": "Advisory warnings about the current sweep configuration. On mainnet, entries appear when the balance threshold or minimum sweep amount are below the recommended defaults (which were measured on regtest).",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "SparkSweepRecordData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "One sweep attempt, including the ones that were refused.",
+        "properties": {
+          "idempotencyKey": {
+            "type": "string",
+            "description": "The UUID this sweep was sent under, which the SDK adopts as its own payment id. Written before the send, which is what makes a crashed sweep resolvable rather than a guess."
+          },
+          "destinationAddress": {
+            "type": "string",
+            "description": "Where it went. Empty for a refusal that never resolved a destination."
+          },
+          "destinationMode": {
+            "$ref": "#/components/schemas/SparkSweepDestinationMode"
+          },
+          "amountSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Amount asked of the SDK. Not necessarily what the destination receives."
+          },
+          "recipientAmountSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "What the destination receives, after the fee when `feesIncluded` is true."
+          },
+          "feesIncluded": {
+            "type": "boolean"
+          },
+          "confirmationSpeed": {
+            "$ref": "#/components/schemas/SparkSweepConfirmationSpeed"
+          },
+          "quotedFeeSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Fee the quote promised when the row was written."
+          },
+          "feeSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Fee actually paid, or null until Spark reports the payment."
+          },
+          "feePercent": {
+            "type": "number",
+            "format": "double",
+            "description": "The fee as a percentage of what the destination receives."
+          },
+          "balanceAtDecisionSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The Spark balance this sweep was decided from, read after an explicit sync."
+          },
+          "txId": {
+            "type": "string",
+            "nullable": true,
+            "description": "On-chain txid of the cooperative exit, or null until Spark reports one."
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/SparkSweepTrigger"
+          },
+          "status": {
+            "$ref": "#/components/schemas/SparkSweepRecordStatus"
+          },
+          "refusalCode": {
+            "$ref": "#/components/schemas/SparkSweepRefusalCode"
+          },
+          "error": {
+            "type": "string",
+            "nullable": true,
+            "description": "Why this sweep was refused or failed, in words fit for a merchant. Never contains secrets. **Not an identity** — it embeds live figures, so use `refusalCode` to decide whether two refusals are the same refusal."
+          },
+          "attemptCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "How many times this row's outcome has been reached. One for a sweep; more for a recurring refusal, which is folded onto a single row per cause per day."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastSeenAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When a recurring refusal was last reached. Null while it has only happened once."
+          },
+          "destinationKind": {
+            "$ref": "#/components/schemas/SparkSweepDestinationKind"
+          },
+          "amount": {
+            "type": "string",
+            "description": "The amount sent, rendered with its own unit. Read this rather than `amountSats`, which is **zero and meaningless** on a sweep funded from a stablecoin balance."
+          },
+          "destinationChain": {
+            "type": "string",
+            "nullable": true
+          },
+          "destinationAsset": {
+            "type": "string",
+            "nullable": true
+          },
+          "provider": {
+            "type": "string",
+            "nullable": true,
+            "description": "Which bridge provider carried it. Recorded because provider availability is not stable."
+          },
+          "providerQuoteId": {
+            "type": "string",
+            "nullable": true,
+            "description": "The provider's quote id, written before the send. On a token-funded sweep this is the **only** thing identifying the send: Spark rejects an idempotency key on any transfer with a token leg."
+          },
+          "idempotencyKeyAccepted": {
+            "type": "boolean",
+            "description": "Whether `idempotencyKey` is also a Spark payment id. False when the send had a token leg — looking a payment up by the key would then return nothing, which read as evidence would say the sweep never happened."
+          },
+          "sourceTokenIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "sourceAmountBaseUnits": {
+            "type": "string",
+            "nullable": true,
+            "description": "The amount sent in the source token's base units, as a decimal string."
+          },
+          "estimatedOutBaseUnits": {
+            "type": "string",
+            "nullable": true
+          },
+          "deliveredAmountBaseUnits": {
+            "type": "string",
+            "nullable": true,
+            "description": "What actually arrived, in destination-asset base units. Null until the provider reports delivery — which arrives through **no event**."
+          },
+          "delivered": {
+            "type": "string",
+            "nullable": true,
+            "description": "What arrived, or is expected to, as a readable quantity with its asset."
+          },
+          "conversionStatus": {
+            "$ref": "#/components/schemas/SparkConversionStatus"
+          }
+        }
+      },
+      "SparkSweepRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Deliberately carries no amount or fee tier: the engine re-derives those from the store's stored configuration and a live quote, so a request cannot change what a merchant's sweep costs. Destination and force are opt-in overrides: omit them to use the store's configured destination and minimum sweep amount.",
+        "properties": {
+          "preview": {
+            "type": "boolean",
+            "description": "True to quote the sweep without sending it. A dry run reserves no address and writes no record.",
+            "default": false
+          },
+          "force": {
+            "default": false,
+            "description": "True to send the sweep even if the balance is below the configured minimum sweep amount. The absolute on-chain protocol minimum still applies.",
+            "type": "boolean"
+          },
+          "destinationAddress": {
+            "description": "A Bitcoin address to send this sweep to, overriding the store's configured sweep destination. Must be a valid address on the server's chain. Not supported for EVM cross-chain sweeps.",
+            "nullable": true,
+            "type": "string"
+          }
+        }
+      },
+      "SparkSweepResultData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "outcome": {
+            "$ref": "#/components/schemas/SparkSweepOutcomeKind"
+          },
+          "succeeded": {
+            "type": "boolean",
+            "description": "True exactly when `outcome` is `Swept`."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Always set, always fit for a merchant to read."
+          },
+          "refusalCode": {
+            "$ref": "#/components/schemas/SparkSweepRefusalCode"
+          },
+          "record": {
+            "nullable": true,
+            "description": "The record this pass created or resolved. Null for a `Skipped` outcome, where nothing happened and nothing is written.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SparkSweepRecordData"
+              }
+            ]
+          }
+        }
+      },
+      "SparkSweepPreviewData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "canSweep": {
+            "type": "boolean",
+            "description": "True when the engine would proceed. False means `refusalReason` is set."
+          },
+          "refusalReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "balanceSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Spark balance the plan was made from, after an explicit sync."
+          },
+          "sweepableSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Balance minus the configured reserve, whether or not it is worth sweeping."
+          },
+          "amountSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Amount that would be asked of the SDK. Null when there would be no sweep."
+          },
+          "recipientAmountSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "What the destination would receive at the store's chosen tier."
+          },
+          "destination": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SparkSweepDestinationData"
+              }
+            ]
+          },
+          "quote": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SparkSweepQuoteData"
+              }
+            ]
+          },
+          "settings": {
+            "$ref": "#/components/schemas/SparkSweepSettings"
+          },
+          "crossChainQuote": {
+            "$ref": "#/components/schemas/SparkCrossChainQuoteData"
+          },
+          "amount": {
+            "type": "string",
+            "nullable": true,
+            "description": "What would be sent, rendered with its own unit. Read this rather than `amountSats` when Stable Balance may be on."
+          }
+        }
+      },
+      "SparkSweepDestinationData": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/SparkSweepDestinationMode"
+          },
+          "rotates": {
+            "type": "boolean",
+            "description": "True when a real sweep would reserve a fresh address rather than reuse this one."
+          }
+        }
+      },
+      "SparkSweepQuoteData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "A live cooperative-exit quote. **An estimate**: it expires in about a minute, and a real sweep re-quotes and re-checks the fee ceiling against the number it commits to.",
+        "properties": {
+          "feeSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "The fee at the tier the store's configuration selects."
+          },
+          "feesIncluded": {
+            "type": "boolean"
+          },
+          "totalDebitedSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "What would leave the Spark balance in total."
+          },
+          "feePercentOfRecipientAmount": {
+            "type": "number",
+            "format": "double",
+            "description": "The fee as a percentage of what the destination receives — the number that makes a flat exit fee honest."
+          },
+          "slowFeeSats": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "mediumFeeSats": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "fastFeeSats": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "SparkSeedSource": {
+        "type": "string",
+        "description": "Where a store's Spark seed came from. Reusing the on-chain hot-wallet seed means one compromise reaches both balances, and the Spark identity pubkey publicly links them.",
+        "enum": [
+          "Generated",
+          "Imported",
+          "HotWallet"
+        ]
+      },
+      "SparkLightningWiringState": {
+        "type": "string",
+        "description": "What a store's Lightning payment method points at. `StaleSpark` is this store's Spark wallet under a superseded payment key — still ours, and dead. `OtherStoreSpark` is another store's Spark wallet - refused at save time, and cleared at startup with the victim's payment key rotated.",
+        "enum": [
+          "StoreNotFound",
+          "NotConfigured",
+          "InternalNode",
+          "OtherNode",
+          "Spark",
+          "StaleSpark",
+          "OtherStoreSpark"
+        ]
+      },
+      "SparkSweepDestinationMode": {
+        "type": "string",
+        "description": "`StoreWallet` takes a fresh, labelled address from the store's BTC derivation scheme and rotates it every sweep. `StaticAddress` uses one fixed address, for stores with no on-chain BTCPay wallet. `EvmAddress` delivers a stablecoin to an address on an EVM chain through a bridge provider; mainnet only, because Spark refuses to start a wallet configured for cross-chain sending on any other network.",
+        "enum": [
+          "StoreWallet",
+          "StaticAddress",
+          "EvmAddress"
+        ]
+      },
+      "SparkSweepConfirmationSpeed": {
+        "type": "string",
+        "description": "Which of the SDK's three cooperative-exit fee tiers to use.",
+        "enum": [
+          "Slow",
+          "Medium",
+          "Fast"
+        ]
+      },
+      "SparkSweepAddressStatus": {
+        "type": "string",
+        "description": "Whether the store has an on-chain BTCPay wallet to sweep into.",
+        "enum": [
+          "Available",
+          "NoOnchainWallet",
+          "Unavailable"
+        ]
+      },
+      "SparkSweepTrigger": {
+        "type": "string",
+        "description": "What set a sweep in motion. Both run the identical engine path.",
+        "enum": [
+          "Automatic",
+          "Manual"
+        ]
+      },
+      "SparkSweepRecordStatus": {
+        "type": "string",
+        "description": "`Pending` means the outcome is not yet known and is resolved against the SDK rather than by retrying blind. `Refused` means the plugin declined and nothing was sent.",
+        "enum": [
+          "Pending",
+          "Sent",
+          "Confirmed",
+          "Failed",
+          "Refused"
+        ]
+      },
+      "SparkSweepOutcomeKind": {
+        "type": "string",
+        "description": "What one pass of the sweep engine did. Only `Swept` means a cooperative exit was accepted. `Unresolved` means the send's fate is unknown and nothing further will be sent until the SDK answers.",
+        "enum": [
+          "Swept",
+          "InFlight",
+          "Skipped",
+          "Refused",
+          "Failed",
+          "Unresolved"
+        ]
+      },
+      "SparkSweepRefusalCode": {
+        "type": "string",
+        "description": "The stable identity of a reason the plugin declined to sweep. Use this rather than the message, which embeds live figures.",
+        "enum": [
+          "None",
+          "WalletNotRunning",
+          "BalanceUnreadable",
+          "NothingAboveReserve",
+          "BelowMinimumSweep",
+          "NoDestination",
+          "QuoteFailed",
+          "InsufficientFunds",
+          "BelowDustFloor",
+          "ReserveBelowFee",
+          "FeeAboveLimit",
+          "CrossChainUnavailable",
+          "NoCrossChainRoute",
+          "CrossChainOverpayExceedsBalance",
+          "StableBalanceHoldsTheFunds",
+          "CrossChainQuoteUnusable",
+          "CrossChainValueUnverifiable"
+        ]
+      },
+      "SparkDepositData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "The store's on-chain deposit address and everything sent to it that has not been credited.",
+        "properties": {
+          "address": {
+            "type": "string",
+            "nullable": true,
+            "description": "The static Bitcoin deposit address, or null when it could not be read. Stable across calls and safe to save."
+          },
+          "addressError": {
+            "type": "string",
+            "nullable": true,
+            "description": "Why the address could not be read."
+          },
+          "walletRunning": {
+            "type": "boolean"
+          },
+          "deposits": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SparkDepositEntryData"
+            },
+            "description": "Unclaimed deposits. Entries with `needsAttention` true are stuck and will never arrive without a claim."
+          },
+          "recommendedFees": {
+            "$ref": "#/components/schemas/SparkRecommendedFeesData"
+          },
+          "claimFeeLeewaySatPerVbyte": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Headroom over the network-recommended rate that automatic claims are allowed, after clamping to the plugin's maximum of 100. The plugin configures Spark's ceiling as 'network-recommended plus this', never as a fixed rate — Spark's own default is a fixed 1 sat/vB, below the mainnet floor essentially always. Read-only: there is no endpoint that sets it, and a rate is the only bound on an automatic claim, since Spark offers no cap relative to the size of the deposit."
+          },
+          "maxManualClaimFeeSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Ceiling on a manual claim, in satoshi. Read-only: there is no endpoint that sets it."
+          },
+          "claimPolicyLooksTooLow": {
+            "type": "boolean",
+            "description": "True when the configured ceiling already looks too low for the current fee market, so a deposit arriving now may not be claimed automatically."
+          }
+        }
+      },
+      "SparkDepositEntryData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "One on-chain deposit Spark knows about and has not credited.",
+        "properties": {
+          "txId": {
+            "type": "string"
+          },
+          "vout": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "amountSats": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isMature": {
+            "type": "boolean",
+            "description": "False while the deposit is still waiting for its third confirmation. Nothing needs doing."
+          },
+          "needsAttention": {
+            "type": "boolean",
+            "description": "True when the deposit has matured and its claim failed. Spark will not retry it."
+          },
+          "claimError": {
+            "type": "string",
+            "nullable": true,
+            "description": "Why the claim failed."
+          },
+          "requiredFeeSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "What the claim would actually cost. The value the claim endpoint uses when none is supplied."
+          },
+          "requiredFeeRateSatPerVbyte": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          }
+        }
+      },
+      "SparkRecommendedFeesData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Mempool fee rates in sat/vB.",
+        "properties": {
+          "fastestFee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "halfHourFee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "hourFee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "economyFee": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "minimumFee": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "SparkClaimDepositRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Which deposit to claim, and at what ceiling.",
+        "properties": {
+          "txId": {
+            "type": "string",
+            "nullable": true,
+            "description": "Transaction id of the deposit, as reported by the deposit endpoint."
+          },
+          "vout": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Output index of the deposit."
+          },
+          "maxFeeSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Ceiling for this claim, in satoshi. Omit to use the fee Spark said the claim needs — the right answer almost always. No value lifts the backstop that refuses to spend more than half a deposit on claiming it."
+          }
+        }
+      },
+      "SparkClaimDepositResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "The plugin's decision about a manual claim. Only `Claimed` broadcast anything.",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/SparkClaimStatus"
+          },
+          "succeeded": {
+            "type": "boolean",
+            "description": "True exactly when `status` is `Claimed`."
+          },
+          "message": {
+            "type": "string",
+            "description": "Always set, always fit for a merchant to read."
+          },
+          "feeSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "The ceiling the claim was issued at."
+          }
+        }
+      },
+      "SparkStableBalanceData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "The store's Stable Balance configuration and what its wallet is actually doing.",
+        "properties": {
+          "desiredActive": {
+            "type": "boolean",
+            "description": "What the store asked for."
+          },
+          "activeLabel": {
+            "type": "string",
+            "nullable": true,
+            "description": "The label the wallet reports as active, or null when stable balance is off there. **This, not `desiredActive`, is what the wallet is doing.**"
+          },
+          "needsReapply": {
+            "type": "boolean",
+            "description": "True when the setting and the wallet disagree. Reported rather than reconciled, because converging them converts the balance."
+          },
+          "available": {
+            "type": "boolean",
+            "description": "False on any network but mainnet, where the feature cannot work at all."
+          },
+          "walletRunning": {
+            "type": "boolean"
+          },
+          "walletError": {
+            "type": "string",
+            "nullable": true
+          },
+          "balance": {
+            "$ref": "#/components/schemas/SparkTokenBalanceData"
+          },
+          "conversionMinimumSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Spark's own floor on a Bitcoin-to-token conversion. A configured `autoConvertThresholdSats` below this is clamped *up* to it rather than honoured."
+          },
+          "settings": {
+            "$ref": "#/components/schemas/StableBalanceInput"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true,
+            "description": "What the last write did, when this is a write's response."
+          }
+        }
+      },
+      "SparkTokenBalanceData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "A token balance the wallet holds.",
+        "properties": {
+          "identifier": {
+            "type": "string"
+          },
+          "ticker": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "baseUnits": {
+            "type": "string",
+            "description": "**Base units as a decimal string, not satoshi and not a quantity.** $35.60 of a 6-decimal token is `\"35600000\"`. A string because the value is a u128 and an 18-decimal token overflows every JSON number a client is likely to parse it into."
+          },
+          "amount": {
+            "type": "string",
+            "description": "The same figure as a human-readable quantity, e.g. `35.6`."
+          },
+          "decimals": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "isFreezable": {
+            "type": "boolean",
+            "description": "Whether the issuer can freeze this balance. **True for USDB.** The counterparty risk a merchant accepts by holding one."
+          }
+        }
+      },
+      "StableBalanceInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "A store's Stable Balance configuration. A `PUT` replaces the whole thing.",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the store wants its balance held in a stablecoin. Changing this converts the balance, in the background, with nothing to report when it finishes."
+          },
+          "disclosureAcknowledged": {
+            "type": "boolean",
+            "description": "Confirmation that the freezable-issuer warning has been read. **Required to enable.**"
+          },
+          "tokenIdentifier": {
+            "type": "string",
+            "nullable": true,
+            "description": "The token identifier. Defaults to mainnet USDB, which the plugin supplies because Spark ships no default for it. Checked against Spark before it is stored."
+          },
+          "label": {
+            "type": "string",
+            "nullable": true,
+            "description": "The label the wallet activates by. An arbitrary display string with no protocol meaning — not a ticker and not the identifier."
+          },
+          "maxSlippageBps": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Conversion slippage tolerance in basis points; Spark's own default is 10. A *different* setting from the cross-chain slippage on the sweep configuration, which defaults to 100 if unset."
+          },
+          "autoConvertThresholdSats": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "description": "Balance at which Spark auto-converts. Null leaves Spark's own minimum in force; a value below that minimum is raised to it rather than honoured."
+          }
+        }
+      },
+      "SparkCrossChainQuoteData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "A live cross-chain quote. **An estimate**: it expires in about a minute, and a real sweep re-quotes and re-checks the fee ceiling against the number it commits to. There is **no arrival estimate** — Spark exposes none, so nothing here can offer one.",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "Which bridge provider would carry it, e.g. `Orchestra`."
+          },
+          "chain": {
+            "type": "string"
+          },
+          "chainId": {
+            "type": "string",
+            "nullable": true
+          },
+          "asset": {
+            "type": "string"
+          },
+          "assetDecimals": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Read from the route rather than assumed: 6 on every Orchestra USDT route except BSC, which is 18."
+          },
+          "amountInSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "**Larger than the amount being sent.** The provider overpays the source leg to absorb its fee and slippage, so a sweep sized to exactly the sweepable balance cannot be funded. The pad is not derivable from a slippage setting; read it here."
+          },
+          "assetAmountIn": {
+            "type": "string",
+            "description": "Gross destination-asset base units, as a decimal string."
+          },
+          "estimatedOut": {
+            "type": "string",
+            "description": "Destination-asset base units expected to arrive, as a decimal string."
+          },
+          "estimatedOutAmount": {
+            "type": "string",
+            "description": "The same figure as a readable quantity with its asset."
+          },
+          "feeAmount": {
+            "type": "string",
+            "description": "In **destination-asset base units**, not satoshi."
+          },
+          "serviceFeeAmount": {
+            "type": "string",
+            "description": "In `serviceFeeAsset`'s base units — which may be a *third* asset again; USDC was observed on a USDT route. Do not add this to `feeAmount`."
+          },
+          "serviceFeeAsset": {
+            "type": "string",
+            "nullable": true
+          },
+          "sourceTransferFeeSats": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "providerQuoteId": {
+            "type": "string",
+            "nullable": true,
+            "description": "The provider's own quote id, persisted before the send. On a sweep funded from a stablecoin balance this is the only thing that identifies the send afterwards."
+          }
+        }
+      },
+      "SparkClaimStatus": {
+        "type": "string",
+        "description": "`Claimed` broadcast a claim. `Refused` means the plugin declined and spent nothing. `Failed` means Spark attempted it and reported an error. `Unavailable` means the store has no running wallet.",
+        "enum": [
+          "Claimed",
+          "Unavailable",
+          "Refused",
+          "Failed"
+        ]
+      },
+      "SparkConversionStatus": {
+        "type": "string",
+        "description": "How far a bridge provider or conversion has got. **No SDK event reports any transition here** — every value is discovered by polling. `RefundNeeded` is the one that needs a human: Spark is holding funds it could not convert, and the plugin requests a refund on the next sweep pass.",
+        "enum": [
+          "Pending",
+          "Completed",
+          "Failed",
+          "RefundNeeded",
+          "Refunded",
+          "Unknown"
+        ]
+      },
+      "SparkSweepDestinationKind": {
+        "type": "string",
+        "description": "Which rail a sweep used. `BitcoinAddress` is a cooperative exit; `EvmAddress` is a cross-chain send through a bridge provider — still an ordinary Spark transfer at the point money leaves the wallet, so there is no unilateral exit either way.",
+        "enum": [
+          "BitcoinAddress",
+          "EvmAddress"
+        ]
+      },
+      "SparkBalanceSyncData": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "The Spark balance after a forced wallet sync.",
+        "properties": {
+          "walletRunning": {
+            "type": "boolean",
+            "description": "Whether a Spark wallet is live for this store."
+          },
+          "balanceSats": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Spark balance in satoshi after forcing a wallet sync. Zero when the wallet is not running."
+          },
+          "syncedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When the sync was performed, UTC."
+          }
+        }
+      }
+    }
+  }
 }

--- a/BTCPayServer.Plugins.Flint/Services/SparkPluginUpdateChecker.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkPluginUpdateChecker.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Abstractions.Contracts;
+using BTCPayServer.HostedServices;
+using BTCPayServer.Plugins;
+using BTCPayServer.Services;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+public class SparkPluginUpdateChecker(
+    SettingsRepository settingsRepository,
+    PluginService pluginService,
+    IHttpClientFactory httpClientFactory,
+    ILogger<SparkPluginUpdateChecker> logger) : IPeriodicTask
+{
+    internal const string HttpClientName = "SparkPluginUpdate";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public async Task Do(CancellationToken cancellationToken)
+    {
+        var settings = await settingsRepository
+            .GetSettingAsync<SparkServerSettings>()
+            .ConfigureAwait(false) ?? new SparkServerSettings();
+
+        if (string.IsNullOrWhiteSpace(settings.UpdateWebhookUrl))
+            return;
+
+        if (!pluginService.Installed.TryGetValue(Constants.PluginIdentifier, out var installedVersion))
+        {
+            logger.LogDebug("Flint: not found in installed plugins; skipping update check");
+            return;
+        }
+
+        Version? latestRemote = null;
+        try
+        {
+            var remotePlugins = await pluginService
+                .GetRemotePlugins(Constants.PluginIdentifier, cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var plugin in remotePlugins)
+            {
+                if (string.Equals(plugin.Identifier, Constants.PluginIdentifier, StringComparison.OrdinalIgnoreCase)
+                    && (latestRemote is null || plugin.Version > latestRemote))
+                {
+                    latestRemote = plugin.Version;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Flint: could not fetch remote plugin versions; skipping update check");
+            return;
+        }
+
+        if (latestRemote is null || latestRemote <= installedVersion)
+            return;
+
+        var availableVersionStr = latestRemote.ToString();
+        if (availableVersionStr == settings.LastNotifiedUpdateVersion)
+            return;
+
+        if (!Uri.TryCreate(settings.UpdateWebhookUrl, UriKind.Absolute, out var uri)
+            || uri.Scheme is not ("http" or "https"))
+        {
+            logger.LogWarning(
+                "Flint: update webhook URL '{Url}' is not a valid http/https URL; notification skipped",
+                settings.UpdateWebhookUrl);
+            return;
+        }
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            @event = "plugin.update-available",
+            pluginIdentifier = Constants.PluginIdentifier,
+            installedVersion = installedVersion.ToString(),
+            availableVersion = availableVersionStr
+        }, SerializerOptions);
+
+        try
+        {
+            using var client = httpClientFactory.CreateClient(HttpClientName);
+            using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+            using var response = await client.PostAsync(uri, content, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning("Flint: update webhook returned {Status}", (int)response.StatusCode);
+                return;
+            }
+
+            logger.LogInformation("Flint: notified update webhook of version {Version}", availableVersionStr);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Flint: update webhook delivery failed");
+            return;
+        }
+
+        settings.LastNotifiedUpdateVersion = availableVersionStr;
+        await settingsRepository.UpdateSetting(settings).ConfigureAwait(false);
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
@@ -275,15 +275,20 @@ public sealed class SparkSweepEngine
         {
             var result = await RunGuardedAsync(storeId, trigger, cancellationToken).ConfigureAwait(false);
 
-            if (result.Kind is SweepOutcomeKind.Swept
-                && result.Record is { } record
-                && _webhookNotifier is { } notifier)
+            if (_webhookNotifier is { } notifier)
             {
                 var stored = await _settingsStore.GetAsync(storeId).ConfigureAwait(false);
                 var webhookUrl = stored?.Sweep?.SweepWebhookUrl;
                 if (!string.IsNullOrWhiteSpace(webhookUrl))
-                    await notifier.NotifyAsync(webhookUrl, storeId, record, cancellationToken)
-                        .ConfigureAwait(false);
+                {
+                    if (result.Kind is SweepOutcomeKind.Swept && result.Record is { } record)
+                        await notifier.NotifyAsync(webhookUrl, storeId, record, cancellationToken)
+                            .ConfigureAwait(false);
+                    else if (result.Kind is SweepOutcomeKind.Failed)
+                        await notifier.NotifyFailureAsync(
+                                webhookUrl, storeId, trigger, result.Reason, result.Record, cancellationToken)
+                            .ConfigureAwait(false);
+                }
             }
 
             return result;

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
@@ -220,6 +220,7 @@ public sealed class SparkSweepEngine
     private readonly ICrossChainValueOracle _valueOracle;
     private readonly TimeProvider _timeProvider;
     private readonly ISweepTransactionLabeler _transactionLabeler;
+    private readonly SparkSweepWebhookNotifier? _webhookNotifier;
     private readonly ILogger<SparkSweepEngine> _logger;
 
     /// <summary>
@@ -237,7 +238,8 @@ public sealed class SparkSweepEngine
         ICrossChainValueOracle valueOracle,
         ISweepTransactionLabeler transactionLabeler,
         TimeProvider timeProvider,
-        ILogger<SparkSweepEngine> logger)
+        ILogger<SparkSweepEngine> logger,
+        SparkSweepWebhookNotifier? webhookNotifier = null)
     {
         _settingsStore = settingsStore;
         _runtime = runtime;
@@ -247,6 +249,7 @@ public sealed class SparkSweepEngine
         _valueOracle = valueOracle;
         _transactionLabeler = transactionLabeler;
         _timeProvider = timeProvider;
+        _webhookNotifier = webhookNotifier;
         _logger = logger;
     }
 
@@ -270,7 +273,20 @@ public sealed class SparkSweepEngine
 
         try
         {
-            return await RunGuardedAsync(storeId, trigger, cancellationToken).ConfigureAwait(false);
+            var result = await RunGuardedAsync(storeId, trigger, cancellationToken).ConfigureAwait(false);
+
+            if (result.Kind is SweepOutcomeKind.Swept
+                && result.Record is { } record
+                && _webhookNotifier is { } notifier)
+            {
+                var stored = await _settingsStore.GetAsync(storeId).ConfigureAwait(false);
+                var webhookUrl = stored?.Sweep?.SweepWebhookUrl;
+                if (!string.IsNullOrWhiteSpace(webhookUrl))
+                    await notifier.NotifyAsync(webhookUrl, storeId, record, cancellationToken)
+                        .ConfigureAwait(false);
+            }
+
+            return result;
         }
         finally
         {

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepEngine.cs
@@ -259,6 +259,8 @@ public sealed class SparkSweepEngine
     public async Task<SweepRunResult> RunAsync(
         string storeId,
         SweepTrigger trigger,
+        bool force = false,
+        string? destinationOverride = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(storeId);
@@ -273,7 +275,7 @@ public sealed class SparkSweepEngine
 
         try
         {
-            var result = await RunGuardedAsync(storeId, trigger, cancellationToken).ConfigureAwait(false);
+            var result = await RunGuardedAsync(storeId, trigger, force, destinationOverride, cancellationToken).ConfigureAwait(false);
 
             if (_webhookNotifier is { } notifier)
             {
@@ -452,6 +454,8 @@ public sealed class SparkSweepEngine
     private async Task<SweepRunResult> RunGuardedAsync(
         string storeId,
         SweepTrigger trigger,
+        bool force,
+        string? destinationOverride,
         CancellationToken cancellationToken)
     {
         var settings = await _settingsStore.GetAsync(storeId).ConfigureAwait(false);
@@ -526,11 +530,23 @@ public sealed class SparkSweepEngine
         // decides which rail the sweep runs on and therefore which unit everything below is in.
         var stableToken = ResolveStableToken(settings, info);
 
+        if (destinationOverride is not null && sweep.DestinationMode is SweepDestinationMode.EvmAddress)
+        {
+            return await RefuseAsync(
+                    storeId, trigger, sweep,
+                    new SweepRefusal(
+                        SweepRefusalCode.NoDestination,
+                        "A destination address override is not supported for EVM cross-chain sweeps. "
+                        + "Change the store's sweep destination mode to Bitcoin first."),
+                    null, balance, 0, 0, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         if (sweep.DestinationMode is SweepDestinationMode.EvmAddress)
         {
             // A different rail with different arithmetic and, when funded from a token, a different unit and no
             // idempotency key. Branched before the sats plan is made rather than after, because a sats plan is
-            // not merely unnecessary on that path — it is denominated in the wrong thing.
+            // not merely unnecessary on that path - it is denominated in the wrong thing.
             return await RunCrossChainAsync(
                     storeId, sdk, trigger, sweep, balance, stableToken, cancellationToken)
                 .ConfigureAwait(false);
@@ -551,6 +567,17 @@ public sealed class SparkSweepEngine
 
         // Step 4.
         var plan = PlanSweep(sweep, balance);
+
+        if (force
+            && plan.Refusal?.Code is SweepRefusalCode.BelowMinimumSweep
+            && plan.SweepableSats >= Constants.MinimumOnchainSendSats)
+        {
+            _logger.LogInformation(
+                "Store {StoreId}: force flag set; sweeping {AmountSats} sat below the configured minimum",
+                storeId, plan.SweepableSats);
+            plan = SweepPlan.Sweep(plan.SweepableSats);
+        }
+
         if (plan.Refusal is { } planRefusal)
         {
             // The one interaction between the two post-MVP features that would otherwise look like a bug. With
@@ -574,19 +601,32 @@ public sealed class SparkSweepEngine
                 .ConfigureAwait(false);
         }
 
-        // reserve: true — this is a real sweep, so the address is reserved and labelled, and therefore rotated.
-        var resolution = await _destinations
-            .ResolveAsync(storeId, sweep, reserve: true, cancellationToken)
-            .ConfigureAwait(false);
-        if (resolution.Destination is not { } destination)
+        SweepDestination destination;
+        if (destinationOverride is not null)
         {
-            return await RefuseAsync(
-                    storeId, trigger, sweep,
-                    new SweepRefusal(
-                        SweepRefusalCode.NoDestination,
-                        resolution.RefusalReason ?? "This store has no usable sweep destination."),
-                    null, balance, plan.AmountSats, 0, cancellationToken)
+            destination = new SweepDestination(
+                destinationOverride,
+                SweepDestinationMode.StaticAddress,
+                SweepDestinationKind.BitcoinAddress,
+                Rotates: false);
+        }
+        else
+        {
+            // reserve: true - this is a real sweep, so the address is reserved and labelled, and therefore rotated.
+            var resolution = await _destinations
+                .ResolveAsync(storeId, sweep, reserve: true, cancellationToken)
                 .ConfigureAwait(false);
+            if (resolution.Destination is not { } resolved)
+            {
+                return await RefuseAsync(
+                        storeId, trigger, sweep,
+                        new SweepRefusal(
+                            SweepRefusalCode.NoDestination,
+                            resolution.RefusalReason ?? "This store has no usable sweep destination."),
+                        null, balance, plan.AmountSats, 0, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            destination = resolved;
         }
 
         // Step 5. A pre-flight quote, so an economic or dust refusal is decided before a record exists — which is

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepSettingsService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepSettingsService.cs
@@ -223,6 +223,17 @@ public sealed class SparkSweepSettingsService
         return new SparkSweepHistoryPage(records, total, skip, count);
     }
 
+    /// <summary>One sweep record for this store, or null when no row matches the key.</summary>
+    public async Task<SweepRecord?> ReadRecordAsync(
+        string storeId,
+        string idempotencyKey,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(storeId);
+        ArgumentException.ThrowIfNullOrEmpty(idempotencyKey);
+        return await _records.GetAsync(storeId, idempotencyKey, cancellationToken).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Validates <paramref name="input"/> and, if it passes, stores it as the store's sweep configuration.
     /// </summary>

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepWebhookNotifier.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepWebhookNotifier.cs
@@ -57,17 +57,12 @@ public class SparkSweepWebhookNotifier
         SweepRecord record,
         CancellationToken cancellationToken = default)
     {
-        if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out var uri)
-            || uri.Scheme is not ("http" or "https"))
-        {
-            _logger.LogWarning(
-                "Store {StoreId}: sweep webhook URL '{Url}' is not a valid http/https URL; notification skipped",
-                storeId, webhookUrl);
+        if (!TryParseUrl(webhookUrl, storeId, out var uri))
             return;
-        }
 
         var json = JsonSerializer.Serialize(new
         {
+            @event = "sweep.swept",
             storeId,
             idempotencyKey = record.IdempotencyKey,
             txId = record.TxId,
@@ -79,6 +74,55 @@ public class SparkSweepWebhookNotifier
             completedAt = record.CompletedAt
         }, SerializerOptions);
 
+        await PostWithRetryAsync(uri!, webhookUrl, storeId, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task NotifyFailureAsync(
+        string webhookUrl,
+        string storeId,
+        SweepTrigger trigger,
+        string reason,
+        SweepRecord? record,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryParseUrl(webhookUrl, storeId, out var uri))
+            return;
+
+        var json = JsonSerializer.Serialize(new
+        {
+            @event = "sweep.failed",
+            storeId,
+            trigger = trigger.ToString(),
+            reason,
+            idempotencyKey = record?.IdempotencyKey,
+            amountSats = record?.AmountSats,
+            destination = record?.DestinationAddress,
+            destinationMode = record?.DestinationMode.ToString()
+        }, SerializerOptions);
+
+        await PostWithRetryAsync(uri!, webhookUrl, storeId, json, cancellationToken).ConfigureAwait(false);
+    }
+
+    private bool TryParseUrl(string webhookUrl, string storeId, out Uri? uri)
+    {
+        if (Uri.TryCreate(webhookUrl, UriKind.Absolute, out uri)
+            && uri.Scheme is "http" or "https")
+            return true;
+
+        _logger.LogWarning(
+            "Store {StoreId}: sweep webhook URL '{Url}' is not a valid http/https URL; notification skipped",
+            storeId, webhookUrl);
+        uri = null;
+        return false;
+    }
+
+    private async Task PostWithRetryAsync(
+        Uri uri,
+        string webhookUrl,
+        string storeId,
+        string json,
+        CancellationToken cancellationToken)
+    {
         for (var attempt = 1; attempt <= MaxAttempts; attempt++)
         {
             try

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepWebhookNotifier.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepWebhookNotifier.cs
@@ -13,12 +13,24 @@ namespace BTCPayServer.Plugins.Flint.Services;
 /// Delivers a webhook POST after each successful sweep.
 /// </summary>
 /// <remarks>
-/// Failures are logged as warnings and never retried. The sweep record in the database is the
-/// authoritative source of truth; the webhook is a convenience notification only.
+/// Transient failures (network errors and 5xx responses) are retried with exponential backoff:
+/// up to <see cref="MaxAttempts"/> total attempts spaced 2 s, 4 s, 8 s apart.
+/// Client errors (4xx) are not retried - they are permanent and will not resolve on their own.
+/// The sweep record in the database is the authoritative source of truth; the webhook is a
+/// convenience notification only, so a delivery failure never blocks or rolls back the sweep.
+///
 /// </remarks>
 public class SparkSweepWebhookNotifier
 {
     public const string HttpClientName = "SparkSweepWebhook";
+    public const int MaxAttempts = 4; // 1 initial + 3 retries
+
+    internal static readonly TimeSpan[] DefaultRetryDelays =
+    [
+        TimeSpan.FromSeconds(2),
+        TimeSpan.FromSeconds(4),
+        TimeSpan.FromSeconds(8),
+    ];
 
     private static readonly JsonSerializerOptions SerializerOptions = new()
     {
@@ -27,13 +39,16 @@ public class SparkSweepWebhookNotifier
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<SparkSweepWebhookNotifier> _logger;
+    private readonly TimeSpan[] _retryDelays;
 
     public SparkSweepWebhookNotifier(
         IHttpClientFactory httpClientFactory,
-        ILogger<SparkSweepWebhookNotifier> logger)
+        ILogger<SparkSweepWebhookNotifier> logger,
+        TimeSpan[]? retryDelays = null)
     {
         _httpClientFactory = httpClientFactory;
         _logger = logger;
+        _retryDelays = retryDelays ?? DefaultRetryDelays;
     }
 
     public async Task NotifyAsync(
@@ -51,7 +66,7 @@ public class SparkSweepWebhookNotifier
             return;
         }
 
-        var payload = new
+        var json = JsonSerializer.Serialize(new
         {
             storeId,
             idempotencyKey = record.IdempotencyKey,
@@ -62,29 +77,47 @@ public class SparkSweepWebhookNotifier
             destinationMode = record.DestinationMode.ToString(),
             trigger = record.Trigger.ToString(),
             completedAt = record.CompletedAt
-        };
+        }, SerializerOptions);
 
-        try
+        for (var attempt = 1; attempt <= MaxAttempts; attempt++)
         {
-            using var client = _httpClientFactory.CreateClient(HttpClientName);
-            using var content = new StringContent(
-                JsonSerializer.Serialize(payload, SerializerOptions),
-                Encoding.UTF8,
-                "application/json");
-            using var response = await client.PostAsync(uri, content, cancellationToken).ConfigureAwait(false);
-
-            if (!response.IsSuccessStatusCode)
+            try
             {
+                using var client = _httpClientFactory.CreateClient(HttpClientName);
+                using var content = new StringContent(json, Encoding.UTF8, "application/json");
+                using var response = await client.PostAsync(uri, content, cancellationToken).ConfigureAwait(false);
+
+                if (response.IsSuccessStatusCode)
+                    return;
+
+                var status = (int)response.StatusCode;
+
+                // 4xx errors are permanent: the endpoint rejected the request and a retry will not help.
+                if (status is >= 400 and < 500)
+                {
+                    _logger.LogWarning(
+                        "Store {StoreId}: sweep webhook returned {StatusCode} (client error); not retrying",
+                        storeId, status);
+                    return;
+                }
+
                 _logger.LogWarning(
-                    "Store {StoreId}: sweep webhook returned {StatusCode}; notification not acknowledged",
-                    storeId, (int)response.StatusCode);
+                    "Store {StoreId}: sweep webhook attempt {Attempt}/{Max} returned {StatusCode}",
+                    storeId, attempt, MaxAttempts, status);
             }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex,
+                    "Store {StoreId}: sweep webhook delivery attempt {Attempt}/{Max} to '{Url}' failed",
+                    storeId, attempt, MaxAttempts, webhookUrl);
+            }
+
+            if (attempt < MaxAttempts)
+                await Task.Delay(_retryDelays[attempt - 1], cancellationToken).ConfigureAwait(false);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogWarning(ex,
-                "Store {StoreId}: sweep webhook delivery to '{Url}' failed",
-                storeId, webhookUrl);
-        }
+
+        _logger.LogWarning(
+            "Store {StoreId}: sweep webhook delivery to '{Url}' failed after {Max} attempts; giving up",
+            storeId, webhookUrl, MaxAttempts);
     }
 }

--- a/BTCPayServer.Plugins.Flint/Services/SparkSweepWebhookNotifier.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSweepWebhookNotifier.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Plugins.Flint.Data;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>
+/// Delivers a webhook POST after each successful sweep.
+/// </summary>
+/// <remarks>
+/// Failures are logged as warnings and never retried. The sweep record in the database is the
+/// authoritative source of truth; the webhook is a convenience notification only.
+/// </remarks>
+public class SparkSweepWebhookNotifier
+{
+    public const string HttpClientName = "SparkSweepWebhook";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<SparkSweepWebhookNotifier> _logger;
+
+    public SparkSweepWebhookNotifier(
+        IHttpClientFactory httpClientFactory,
+        ILogger<SparkSweepWebhookNotifier> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task NotifyAsync(
+        string webhookUrl,
+        string storeId,
+        SweepRecord record,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out var uri)
+            || uri.Scheme is not ("http" or "https"))
+        {
+            _logger.LogWarning(
+                "Store {StoreId}: sweep webhook URL '{Url}' is not a valid http/https URL; notification skipped",
+                storeId, webhookUrl);
+            return;
+        }
+
+        var payload = new
+        {
+            storeId,
+            idempotencyKey = record.IdempotencyKey,
+            txId = record.TxId,
+            amountSats = record.AmountSats,
+            feeSats = record.FeeSats,
+            destination = record.DestinationAddress,
+            destinationMode = record.DestinationMode.ToString(),
+            trigger = record.Trigger.ToString(),
+            completedAt = record.CompletedAt
+        };
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient(HttpClientName);
+            using var content = new StringContent(
+                JsonSerializer.Serialize(payload, SerializerOptions),
+                Encoding.UTF8,
+                "application/json");
+            using var response = await client.PostAsync(uri, content, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Store {StoreId}: sweep webhook returned {StatusCode}; notification not acknowledged",
+                    storeId, (int)response.StatusCode);
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Store {StoreId}: sweep webhook delivery to '{Url}' failed",
+                storeId, webhookUrl);
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/SweepTask.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SweepTask.cs
@@ -89,7 +89,7 @@ public class SweepTask : IPeriodicTask
     private async Task SweepStoreAsync(string storeId, CancellationToken cancellationToken)
     {
         var result = await _engine
-            .RunAsync(storeId, SweepTrigger.Automatic, cancellationToken)
+            .RunAsync(storeId, SweepTrigger.Automatic, cancellationToken: cancellationToken)
             .ConfigureAwait(false);
 
         // Only the interesting outcomes are logged at Information. A skip is the overwhelmingly common case —

--- a/BTCPayServer.Plugins.Flint/SparkPlugin.cs
+++ b/BTCPayServer.Plugins.Flint/SparkPlugin.cs
@@ -309,6 +309,15 @@ public class SparkPlugin : BaseBTCPayServerPlugin
         // its own. See SparkLightningConfigSweepTask.
         services.AddScheduledTask<SparkLightningConfigSweepTask>(Constants.ConfigSweepInterval);
 
+        // Daily registry check: fires a webhook when a new Flint version appears on the plugin registry.
+        services.AddHttpClient(SparkPluginUpdateChecker.HttpClientName, client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                $"BTCPayServer.Plugins.Flint/{typeof(SparkPlugin).Assembly.GetName().Version}");
+        });
+        services.AddScheduledTask<SparkPluginUpdateChecker>(TimeSpan.FromDays(1));
+
         // UI extension points. Paths are relative to Views/Shared/ and resolved as partials.
         services.AddUIExtension("ln-payment-method-setup-tabhead", "Spark/LNPaymentMethodSetupTabhead");
         services.AddUIExtension("ln-payment-method-setup-tab", "Spark/LNPaymentMethodSetupTab");

--- a/BTCPayServer.Plugins.Flint/SparkPlugin.cs
+++ b/BTCPayServer.Plugins.Flint/SparkPlugin.cs
@@ -231,6 +231,16 @@ public class SparkPlugin : BaseBTCPayServerPlugin
             provider.GetRequiredService<StoreRepository>);
         services.AddSingleton<ICrossChainValueOracle, BTCPayCrossChainValueOracle>();
 
+        // Webhook notifier for post-sweep notifications. Named client so the timeout applies to delivery
+        // alone and does not share the catalogue's socket pool. Failures are logged as warnings.
+        services.AddHttpClient(SparkSweepWebhookNotifier.HttpClientName, client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(10);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(
+                $"BTCPayServer.Plugins.Flint/{typeof(SparkPlugin).Assembly.GetName().Version}");
+        });
+        services.AddSingleton<SparkSweepWebhookNotifier>();
+
         // The sweep engine. One path for automatic and manual sweeps; every economic and safety guard lives here
         // rather than in the controller or the view.
         services.TryAddSingleton(TimeProvider.System);

--- a/BTCPayServer.Plugins.Flint/SparkServerSettings.cs
+++ b/BTCPayServer.Plugins.Flint/SparkServerSettings.cs
@@ -1,0 +1,7 @@
+namespace BTCPayServer.Plugins.Flint;
+
+public class SparkServerSettings
+{
+    public string? UpdateWebhookUrl { get; set; }
+    public string? LastNotifiedUpdateVersion { get; set; }
+}

--- a/BTCPayServer.Plugins.Flint/SparkSettings.cs
+++ b/BTCPayServer.Plugins.Flint/SparkSettings.cs
@@ -663,6 +663,16 @@ public class SweepSettings
     /// </summary>
     public string? StaticAddress { get; set; }
 
+    /// <summary>
+    /// Optional HTTP(S) URL that receives a POST with sweep details after each successful sweep.
+    /// The payload is a JSON object with <c>storeId</c>, <c>idempotencyKey</c>, <c>txId</c>,
+    /// <c>amountSats</c>, <c>feeSats</c>, <c>destination</c>, <c>destinationMode</c>,
+    /// <c>trigger</c>, and <c>completedAt</c>.
+    /// Delivery failures are logged as warnings and never retried; the sweep record is the
+    /// authoritative source of truth.
+    /// </summary>
+    public string? SweepWebhookUrl { get; set; }
+
     #region Cross-chain
 
     /// <summary>
@@ -826,6 +836,7 @@ public class SweepSettings
         EvmChain = EvmChain,
         EvmAsset = EvmAsset,
         CrossChainSlippageBps = CrossChainSlippageBps,
-        CrossChainMinimumStableUnits = CrossChainMinimumStableUnits
+        CrossChainMinimumStableUnits = CrossChainMinimumStableUnits,
+        SweepWebhookUrl = SweepWebhookUrl
     };
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this plugin are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8.0] - 2026-08-24
+
+### Added
+
+- **Plugin update webhook.** A new server-level setting (`PUT /api/v1/server/spark`) accepts an
+  `updateWebhookUrl`. Once set, Flint checks the BTCPay plugin registry daily and POSTs a
+  `plugin.update-available` event payload when a newer version is found. The payload includes
+  `pluginIdentifier`, `installedVersion`, and `availableVersion`. Each available version is
+  notified at most once. Read the current setting with `GET /api/v1/server/spark`. Both endpoints
+  require `canModifyServerSettings`.
+
+
 ## [0.1.7.0] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this plugin are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7.0] - 2026-08-24
+
+### Added
+
+- **GET sweep record by idempotency key.** New endpoint
+  `GET /api/v1/stores/{storeId}/spark/sweep/{idempotencyKey}` returns the full sweep record for a
+  given key. Requires `canViewStoreSettings`. Returns 404 with code `sweep-record-not-found` when no
+  record matches.
+
+- **Destination address override in POST sweep.** The `POST .../spark/sweep` request body now accepts
+  an optional `destinationAddress` field. When supplied, the sweep sends to that Bitcoin address
+  instead of the store's configured sweep destination. The address is validated against the server's
+  chain before the engine runs. Not supported for EVM cross-chain sweep mode (returns 422).
+
+- **Force flag in POST sweep.** The request body now accepts an optional `force` boolean (default
+  false). When true, the sweep proceeds even if the Spark balance is below the store's configured
+  minimum sweep amount. The absolute on-chain protocol minimum (`Constants.MinimumOnchainSendSats`)
+  still applies and cannot be bypassed.
+
+
 ## [0.1.6.2] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this plugin are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6.2] - 2026-08-24
+
+### Added
+
+- **Sweep webhook fires on failed sweeps.** When a sweep is attempted and fails (Spark rejects it or
+  reports it as failed), Flint now POSTs an `event: "sweep.failed"` notification to the configured
+  webhook URL. The payload includes `storeId`, `trigger`, `reason`, and — when a sweep record was
+  created before the failure — `idempotencyKey`, `amountSats`, `destination`, and `destinationMode`.
+  Same retry logic as the success notification (3 retries with exponential backoff).
+
+### Changed
+
+- **Success webhook payload includes `event: "sweep.swept"`.** Added to let receivers distinguish
+  success from failure notifications on the same endpoint without inspecting other fields.
+
+
 ## [0.1.6.1] - 2026-08-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this plugin are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6.1] - 2026-08-24
+
+### Changed
+
+- **Sweep webhook delivery retries on transient failures.** Flint now retries a failed webhook POST up
+  to three times with exponential backoff (2 s, 4 s, 8 s) before giving up. 5xx responses and network
+  errors are retried; 4xx responses are not (they indicate a permanent client-side rejection and will not
+  resolve on their own).
+
 ## [0.1.6.0] - 2026-08-23
 
 ### Added
@@ -16,8 +25,8 @@ All notable changes to this plugin are recorded here. The format follows
 - **Sweep webhook.** Setting `sweepWebhookUrl` in the sweep configuration causes Flint to POST a JSON
   payload to that URL after each successful sweep. The payload includes `storeId`, `idempotencyKey`,
   `txId`, `amountSats`, `feeSats`, `destination`, `destinationMode`, `trigger`, and `completedAt`.
-  Delivery failures are logged as warnings and never retried; the sweep record is the authoritative
-  source. The field is included in `SweepSettings.Clone()` so it survives a seed change.
+  Delivery failures are logged as warnings; the sweep record is the authoritative source. The field is
+  included in `SweepSettings.Clone()` so it survives a seed change.
 - **Sweep configuration warnings.** `GET /api/v1/stores/{storeId}/spark/sweep` now includes a `warnings`
   array. On mainnet, entries appear when the balance threshold or minimum sweep amount are below the
   recommended defaults (which were measured on regtest and may not hold on mainnet).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to this plugin are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6.0] - 2026-08-23
+
+### Added
+
+- **`POST /api/v1/stores/{storeId}/spark/sync` forces a wallet sync and returns the current balance.**
+  The balance returned by other endpoints is read from the SDK cache without forcing a sync and may lag
+  settlement by up to 20 seconds. The new endpoint forces an explicit sync before reading, so the
+  returned `balanceSats` is current at call time. Requires `btcpay.store.canmodifystoresettings`.
+  Response: `{ "walletRunning": bool, "balanceSats": long, "syncedAt": timestamp }`.
+- **Sweep webhook.** Setting `sweepWebhookUrl` in the sweep configuration causes Flint to POST a JSON
+  payload to that URL after each successful sweep. The payload includes `storeId`, `idempotencyKey`,
+  `txId`, `amountSats`, `feeSats`, `destination`, `destinationMode`, `trigger`, and `completedAt`.
+  Delivery failures are logged as warnings and never retried; the sweep record is the authoritative
+  source. The field is included in `SweepSettings.Clone()` so it survives a seed change.
+- **Sweep configuration warnings.** `GET /api/v1/stores/{storeId}/spark/sweep` now includes a `warnings`
+  array. On mainnet, entries appear when the balance threshold or minimum sweep amount are below the
+  recommended defaults (which were measured on regtest and may not hold on mainnet).
+- **`scripts/setup-stores.sh`** - bash script for headless provisioning of one or more stores via the
+  Greenfield API. Saves each store's recovery phrase (optionally GPG-encrypted) immediately on
+  provisioning, since the API returns it exactly once.
+- **`scripts/flint-logrotate.conf`** - logrotate configuration for `sdk.log`. Uses `copytruncate`
+  because the Rust SDK holds the file handle open; a rename-based rotation leaves the SDK writing to
+  the renamed file.
+- **`docs/railway.md`** - deployment guide for Railway: persistent volume requirements, environment
+  variables, log rotation options, and a post-deploy verification script.
 
 ## [1.1.0] — 2026-09-07
 
@@ -237,6 +262,7 @@ lives in the automation that keeps the plugin watching upstream for the right ch
   scrubber's five regex passes run only on lines that will actually be emitted. Lines that are
   emitted scrub exactly as before.
 
+
 ## [1.0.1] — 2026-08-26
 
 ### Changed
@@ -250,6 +276,7 @@ lives in the automation that keeps the plugin watching upstream for the right ch
   stronger warning for a store manager who is not a server admin. The same disclosure is on the
   Greenfield provisioning endpoint and in SECURITY.md, the README trust model and the trust-model
   document.
+
 
 ## [1.0.0] — 2026-08-26
 
@@ -274,6 +301,7 @@ lives in the automation that keeps the plugin watching upstream for the right ch
   the new `DepositInfo` fields are default-off / ignored. Verified on mainnet against a live
   Lightspark service provider on the test servers; the SDK's own storage schema migrates to
   version 40 on startup.
+
 
 ## [0.1.5.5] — 2026-08-25
 
@@ -327,7 +355,7 @@ lives in the automation that keeps the plugin watching upstream for the right ch
   configuration (with the victim's payment key rotated, so previously leaked copies of the victim's
   string stop resolving).
 
-## [0.1.5.2] — 2026-08-22
+## [0.1.5.2] - 2026-08-22
 
 ### Changed
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,8 +21,13 @@ Everything about the plugin beyond "what is it and how do I install it". Start a
 
 ## Automating it
 
-- **[Greenfield API](greenfield-api.md)** — the ten endpoints that do everything the pages do, their
+- **[Greenfield API](greenfield-api.md)** — the endpoints that do everything the pages do, their
   API-key permissions, and a worked `curl` script for provisioning a store headlessly.
+
+## Deploying it
+
+- **[Railway](railway.md)** — persistent volume requirements, environment variables, log rotation
+  options, and a post-deploy verification script for Railway deployments.
 
 ## Working on it
 

--- a/docs/greenfield-api.md
+++ b/docs/greenfield-api.md
@@ -19,6 +19,7 @@ engine with the same guards.
 | `GET` | `/api/v1/stores/{storeId}/spark/sweep` | `btcpay.store.canviewstoresettings` |
 | `PUT` | `/api/v1/stores/{storeId}/spark/sweep` | `btcpay.store.canmodifystoresettings` |
 | `POST` | `/api/v1/stores/{storeId}/spark/sweep` | `btcpay.store.canmodifystoresettings` |
+| `POST` | `/api/v1/stores/{storeId}/spark/sync` | `btcpay.store.canmodifystoresettings` |
 | `GET` | `/api/v1/stores/{storeId}/spark/deposit` | `btcpay.store.canviewstoresettings` |
 | `POST` | `/api/v1/stores/{storeId}/spark/deposit/claim` | `btcpay.store.canmodifystoresettings` |
 | `GET` | `/api/v1/stores/{storeId}/spark/stable-balance` | `btcpay.store.canviewstoresettings` |
@@ -38,7 +39,11 @@ Three things are worth knowing before scripting against it.
   store whose fee ceiling sits below the current exit fee stays there indefinitely and nothing is wrong —
   so gate on `outcome`, and read `refusalCode` for the stable identity of a refusal.
 - **`balanceSats` is indicative.** It is read from the SDK's cache without forcing a sync, lags settlement
-  by around 20 seconds, and drifts by a few sats. Do not reconcile against it.
+  by around 20 seconds, and drifts by a few sats. Do not reconcile against it. Use
+  `POST .../spark/sync` when you need a current reading.
+- **`GET .../spark/sweep` includes a `warnings` array.** On mainnet, it is non-empty when the
+  balance threshold or minimum sweep amount are below the recommended defaults (which were measured on
+  regtest). Scripts should print this array at provisioning time.
 
 Setting a store up with a fresh seed and reading its state back:
 
@@ -86,3 +91,40 @@ clears the store's Lightning payment method only if it still points at this stor
 ```bash
 curl -sS -X DELETE "$BTCPAY/api/v1/stores/$STORE/spark" -H "$AUTH" -i | head -1
 ```
+
+Force a wallet sync and read a current balance (the SDK cache may lag settlement by ~20 s):
+
+```bash
+curl -sS -X POST "$BTCPAY/api/v1/stores/$STORE/spark/sync" -H "$AUTH" | jq
+# { "walletRunning": true, "balanceSats": 218432, "syncedAt": "2026-08-23T..." }
+```
+
+Configure a sweep webhook and receive a POST after each successful sweep:
+
+```bash
+# Add sweepWebhookUrl alongside the other sweep settings.
+curl -sS -X PUT "$BTCPAY/api/v1/stores/$STORE/spark/sweep" \
+  -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"enabled":true,"balanceThresholdSats":200000,"minimumSweepSats":100000,
+       "maxFeePercent":3.0,"drainWhenSweeping":true,"destinationMode":"StoreWallet",
+       "sweepWebhookUrl":"https://your.endpoint/spark-swept"}' | jq .settings
+```
+
+The payload delivered to the webhook URL:
+
+```json
+{
+  "storeId": "...",
+  "idempotencyKey": "<uuid>",
+  "txId": "<on-chain txid>",
+  "amountSats": 215000,
+  "feeSats": 3000,
+  "destination": "bc1q...",
+  "destinationMode": "StoreWallet",
+  "trigger": "Automatic",
+  "completedAt": "2026-08-23T12:34:56.789+00:00"
+}
+```
+
+Delivery failures are logged as warnings and never retried. The sweep record in the database is the
+authoritative source of truth.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -88,7 +88,8 @@
   At the shipped `info` level it is not fast-growing, but it is unbounded and it grows for as long as the
   server runs. **Treat it as a file your host is responsible for**: point `logrotate` (or your container's
   log policy) at it, with the caveat that the SDK holds the handle open, so a rotation scheme that renames
-  the file needs `copytruncate` rather than `create`. It is safe to delete while the server is stopped.
+  the file needs `copytruncate` rather than `create`. A ready-to-install `logrotate` configuration using
+  `copytruncate` is at `scripts/flint-logrotate.conf`. It is safe to delete while the server is stopped.
   Nothing in the plugin reads it back; it exists for you and for a bug report.
 - **Everything the plugin writes under the data directory is owner-only, and that is the only protection
   it has.** Each store's SDK state lives in `<DataDir>/Plugins/Flint/<storeId>/`, beside the log directory,

--- a/docs/railway.md
+++ b/docs/railway.md
@@ -1,0 +1,99 @@
+[<- Docs index](README.md)
+
+# Deploying on Railway
+
+This page covers the parts of a Railway deployment that are specific to Flint.
+For general BTCPay Server on Railway guidance, consult the BTCPay docs.
+
+## Persistent volume
+
+Flint writes per-store SDK state (SQLite databases, key material) and the SDK
+log to the BTCPay DataDir:
+
+```
+<DataDir>/Plugins/Flint/<storeId>/   # SDK state per store
+<DataDir>/Plugins/Flint/logs/        # sdk.log
+```
+
+All of this must survive a deploy or a container restart. In Railway, attach a
+volume to your BTCPay service and mount it at the DataDir path. The DataDir is
+usually `/var/lib/btcpay` in Docker images, but verify against the image you
+use.
+
+**Railway volume settings (recommended):**
+- Size: start at 5 GB and adjust; each active store's SDK state is small but
+  the log grows without bound at `info` level on a busy server.
+- Mount path: wherever `$BTCPAY_DATADIR` points in your image, typically
+  `/var/lib/btcpay`.
+
+Without a persistent volume, every deploy wipes the SDK state and the plugin
+must re-sync each store's wallet from scratch. The mnemonic is encrypted and
+stored in BTCPay's Postgres database, so the funds are safe, but the initial
+sync takes a few minutes and sweeps are paused while it runs.
+
+## Environment variables
+
+| Variable | Notes |
+|---|---|
+| `BTCPAY_DATADIR` | Absolute path to the volume mount. Verified by `GET /api/v1/stores/{storeId}/spark` as `storageDirectory`. |
+| `BTCPAY_POSTGRES` | Standard BTCPay Postgres connection string. Flint's own schema (`plugin_flint`) is created in this database. |
+
+No Flint-specific environment variables are required. All configuration is per
+store, set via the UI or the Greenfield API.
+
+## Log rotation
+
+The SDK log at `<DataDir>/Plugins/Flint/logs/sdk.log` is not capped or rotated
+by the plugin; see [Known limitations](limitations.md#sdk-log-rotation) for the
+reason. On Railway, two options:
+
+1. **Container log policy**: if your Railway deployment uses a logging driver
+   that captures stdout/stderr and rotates at the platform level, the forwarded
+   lines from BTCPay's own logger are already covered. The file-based `sdk.log`
+   is a second copy written by the Rust SDK directly, outside any container
+   logging policy.
+
+2. **logrotate inside the container**: add `logrotate` to your image and
+   install the config from `scripts/flint-logrotate.conf`. The `copytruncate`
+   directive is required because the SDK holds the file handle open.
+
+## Health check and readiness
+
+The plugin exposes no dedicated health endpoint. Use BTCPay's own health check
+(`GET /api/v1/health`) for the service layer, then `GET
+/api/v1/stores/{storeId}/spark` with an API key to verify that `walletRunning`
+is `true` for each store after a deploy.
+
+A store whose wallet is not running one minute after startup is worth
+investigating in the BTCPay log (search for `Flint` or the store id).
+
+## Typical deploy flow
+
+```bash
+# After every Railway deploy, verify each store
+BTCPAY=https://your-btcpay.railway.app
+KEY=<api-key-with-canmodifystoresettings>
+
+for store_id in store1 store2; do
+    status=$(curl -sS -H "Authorization: token $KEY" \
+        "$BTCPAY/api/v1/stores/$store_id/spark")
+    echo "$store_id: wallet=$(echo "$status" | jq -r .walletRunning), \
+         network=$(echo "$status" | jq -r .networkStatus.isOperational)"
+done
+```
+
+To provision a set of stores from scratch, use `scripts/setup-stores.sh`.
+
+## Secrets
+
+The plugin stores each store's encrypted mnemonic in BTCPay's Postgres database.
+The key that decrypts it lives in the DataDir (ASP.NET Data Protection keyring).
+Back both up independently:
+
+- Postgres: Railway's automated backups or `pg_dump` on a schedule.
+- DataDir: snapshot the Railway volume or `rsync` it to cold storage.
+
+A mnemonic whose decryption key is lost is permanently inaccessible. If the
+volume is lost but Postgres is intact, the mnemonic row exists but cannot be
+decrypted; the store must be re-provisioned with a new seed, and the old seed
+must be used to recover funds separately (via any Spark-compatible wallet).

--- a/scripts/flint-logrotate.conf
+++ b/scripts/flint-logrotate.conf
@@ -1,0 +1,27 @@
+# logrotate configuration for Flint's SDK log file.
+#
+# The Rust SDK holds sdk.log open for the lifetime of the BTCPay process; a
+# rotation scheme that renames the current file causes the SDK to keep writing
+# to the renamed file and leaves the new path empty. Use copytruncate: it
+# copies the current content, then truncates the live file in place, so the
+# SDK's open file descriptor stays valid and new writes go to the right path.
+#
+# Adjust the path below to match your BTCPay DataDir. The default when BTCPay
+# runs in a Docker volume is usually /var/lib/docker/volumes/<name>/_data.
+#
+# Install:
+#   cp flint-logrotate.conf /etc/logrotate.d/flint
+#   logrotate -d /etc/logrotate.d/flint   # dry-run to verify
+#
+# The log grows slowly at the default "info" level but is unbounded; rotate
+# it daily and keep two weeks.
+
+/var/lib/btcpay/Plugins/Flint/logs/sdk.log {
+    daily
+    rotate 14
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/scripts/setup-stores.sh
+++ b/scripts/setup-stores.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Provisions one or more BTCPay stores with Flint and configures sweep.
+# Usage: ./setup-stores.sh <btcpay-url> <store-id> [<store-id>...]
+#
+# Environment variables (required):
+#   BTCPAY_API_KEY   - API key with btcpay.store.canmodifystoresettings on every listed store
+#
+# Environment variables (optional):
+#   SWEEP_ENABLED              - "true" (default) or "false"
+#   SWEEP_THRESHOLD_SATS       - balance threshold (default: 200000)
+#   SWEEP_MIN_SATS             - minimum sweep (default: 100000)
+#   SWEEP_MAX_FEE_PERCENT      - fee ceiling, percent (default: 3.0)
+#   SWEEP_DESTINATION_MODE     - StoreWallet (default) | StaticAddress
+#   SWEEP_STATIC_ADDRESS       - required when SWEEP_DESTINATION_MODE=StaticAddress
+#   SWEEP_DRAIN                - "true" (default) or "false"
+#   SWEEP_SPEED                - Slow | Medium (default) | Fast
+#   SEED_GPG_RECIPIENT         - if set, seeds are encrypted to this GPG key; plain-text otherwise
+#   SEED_OUTPUT_DIR            - directory for seed files (default: ./seeds)
+#
+# The generated recovery phrase is printed exactly once by the API and never again.
+# Keep the output files safe.
+
+set -euo pipefail
+
+# ── argument validation ───────────────────────────────────────────────────────
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <btcpay-url> <store-id> [<store-id>...]" >&2
+    exit 1
+fi
+
+if [[ -z "${BTCPAY_API_KEY:-}" ]]; then
+    echo "Error: BTCPAY_API_KEY is not set." >&2
+    exit 1
+fi
+
+BTCPAY="${1%/}"
+shift
+STORES=("$@")
+
+# ── defaults ─────────────────────────────────────────────────────────────────
+
+SWEEP_ENABLED="${SWEEP_ENABLED:-true}"
+SWEEP_THRESHOLD_SATS="${SWEEP_THRESHOLD_SATS:-200000}"
+SWEEP_MIN_SATS="${SWEEP_MIN_SATS:-100000}"
+SWEEP_MAX_FEE_PERCENT="${SWEEP_MAX_FEE_PERCENT:-3.0}"
+SWEEP_DESTINATION_MODE="${SWEEP_DESTINATION_MODE:-StoreWallet}"
+SWEEP_STATIC_ADDRESS="${SWEEP_STATIC_ADDRESS:-}"
+SWEEP_DRAIN="${SWEEP_DRAIN:-true}"
+SWEEP_SPEED="${SWEEP_SPEED:-Medium}"
+SEED_GPG_RECIPIENT="${SEED_GPG_RECIPIENT:-}"
+SEED_OUTPUT_DIR="${SEED_OUTPUT_DIR:-./seeds}"
+
+AUTH="Authorization: token ${BTCPAY_API_KEY}"
+
+mkdir -p "${SEED_OUTPUT_DIR}"
+chmod 700 "${SEED_OUTPUT_DIR}"
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+provision_store() {
+    local store_id="$1"
+    echo ""
+    echo "=== Provisioning store: ${store_id} ==="
+
+    # Provision with a freshly generated seed. The mnemonic in this response is the only
+    # copy the server will ever hand out — capture it before doing anything else.
+    local provision_json
+    provision_json=$(curl -sS -f \
+        -X POST "${BTCPAY}/api/v1/stores/${store_id}/spark" \
+        -H "${AUTH}" -H 'Content-Type: application/json' \
+        -d '{"seedSource":"generate"}') || {
+        echo "  ERROR: provision request failed for store ${store_id}" >&2
+        return 1
+    }
+
+    local mnemonic
+    mnemonic=$(echo "${provision_json}" | jq -r '.mnemonic // empty')
+
+    if [[ -z "${mnemonic}" ]]; then
+        echo "  ERROR: no mnemonic in provision response. Store may already be configured." >&2
+        echo "  Response: ${provision_json}" >&2
+        return 1
+    fi
+
+    # Save the seed — this is the only chance.
+    local seed_file="${SEED_OUTPUT_DIR}/spark-${store_id}.seed"
+    if [[ -n "${SEED_GPG_RECIPIENT}" ]]; then
+        echo "${mnemonic}" | gpg --batch --yes -e -r "${SEED_GPG_RECIPIENT}" -o "${seed_file}.gpg"
+        chmod 600 "${seed_file}.gpg"
+        echo "  Seed saved (GPG-encrypted): ${seed_file}.gpg"
+    else
+        printf '%s\n' "${mnemonic}" > "${seed_file}"
+        chmod 600 "${seed_file}"
+        echo "  Seed saved (plain text, keep safe): ${seed_file}"
+    fi
+
+    echo "  Wallet running: $(echo "${provision_json}" | jq -r '.status.walletRunning')"
+    echo "  Lightning wiring: $(echo "${provision_json}" | jq -r '.status.lightningWiring')"
+    echo "  Identity pubkey: $(echo "${provision_json}" | jq -r '.status.identityPubkey')"
+}
+
+configure_sweep() {
+    local store_id="$1"
+    echo "  Configuring sweep for store: ${store_id}"
+
+    local body
+    body=$(jq -n \
+        --argjson enabled "${SWEEP_ENABLED}" \
+        --argjson threshold "${SWEEP_THRESHOLD_SATS}" \
+        --argjson min "${SWEEP_MIN_SATS}" \
+        --argjson maxfee "${SWEEP_MAX_FEE_PERCENT}" \
+        --argjson drain "${SWEEP_DRAIN}" \
+        --arg speed "${SWEEP_SPEED}" \
+        --arg mode "${SWEEP_DESTINATION_MODE}" \
+        --arg addr "${SWEEP_STATIC_ADDRESS}" \
+        '{
+            enabled: $enabled,
+            balanceThresholdSats: $threshold,
+            minimumSweepSats: $min,
+            maxFeePercent: $maxfee,
+            drainWhenSweeping: $drain,
+            confirmationSpeed: $speed,
+            destinationMode: $mode
+        } + (if $addr != "" then {staticAddress: $addr} else {} end)')
+
+    local result
+    result=$(curl -sS -f \
+        -X PUT "${BTCPAY}/api/v1/stores/${store_id}/spark/sweep" \
+        -H "${AUTH}" -H 'Content-Type: application/json' \
+        -d "${body}") || {
+        echo "  WARNING: sweep configuration failed for store ${store_id}" >&2
+        return 1
+    }
+
+    echo "  Sweep enabled: $(echo "${result}" | jq -r '.settings.enabled')"
+    echo "  Threshold: $(echo "${result}" | jq -r '.settings.balanceThresholdSats') sats"
+    echo "  Destination: $(echo "${result}" | jq -r '.settings.destinationMode')"
+    echo "  Warnings:"
+    echo "${result}" | jq -r '.warnings[]? | "    - \(.)"' || true
+}
+
+read_status() {
+    local store_id="$1"
+    echo "  Verifying status for store: ${store_id}"
+
+    local status
+    status=$(curl -sS -f \
+        "${BTCPAY}/api/v1/stores/${store_id}/spark" \
+        -H "${AUTH}") || {
+        echo "  WARNING: status read failed for store ${store_id}" >&2
+        return 1
+    }
+
+    echo "  Configured: $(echo "${status}" | jq -r '.configured')"
+    echo "  Wallet running: $(echo "${status}" | jq -r '.walletRunning')"
+    echo "  Network operational: $(echo "${status}" | jq -r '.networkStatus.isOperational')"
+}
+
+# ── main loop ─────────────────────────────────────────────────────────────────
+
+FAILED=()
+
+for store_id in "${STORES[@]}"; do
+    if provision_store "${store_id}"; then
+        configure_sweep "${store_id}" || true
+        read_status "${store_id}" || true
+    else
+        FAILED+=("${store_id}")
+    fi
+done
+
+echo ""
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+    echo "FAILED stores: ${FAILED[*]}" >&2
+    exit 1
+else
+    echo "All stores provisioned successfully."
+fi


### PR DESCRIPTION
This PR adds several features built on top of v0.1.5.4, across four releases.

---

## v0.1.6.0 — Balance sync, sweep webhook, config warnings, setup scripts

- **`POST .../spark/sync`** — forces a wallet sync and returns the current balance (`walletRunning`, `balanceSats`, `syncedAt`). Bypasses the 20-second SDK cache. Requires `canModifyStoreSettings`.
- **Sweep webhook** — `sweepWebhookUrl` in sweep settings causes Flint to POST a JSON payload after each successful sweep: `storeId`, `idempotencyKey`, `txId`, `amountSats`, `feeSats`, `destination`, `destinationMode`, `trigger`, `completedAt`.
- **Sweep configuration warnings** — `GET .../spark/sweep` now includes a `warnings` array. On mainnet, entries appear when thresholds fall below the recommended defaults calibrated on regtest.
- **`scripts/setup-stores.sh`** — headless multi-store provisioning via Greenfield API with optional GPG seed encryption.
- **`scripts/flint-logrotate.conf`** — `copytruncate`-based logrotate config for `sdk.log` (Rust SDK holds the file handle open).
- **`docs/railway.md`** — deployment guide: persistent volumes, environment variables, log rotation, health check.

## v0.1.6.1 — Sweep webhook retry

- Webhook delivery retries up to 3 times with exponential backoff (2 s, 4 s, 8 s). 5xx and network errors are retried; 4xx are not.

## v0.1.6.2 — Webhook on failed sweeps

- `event: "sweep.failed"` payload fired when a sweep attempt fails. Carries `storeId`, `trigger`, `reason`, and (when a record was created before the failure) `idempotencyKey`, `amountSats`, `destination`, `destinationMode`.
- Success payload gains `event: "sweep.swept"` so receivers can route both event types on the same endpoint.

## v0.1.7.0 — Sweep API improvements

- **`GET .../spark/sweep/{idempotencyKey}`** — retrieve a specific sweep record by idempotency key. Requires `canViewStoreSettings`. Returns 404 with `sweep-record-not-found` when no record matches.
- **`destinationAddress`** in `POST .../spark/sweep` — overrides the store's configured sweep destination for this one sweep. Validated against the server's chain. Not supported for EVM cross-chain sweep mode (returns 422).
- **`force`** flag in `POST .../spark/sweep`** — bypasses the store's configured minimum sweep amount. The absolute on-chain protocol minimum (`Constants.MinimumOnchainSendSats`) still applies.

## v0.1.8.0 — Server-level plugin update webhook

- **`GET/PUT /api/v1/server/spark`** (requires `canModifyServerSettings`) — read or set `updateWebhookUrl`.
- A daily background task compares the installed version against the BTCPay plugin registry. When a newer version is available, Flint POSTs `{ event: "plugin.update-available", pluginIdentifier, installedVersion, availableVersion }` to the configured URL. Each version is notified at most once.

---

All endpoints are documented in `swagger.json`. All new behaviour is covered by the unit test suite (1109 passing, 86 skipped — env-gated Postgres/regtest tests).