### PR TITLE
Close superseded-invoice credit and cross-store connection-string audit findings

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeHttpContextAccessor.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeHttpContextAccessor.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Http;
+
+namespace BTCPayServer.Plugins.Flint.Tests.Fakes;
+
+/// <summary>
+/// A settable <see cref="IHttpContextAccessor"/> for tests that need to stand in for an authorised request.
+/// </summary>
+public sealed class FakeHttpContextAccessor : IHttpContextAccessor
+{
+    public HttpContext? HttpContext { get; set; }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeStoreIdSource.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeStoreIdSource.cs
@@ -1,0 +1,19 @@
+using BTCPayServer.Plugins.Flint.Services;
+
+namespace BTCPayServer.Plugins.Flint.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="ISparkStoreIdSource"/> for tests of the configuration sweep.
+/// </summary>
+public sealed class FakeStoreIdSource : ISparkStoreIdSource
+{
+    private readonly string[] _storeIds;
+
+    public FakeStoreIdSource(params string[] storeIds)
+    {
+        _storeIds = storeIds;
+    }
+
+    public Task<string[]> GetStoreIdsAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(_storeIds);
+}

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemoryInvoiceRecordStore.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemoryInvoiceRecordStore.cs
@@ -68,7 +68,7 @@ public sealed class InMemoryInvoiceRecordStore : IInvoiceRecordStore
     {
         IEnumerable<InvoiceRecord> query = _records.Values
             .Where(r => r.StoreId == storeId
-                        && r.Status is InvoiceRecordStatus.Unpaid
+                        && r.Status is not InvoiceRecordStatus.Paid
                         && r.ExpiresAt > settleableFrom);
 
         if (after is not null)
@@ -94,7 +94,7 @@ public sealed class InMemoryInvoiceRecordStore : IInvoiceRecordStore
     {
         var record = _records.GetValueOrDefault(paymentHash);
         if (record is null || record.StoreId != storeId ||
-            record.Status is not InvoiceRecordStatus.Unpaid || record.SdkPaymentId is not null)
+            record.Status is InvoiceRecordStatus.Paid || record.SdkPaymentId is not null)
         {
             return Task.FromResult(false);
         }

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkServiceHarness.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkServiceHarness.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using BTCPayServer.Configuration;
 using BTCPayServer.Logging;
 using BTCPayServer.Plugins.Flint.Sdk;
@@ -111,6 +112,12 @@ public sealed class SparkServiceHarness : IDisposable
         var invoices = new InMemoryInvoiceRecordStore();
         var reconciler = new SparkSettlementReconciler(
             invoices, broadcaster, NullLogger<SparkSettlementReconciler>.Instance);
+        var wiring = new SparkLightningWiring(lightning, NullLogger<SparkLightningWiring>.Instance);
+
+        // The startup sweep is real here — it runs against the stores this harness knows about — so the
+        // deferred factory is wired to a sweeper built over the same fakes. The sweeper is constructed after
+        // the service because its settings store is the service itself; the closure makes that ordering safe.
+        SparkLightningConfigSweeper? sweeper = null;
 
         var service = new TestableSparkService(
             connectDeadline ?? TimeSpan.FromMilliseconds(250),
@@ -128,11 +135,18 @@ public sealed class SparkServiceHarness : IDisposable
             reconciler,
             broadcaster,
             protector,
-            new SparkLightningWiring(lightning, NullLogger<SparkLightningWiring>.Instance),
+            wiring,
             new StubBolt11Parser(),
             TimeProvider.System,
+            () => sweeper ?? throw new InvalidOperationException("harness sweep not wired"),
             NullLoggerFactory.Instance,
             log);
+
+        sweeper = new SparkLightningConfigSweeper(
+            new FakeStoreIdSource(lightning.Stores.Keys.ToArray()),
+            wiring,
+            service,
+            NullLogger<SparkLightningConfigSweeper>.Instance);
 
         return new SparkServiceHarness(
             service, stores, sdk, lightning, protector, invoices, broadcaster, log, dataDir);
@@ -206,11 +220,12 @@ public sealed class SparkServiceHarness : IDisposable
             SparkLightningWiring lightningWiring,
             IBolt11Parser bolt11Parser,
             TimeProvider timeProvider,
+            Func<SparkLightningConfigSweeper> configSweeperFactory,
             ILoggerFactory loggerFactory,
             ILogger<SparkService> logger)
             : base(eventAggregator, storeRepository, dataDirectories, networkProvider, sdkClientFactory,
                 invoiceStore, outgoingStore, reconciler, broadcaster, mnemonicProtector, lightningWiring,
-                bolt11Parser, timeProvider, loggerFactory, logger)
+                bolt11Parser, timeProvider, configSweeperFactory, loggerFactory, logger)
         {
             _connectDeadline = connectDeadline;
             _confirmStatusDeadline = confirmStatusDeadline;

--- a/BTCPayServer.Plugins.Flint.Tests/InvoiceRecordStoreContractTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/InvoiceRecordStoreContractTests.cs
@@ -159,8 +159,11 @@ public abstract class InvoiceRecordStoreContractTests
     }
 
     [Fact]
-    public async Task Settling_a_cancelled_invoice_is_refused_and_changes_nothing()
+    public async Task Settling_a_cancelled_invoice_credits_it_like_any_other()
     {
+        // A cancelled invoice is still payable on the service provider — Spark has no way to withdraw it —
+        // so a late payment must still settle and credit the invoice it was minted for. Refusing would
+        // leave real money unattributed in the wallet balance with the BTCPay invoice unpaid.
         var store = await CreateStoreAsync();
         await store.AddAsync(NewRecord(), Ct);
         Assert.True(await store.CancelAsync(StoreId, PaymentFixture.PaymentHash, Ct));
@@ -169,12 +172,13 @@ public abstract class InvoiceRecordStoreContractTests
             StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, PaymentFixture.Preimage,
             DateTimeOffset.UtcNow, Ct);
 
-        Assert.Equal(InvoiceSettlementOutcome.RefusedCancelled, result.Outcome);
+        Assert.Equal(InvoiceSettlementOutcome.Settled, result.Outcome);
         var reread = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
-        Assert.Equal(InvoiceRecordStatus.Expired, reread!.Status);
-        Assert.Null(reread.AmountReceivedMsat);
-        Assert.Null(reread.SettledAt);
-        Assert.Null(reread.SdkPaymentId);
+        Assert.Equal(InvoiceRecordStatus.Paid, reread!.Status);
+        Assert.Equal(100_000, reread.AmountReceivedMsat);
+        Assert.Equal("sdk-1", reread.SdkPaymentId);
+        Assert.Equal(PaymentFixture.Preimage, reread.Preimage);
+        Assert.NotNull(reread.SettledAt);
     }
 
     [Fact]
@@ -216,7 +220,7 @@ public abstract class InvoiceRecordStoreContractTests
     }
 
     [Fact]
-    public async Task Recording_an_SDK_payment_id_only_succeeds_once_and_only_while_unpaid()
+    public async Task Recording_an_SDK_payment_id_succeeds_once_and_only_until_settled()
     {
         var store = await CreateStoreAsync();
         await store.AddAsync(NewRecord(), Ct);
@@ -228,6 +232,21 @@ public abstract class InvoiceRecordStoreContractTests
         // Never overwritten: for a self-payment the second id would be the wrong leg's.
         Assert.False(await store.TryRecordSdkPaymentIdAsync(StoreId, PaymentFixture.PaymentHash, "sdk-2", Ct));
         reread = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
+        Assert.Equal("sdk-1", reread!.SdkPaymentId);
+    }
+
+    [Fact]
+    public async Task Recording_an_SDK_payment_id_still_works_after_the_invoice_is_cancelled()
+    {
+        // A pending event can arrive after BTCPay cancelled a superseded invoice. Recording the id keeps the
+        // settlement's point lookup working for exactly the late payment a cancelled invoice can still
+        // receive — without it, that payment is found only by a history scan.
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(), Ct);
+        Assert.True(await store.CancelAsync(StoreId, PaymentFixture.PaymentHash, Ct));
+
+        Assert.True(await store.TryRecordSdkPaymentIdAsync(StoreId, PaymentFixture.PaymentHash, "sdk-1", Ct));
+        var reread = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
         Assert.Equal("sdk-1", reread!.SdkPaymentId);
     }
 
@@ -380,8 +399,11 @@ public abstract class InvoiceRecordStoreContractTests
     }
 
     [Fact]
-    public async Task Reconciliation_excludes_paid_and_cancelled_invoices()
+    public async Task Reconciliation_excludes_paid_but_still_rechecks_cancelled_invoices()
     {
+        // Paid is terminal. A cancelled invoice, by contrast, is still payable on the service provider, so
+        // it must stay in the reconciliation set — a late payment of a cancelled invoice is exactly what the
+        // reconciliation pass exists to catch when the SDK's completion event is dropped.
         var store = await CreateStoreAsync();
         var paidHash = "d".PadLeft(64, '0');
         var cancelledHash = "e".PadLeft(64, '0');
@@ -393,7 +415,7 @@ public abstract class InvoiceRecordStoreContractTests
         var listed = await store.ListForReconciliationAsync(
             StoreId, DateTimeOffset.UtcNow.AddHours(-1), after: null, limit: 10, Ct);
 
-        Assert.Empty(listed);
+        Assert.Equal(cancelledHash, Assert.Single(listed).PaymentHash);
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Flint.Tests/InvoiceRecordTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/InvoiceRecordTests.cs
@@ -42,18 +42,21 @@ public class InvoiceRecordTests
         Assert.Equal(InvoiceRecordStatus.Expired, record.Status);
     }
 
-    [Fact]
-    public void Natural_expiry_is_reported_but_not_persisted()
+    public void A_cancelled_invoice_reports_unpaid_until_it_settles()
     {
+        // Cancellation marks the invoice locally but cannot withdraw it from the service provider, so it
+        // stays payable. Reporting it expired would make BTCPay's listener drop it — the listener that
+        // would deliver the late payment's credit — so it must read unpaid until a payment settles it.
         var record = Unpaid();
+        Assert.True(record.TryCancel());
 
-        Assert.Equal(InvoiceRecordStatus.Unpaid, record.EffectiveStatus(record.ExpiresAt));
-        Assert.Equal(InvoiceRecordStatus.Expired, record.EffectiveStatus(record.ExpiresAt.AddSeconds(1)));
-        // Crucially, the stored status is untouched, so a late payment can still settle.
-        Assert.Equal(InvoiceRecordStatus.Unpaid, record.Status);
+        Assert.Equal(InvoiceRecordStatus.Expired, record.Status);
+        Assert.Equal(InvoiceRecordStatus.Unpaid, record.EffectiveStatus(record.ExpiresAt.AddDays(1)));
+
+        Assert.Equal(InvoiceSettlementOutcome.Settled, record.TrySettle("sdk-1", 100_000, null, Created));
+        Assert.Equal(InvoiceRecordStatus.Paid, record.Status);
+        Assert.Equal(InvoiceRecordStatus.Paid, record.EffectiveStatus(record.ExpiresAt.AddYears(1)));
     }
-
-    [Fact]
     public void A_naturally_expired_invoice_still_settles()
     {
         // The SSP will accept a payment after expiry and Spark has no way to stop it. Dropping that payment

--- a/BTCPayServer.Plugins.Flint.Tests/Postgres/PostgresConcurrencyTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Postgres/PostgresConcurrencyTests.cs
@@ -97,11 +97,13 @@ public class PostgresConcurrencyTests
     }
 
     [Fact]
-    public async Task A_settle_racing_a_cancel_never_produces_a_paid_invoice_that_reads_as_cancelled()
+    public async Task A_cancel_racing_a_settlement_can_never_suppress_the_credit()
     {
-        // Run repeatedly because the interleaving is what is under test. Either order is a valid outcome; what
-        // must never happen is a row that was settled and then silently reverted to cancelled, which is what a
-        // read-modify-write cancel would produce.
+        // Run repeatedly because the interleaving is what is under test. Depending on who commits first
+        // either the cancel is a no-op (the invoice already settled) or it merely marks the invoice locally
+        // before the settlement goes through — cancellation cannot withdraw an invoice from the service
+        // provider, so a payment that arrives must be credited either way. The row must always end Paid
+        // with the received amount, never cancelled.
         var store = await CreateStoreAsync();
 
         for (var attempt = 0; attempt < 25; attempt++)
@@ -114,24 +116,13 @@ public class PostgresConcurrencyTests
             var cancel = Task.Run(() => store.CancelAsync(StoreId, hash, Ct), Ct);
 
             var settleResult = await settle;
-            var cancelled = await cancel;
+            await cancel;
             var final = await store.GetAsync(StoreId, hash, Ct);
 
             Assert.NotNull(final);
-            // Exactly one of the two won, and the stored row agrees with whichever it was.
-            if (settleResult.Outcome is InvoiceSettlementOutcome.Settled)
-            {
-                Assert.False(cancelled, "a cancel must not succeed against an invoice that settled");
-                Assert.Equal(InvoiceRecordStatus.Paid, final.Status);
-                Assert.Equal(100_000, final.AmountReceivedMsat);
-            }
-            else
-            {
-                Assert.Equal(InvoiceSettlementOutcome.RefusedCancelled, settleResult.Outcome);
-                Assert.True(cancelled);
-                Assert.Equal(InvoiceRecordStatus.Expired, final.Status);
-                Assert.Null(final.AmountReceivedMsat);
-            }
+            Assert.Equal(InvoiceSettlementOutcome.Settled, settleResult.Outcome);
+            Assert.Equal(InvoiceRecordStatus.Paid, final.Status);
+            Assert.Equal(100_000, final.AmountReceivedMsat);
         }
     }
 

--- a/BTCPayServer.Plugins.Flint.Tests/SparkLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkLightningClientTests.cs
@@ -2,7 +2,9 @@ using BTCPayServer.Lightning;
 using BTCPayServer.Plugins.Flint.Data;
 using BTCPayServer.Plugins.Flint.Sdk;
 using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Data;
 using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using NBitcoin;
 using Xunit;
@@ -23,7 +25,7 @@ public class SparkLightningClientTests
         SparkSettlementBroadcaster Broadcaster,
         InMemoryOutgoingPaymentStore Outgoing);
 
-    private static Harness Create(Bolt11Info? bolt11Info = null)
+    private static Harness Create(Bolt11Info? bolt11Info = null, IHttpContextAccessor? httpContextAccessor = null)
     {
         var sdk = new FakeSparkSdkClient { NextPaymentRequest = Bolt11 };
         var store = new InMemoryInvoiceRecordStore();
@@ -35,7 +37,8 @@ public class SparkLightningClientTests
             store, broadcaster, NullLogger<SparkSettlementReconciler>.Instance);
 
         var client = new SparkLightningClient(
-            StoreId, PaymentKey, sdk, store, outgoing, reconciler, broadcaster, parser, NullLogger.Instance);
+            StoreId, PaymentKey, sdk, store, outgoing, reconciler, broadcaster, parser, NullLogger.Instance,
+            httpContextAccessor);
         return new Harness(client, sdk, store, broadcaster, outgoing);
     }
 
@@ -400,7 +403,7 @@ public class SparkLightningClientTests
     #region CancelInvoice
 
     [Fact]
-    public async Task CancelInvoice_marks_the_record_and_then_settlement_is_refused()
+    public async Task CancelInvoice_keeps_a_late_payment_settleable_and_creditable()
     {
         var (client, sdk, store, _, _) = Create();
         Seed(store);
@@ -408,13 +411,32 @@ public class SparkLightningClientTests
         await client.CancelInvoice(Hash, Ct);
         Assert.Equal(InvoiceRecordStatus.Expired, store.Records[Hash].Status);
 
-        // A payment can still arrive: Spark cannot withdraw the invoice from the SSP.
+        // A payment can still arrive: Spark cannot withdraw the invoice from the SSP. Refusing to settle it
+        // would leave the money unattributed in the wallet and the BTCPay invoice unpaid, so it must be
+        // reported paid with the received amount.
         sdk.Payments.Add(Receive());
         var invoice = await client.GetInvoice(Hash, Ct);
 
-        Assert.Equal(LightningInvoiceStatus.Expired, invoice.Status);
+        Assert.Equal(LightningInvoiceStatus.Paid, invoice.Status);
+        Assert.Equal(100_000, invoice.AmountReceived!.MilliSatoshi);
+        Assert.Equal("sdk-1", store.Records[Hash].SdkPaymentId);
+        Assert.NotNull(store.Records[Hash].SettledAt);
+    }
+
+    [Fact]
+    public async Task GetInvoice_reports_a_cancelled_but_unpaid_invoice_as_unpaid()
+    {
+        // BTCPay's Lightning listener drops an invoice whose status reads expired — the very listener that
+        // would deliver a late payment's credit. A cancelled Spark invoice is still payable, so it must keep
+        // reporting unpaid until it settles.
+        var (client, _, store, _, _) = Create();
+        Seed(store);
+        await client.CancelInvoice(Hash, Ct);
+
+        var invoice = await client.GetInvoice(Hash, Ct);
+
+        Assert.Equal(LightningInvoiceStatus.Unpaid, invoice.Status);
         Assert.Null(invoice.AmountReceived);
-        Assert.Null(store.Records[Hash].SettledAt);
     }
 
     [Fact]
@@ -552,6 +574,53 @@ public class SparkLightningClientTests
         Assert.NotNull(result.ErrorMessage);
         // Never the raw "@v1=..." UniFFI message.
         Assert.DoesNotContain("@v1=", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Validate_refuses_a_connection_string_saved_on_another_store()
+    {
+        // The save-time layer of cross-store enforcement. This client is bound to store-1 (the store id
+        // embedded in its connection string); the request is authorised for store-2. Accepting the save
+        // would let store-2 receive into and spend from store-1's wallet, which is the cross-store hijack.
+        var (client, _, _, _, _) = Create(httpContextAccessor: ContextAuthorisedFor("store-2"));
+
+        var result = await client.Validate();
+
+        Assert.NotNull(result);
+        Assert.Contains("another store", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Validate_accepts_a_connection_string_saved_on_its_own_store()
+    {
+        // The legitimate save: store-1's own string, saved on store-1, passes the store check and reaches
+        // the live wallet check.
+        var (client, _, _, _, _) = Create(httpContextAccessor: ContextAuthorisedFor(StoreId));
+
+        Assert.Null(await client.Validate());
+    }
+
+    [Fact]
+    public async Task Validate_with_no_request_context_still_runs_the_live_check()
+    {
+        // A background resolution has no request and therefore no store to compare; the store check must pass
+        // silently (not fail closed on missing context) while the live wallet check still runs.
+        var (client, sdk, _, _, _) = Create();
+        sdk.FailWith = new ObjectDisposedException("BreezSdk");
+
+        var result = await client.Validate();
+
+        Assert.NotNull(result);
+        Assert.NotNull(result.ErrorMessage);
+    }
+
+    private static IHttpContextAccessor ContextAuthorisedFor(string storeId)
+    {
+        // Reproduces an authorised store route: core's authorisation middleware places the configured store
+        // in HttpContext.Items under "BTCPAY.STOREDATA" (the GetStoreData family of extensions).
+        var context = new DefaultHttpContext();
+        context.SetStoreData(new StoreData { Id = storeId });
+        return new FakeHttpContextAccessor { HttpContext = context };
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Flint.Tests/SparkLightningConfigSweeperTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkLightningConfigSweeperTests.cs
@@ -1,0 +1,184 @@
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The startup backstop for the cross-store connection-string enforcement: configurations that predate the
+/// save-time refusal, or that were written without one, are cleared and their victim's payment key is
+/// rotated so every leaked copy of the victim's string stops resolving.
+/// </summary>
+public class SparkLightningConfigSweeperTests
+{
+    private const string VictimKey = "0f1e2d3c4b5a69788796a5b4c3d2e1f0";
+    private const string LndConnectionString =
+        "type=lnd-rest;server=https://127.0.0.1:8080/;macaroon=abcdef";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static SparkLightningConfigSweeper Create(
+        FakeStoreLightningConfigStore configs,
+        FakeSparkStoreSettingsStore settings,
+        params string[] storeIds) => new(
+        new FakeStoreIdSource(storeIds),
+        new SparkLightningWiring(configs, NullLogger<SparkLightningWiring>.Instance),
+        settings,
+        NullLogger<SparkLightningConfigSweeper>.Instance);
+
+    private static FakeSparkStoreSettingsStore SettingsWithVictim()
+    {
+        var settings = new FakeSparkStoreSettingsStore();
+        settings.Settings["store-2"] = new SparkSettings { PaymentKey = VictimKey };
+        return settings;
+    }
+
+    [Fact]
+    public async Task Sweep_clears_the_cross_store_configuration_and_rotates_the_victim_key()
+    {
+        // store-1's Lightning payment method embeds store-2's wallet. The sweep must remove that
+        // configuration and mint a fresh key for store-2, rewriting store-2's own configuration so the
+        // victim's copy of the string — and the attacker's — both die.
+        var configs = FakeStoreLightningConfigStore
+            .WithStore("store-1", SparkConnectionString.Format("store-2", VictimKey))
+            .Add("store-2", SparkConnectionString.Format("store-2", VictimKey));
+        var settings = SettingsWithVictim();
+        var sweeper = Create(configs, settings, "store-1", "store-2");
+
+        var result = await sweeper.SweepAsync(Ct);
+
+        Assert.Equal(new SparkLightningConfigSweepResult(1, 1), result);
+
+        // The hijacking configuration is gone.
+        Assert.Null(configs.Stores["store-1"].ConnectionString);
+
+        // The victim's key was rotated and its own configuration now carries the fresh string.
+        var rotated = settings.Settings["store-2"]!;
+        Assert.NotEqual(VictimKey, rotated.PaymentKey);
+        Assert.Equal(
+            SparkConnectionString.Format("store-2", rotated.PaymentKey),
+            configs.Stores["store-2"].ConnectionString);
+    }
+
+    [Fact]
+    public async Task Sweep_leaves_well_formed_configurations_alone()
+    {
+        // Own-store strings (current or stale) are not cross-store: nothing to clear, nothing to rotate.
+        var configs = FakeStoreLightningConfigStore
+            .WithStore("store-1", SparkConnectionString.Format("store-1", VictimKey))
+            .Add("store-2", "type=lnd-rest;server=https://127.0.0.1:8080/;macaroon=abcdef");
+        var settings = SettingsWithVictim();
+        var sweeper = Create(configs, settings, "store-1", "store-2");
+
+        var result = await sweeper.SweepAsync(Ct);
+
+        Assert.Equal(new SparkLightningConfigSweepResult(0, 0), result);
+        Assert.Equal(
+            SparkConnectionString.Format("store-1", VictimKey),
+            configs.Stores["store-1"].ConnectionString);
+        Assert.Equal(VictimKey, settings.Settings["store-2"]!.PaymentKey);
+    }
+
+    [Fact]
+    public async Task Sweep_clears_a_configuration_whose_victim_has_no_spark_settings_without_rotating()
+    {
+        // A cross-store string pointing at a store with no Spark wallet at all resolves to nothing today, so
+        // clearing the configuration is the whole remediation — there is no key to rotate.
+        var configs = FakeStoreLightningConfigStore
+            .WithStore("store-1", SparkConnectionString.Format("store-2", VictimKey));
+        var settings = new FakeSparkStoreSettingsStore();
+        var sweeper = Create(configs, settings, "store-1");
+
+        var result = await sweeper.SweepAsync(Ct);
+
+        Assert.Equal(new SparkLightningConfigSweepResult(1, 0), result);
+        Assert.Null(configs.Stores["store-1"].ConnectionString);
+        Assert.Empty(settings.Writes);
+    }
+
+    [Fact]
+    public async Task Sweep_restores_the_previous_key_when_the_rotation_is_declined()
+    {
+        // The wallet-owner guard or an unsupported chain can make SetAsync report "stored but not running";
+        // the sweep must not leave the victim half-rotated.
+        var configs = FakeStoreLightningConfigStore
+            .WithStore("store-1", SparkConnectionString.Format("store-2", VictimKey))
+            .Add("store-2", SparkConnectionString.Format("store-2", VictimKey));
+        var settings = SettingsWithVictim();
+        settings.NextSetDeclinesWith = "the wallet declined to restart";
+        var sweeper = Create(configs, settings, "store-1", "store-2");
+
+        var result = await sweeper.SweepAsync(Ct);
+
+        Assert.Equal(new SparkLightningConfigSweepResult(1, 0), result);
+        // The cross-store configuration is still cleared; only the rotation was rolled back.
+        Assert.Null(configs.Stores["store-1"].ConnectionString);
+        Assert.Equal(VictimKey, settings.Settings["store-2"]!.PaymentKey);
+    }
+
+    [Fact]
+    public async Task Sweep_rotates_a_multiply_referenced_victim_exactly_once()
+    {
+        // Two stores both drive the same victim wallet; one rotation revokes both leaked copies.
+        var configs = FakeStoreLightningConfigStore
+            .WithStore("store-1", SparkConnectionString.Format("store-2", VictimKey))
+            .Add("store-3", SparkConnectionString.Format("store-2", VictimKey))
+            .Add("store-2", SparkConnectionString.Format("store-2", VictimKey));
+        var settings = SettingsWithVictim();
+        var sweeper = Create(configs, settings, "store-1", "store-2", "store-3");
+
+        var result = await sweeper.SweepAsync(Ct);
+
+        Assert.Equal(new SparkLightningConfigSweepResult(2, 1), result);
+        Assert.Null(configs.Stores["store-1"].ConnectionString);
+        Assert.Null(configs.Stores["store-3"].ConnectionString);
+        // Store-2's settings were written exactly twice: once rotated, and its own wire-up is in the config
+        // store, not here.
+        Assert.Single(settings.Writes, w => w.StoreId == "store-2");
+    }
+
+    [Fact]
+    public async Task Sweep_rotates_the_key_but_leaves_a_victim_configuration_that_moved_away_alone()
+    {
+        // A merchant who switched their Lightning to their own node has a configuration that must not be
+        // clobbered; rotating the (now unused) key still revokes the leaked copy of the old string.
+        var configs = FakeStoreLightningConfigStore
+            .WithStore("store-1", SparkConnectionString.Format("store-2", VictimKey))
+            .Add("store-2", LndConnectionString);
+        var settings = SettingsWithVictim();
+        var sweeper = Create(configs, settings, "store-1", "store-2");
+
+        var result = await sweeper.SweepAsync(Ct);
+
+        Assert.Equal(new SparkLightningConfigSweepResult(1, 1), result);
+        Assert.Null(configs.Stores["store-1"].ConnectionString);
+        Assert.NotEqual(VictimKey, settings.Settings["store-2"]!.PaymentKey);
+        Assert.Equal(LndConnectionString, configs.Stores["store-2"].ConnectionString);
+    }
+
+    [Fact]
+    public async Task Sweep_keeps_going_when_one_stores_clear_fails()
+    {
+        // One store whose configuration cannot be cleared must not stop the walk from clearing the next.
+        var configs = FakeStoreLightningConfigStore
+            .WithStore("store-1", SparkConnectionString.Format("store-2", VictimKey))
+            .Add("store-3", SparkConnectionString.Format("store-4", "other-victim-key"));
+        configs.FailNextSetWith = new InvalidOperationException("repository failed");
+        var settings = new FakeSparkStoreSettingsStore();
+        settings.Settings["store-2"] = new SparkSettings { PaymentKey = VictimKey };
+        settings.Settings["store-4"] = new SparkSettings { PaymentKey = "other-victim-key" };
+        var sweeper = Create(configs, settings, "store-1", "store-3");
+
+        var result = await sweeper.SweepAsync(Ct);
+
+        // store-1's clear hit the injected failure and was swallowed; store-3 was still cleared and its
+        // victim still rotated.
+        Assert.Equal(new SparkLightningConfigSweepResult(1, 1), result);
+        Assert.Equal(
+            SparkConnectionString.Format("store-2", VictimKey),
+            configs.Stores["store-1"].ConnectionString);
+        Assert.Null(configs.Stores["store-3"].ConnectionString);
+        Assert.NotEqual("other-victim-key", settings.Settings["store-4"]!.PaymentKey);
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/SparkLightningWiringTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkLightningWiringTests.cs
@@ -105,13 +105,55 @@ public class SparkLightningWiringTests
     [Fact]
     public async Task Clear_leaves_another_stores_spark_configuration_alone()
     {
-        // The connection string is store-bound so this configuration is already broken, but overwriting
-        // another store's stated intent is worse than leaving a visibly broken configuration behind.
+        // ClearIfOursAsync runs while a store's own Spark settings are being removed, so it only ever clears
+        // this store's own configuration. A cross-store configuration is not ours to clear at that moment —
+        // that is the configuration sweep's job.
         var configStore = FakeStoreLightningConfigStore.WithStore(
             StoreId, SparkConnectionString.Format(OtherStoreId, PaymentKey));
 
         Assert.False(await Create(configStore).ClearIfOursAsync(StoreId));
         Assert.Empty(configStore.Writes);
+    }
+
+    [Fact]
+    public async Task Clear_cross_store_removes_a_configuration_pointing_at_another_store()
+    {
+        // The sweep's remediation: a valid string embedding a different store id is the one configuration
+        // that is broken by definition, so it is cleared and the victim's id is reported.
+        var configStore = FakeStoreLightningConfigStore.WithStore(
+            StoreId, SparkConnectionString.Format(OtherStoreId, PaymentKey));
+
+        var victim = await Create(configStore).ClearCrossStoreAsync(StoreId);
+
+        Assert.Equal(OtherStoreId, victim);
+        Assert.Null(Assert.Single(configStore.Writes).ConnectionString);
+    }
+
+    [Theory]
+    // Our own store: not cross-store.
+    [InlineData("type=flint;store-id=" + StoreId + ";key=0f1e2d3c4b5a69788796a5b4c3d2e1f0")]
+    // Somebody else's node: never cleared by this method.
+    [InlineData("type=lnd-rest;server=https://127.0.0.1:8080/;macaroon=abcdef")]
+    // Our type but malformed: the owner is unknown, so left alone.
+    [InlineData("type=flint;store-id=" + StoreId)]
+    public async Task Clear_cross_store_leaves_everything_else_alone(string connectionString)
+    {
+        var configStore = FakeStoreLightningConfigStore.WithStore(StoreId, connectionString);
+
+        Assert.Null(await Create(configStore).ClearCrossStoreAsync(StoreId));
+        Assert.Empty(configStore.Writes);
+    }
+
+    [Fact]
+    public async Task Clear_cross_store_leaves_a_missing_or_internal_node_configuration_alone()
+    {
+        // A store with no Lightning payment method, and BTCPay's internal node, have nothing cross-store.
+        var none = new FakeStoreLightningConfigStore();
+        Assert.Null(await Create(none).ClearCrossStoreAsync(StoreId));
+
+        var internalNode = FakeStoreLightningConfigStore.WithStore(StoreId, isInternalNode: true);
+        Assert.Null(await Create(internalNode).ClearCrossStoreAsync(StoreId));
+        Assert.Empty(internalNode.Writes);
     }
 
     [Fact]
@@ -196,7 +238,7 @@ public class SparkLightningWiringTests
     // Ours, but a key the settings no longer hold.
     [InlineData("", false, "type=flint;store-id=store-1;key=aaaabbbbccccdddd",
         SparkLightningWiringState.StaleSpark)]
-    // Another store's Spark wallet. Broken, but not ours to overwrite.
+    // Another store's Spark wallet: refused at save time, cleared by the startup sweep.
     [InlineData("", false, "type=flint;store-id=store-2;key=" + PaymentKey,
         SparkLightningWiringState.OtherStoreSpark)]
     public void Classify_maps_every_configuration_to_its_own_state(

--- a/BTCPayServer.Plugins.Flint.Tests/SparkReconciliationTaskTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkReconciliationTaskTests.cs
@@ -1,0 +1,52 @@
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The scheduled task that runs the reconciliation pass and, on the same cadence, the cross-store
+/// configuration sweep — the periodic half of the store-binding enforcement, so a cross-store Lightning
+/// configuration written outside HTTP survives at most one interval rather than until the next restart.
+/// </summary>
+/// <remarks>
+/// The walk itself is covered by the reconciler and sweeper suites; what is under test here is the wiring —
+/// that <see cref="SparkReconciliationTask.Do"/> actually reaches the sweep, so a future edit that drops the
+/// call fails here rather than silently widening the window it exists to close.
+/// </remarks>
+public class SparkReconciliationTaskTests
+{
+    private const string VictimKey = "0f1e2d3c4b5a69788796a5b4c3d2e1f0";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    [Fact(Timeout = 30_000)]
+    public async Task Do_runs_the_cross_store_sweep_on_the_periodic_pass()
+    {
+        using var harness = SparkServiceHarness.Create();
+        await harness.Service.StartAsync(Ct);
+
+        // The misconfiguration lands after startup — the shape that needs the periodic pass, because nothing
+        // about this particular Save went through the plugin.
+        var configs = FakeStoreLightningConfigStore
+            .WithStore("attacker", SparkConnectionString.Format("victim", VictimKey))
+            .Add("victim", SparkConnectionString.Format("victim", VictimKey));
+        var settings = new FakeSparkStoreSettingsStore();
+        settings.Settings["victim"] = new SparkSettings { PaymentKey = VictimKey };
+
+        var task = new SparkReconciliationTask(
+            harness.Service,
+            new SparkLightningConfigSweeper(
+                new FakeStoreIdSource("attacker", "victim"),
+                new SparkLightningWiring(configs, NullLogger<SparkLightningWiring>.Instance),
+                settings,
+                NullLogger<SparkLightningConfigSweeper>.Instance),
+            NullLogger<SparkReconciliationTask>.Instance);
+
+        await task.Do(Ct);
+
+        Assert.Null(configs.Stores["attacker"].ConnectionString);
+        Assert.NotEqual(VictimKey, settings.Settings["victim"]!.PaymentKey);
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSettlementReconcilerTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSettlementReconcilerTests.cs
@@ -137,7 +137,7 @@ public class SparkSettlementReconcilerTests
     }
 
     [Fact]
-    public async Task Applying_a_settlement_to_a_cancelled_invoice_notifies_nobody()
+    public async Task Applying_a_settlement_to_a_cancelled_invoice_credits_it_and_notifies_once()
     {
         var (reconciler, store, broadcaster) = Create();
         Seed(store);
@@ -146,9 +146,55 @@ public class SparkSettlementReconcilerTests
 
         var result = await reconciler.ApplyAsync(StoreId, Receive(), Ct);
 
-        Assert.Equal(InvoiceSettlementOutcome.RefusedCancelled, result.Outcome);
+        Assert.Equal(InvoiceSettlementOutcome.Settled, result.Outcome);
+        Assert.NotNull(result.Record);
+        Assert.Equal(InvoiceRecordStatus.Paid, result.Record.Status);
+        Assert.Equal(100_000, result.Record.AmountReceivedMsat);
+
+        // The notification is what lets BTCPay reach the invoice this bolt11 was minted for; it must fire
+        // exactly once, exactly for this payment.
+        var notification = await listener.ReadAsync(Ct);
+        Assert.Equal(Hash, notification.PaymentHash);
+        Assert.Equal(100_000, notification.AmountReceivedMsat);
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await listener.ReadAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task A_late_payment_of_a_superseded_invoice_credits_the_invoice_it_was_minted_for()
+    {
+        // The production shape of the finding: an X -> Y invoice replacement (sequential requests to a
+        // public TopUp LNURL callback cancel the older bolt11), then a late completed payment of X. Spark
+        // cannot withdraw X, so the payment settles anyway. It must credit X — the invoice whose payment
+        // hash it carries — not the replacement, and Y must stay untouched.
+        var (reconciler, store, broadcaster) = Create();
+        var xHash = new string('a', 64);
+        var yHash = new string('b', 64);
+        Seed(store, hash: xHash);
+        Seed(store, hash: yHash);
+
+        // BTCPay replaces X with Y: the old bolt11 is cancelled locally, the new one offered.
+        Assert.True(await store.CancelAsync(StoreId, xHash, Ct));
+        Assert.Equal(InvoiceRecordStatus.Expired, store.Records[xHash].Status);
+        Assert.Equal(InvoiceRecordStatus.Unpaid, store.Records[yHash].Status);
+
+        using var listener = broadcaster.Subscribe(StoreId);
+        var result = await reconciler.ApplyAsync(
+            StoreId, Receive(hash: xHash, sdkPaymentId: "sdk-late", amountSats: 100), Ct);
+
+        // X is credited with the received amount and the settlement is published for BTCPay.
+        Assert.Equal(InvoiceSettlementOutcome.Settled, result.Outcome);
+        Assert.Equal(xHash, result.Record!.PaymentHash);
+        Assert.Equal(InvoiceRecordStatus.Paid, result.Record.Status);
+        Assert.Equal(100_000, result.Record.AmountReceivedMsat);
+
+        var notification = await listener.ReadAsync(Ct);
+        Assert.Equal(xHash, notification.PaymentHash);
+        Assert.Equal(100_000, notification.AmountReceivedMsat);
+
+        // The replacement is untouched: nothing about X's late payment credits Y.
+        Assert.Equal(InvoiceRecordStatus.Unpaid, store.Records[yHash].Status);
+        Assert.Null(store.Records[yHash].AmountReceivedMsat);
     }
 
     [Fact]
@@ -302,8 +348,12 @@ public class SparkSettlementReconcilerTests
     }
 
     [Fact]
-    public async Task Reconciling_a_store_skips_paid_cancelled_and_expired_invoices()
+    public async Task Reconciling_a_store_skips_paid_and_long_expired_but_rechecks_cancelled_invoices()
     {
+        // Paid is terminal and a long-expired invoice is past the grace window (a deliberate bound). A
+        // cancelled invoice, by contrast, is still payable on the service provider, so the walk re-examines
+        // it within the same window as anything else — a late payment of a cancelled invoice is exactly what
+        // the walk exists to catch when the SDK's completion event is dropped.
         var (reconciler, store, _) = Create();
         var expiredHash = new string('b', 64);
         var cancelledHash = new string('c', 64);
@@ -319,8 +369,9 @@ public class SparkSettlementReconcilerTests
         var settled = await reconciler.ReconcileStoreAsync(StoreId, sdk, Ct);
 
         Assert.Equal(0, settled);
-        // Nothing was even asked about: the pending query excluded all three.
-        Assert.Empty(sdk.ListQueries);
+        // Only the cancelled invoice was asked about; paid and long-expired did not even produce a query.
+        var query = Assert.Single(sdk.ListQueries);
+        Assert.True(query.From < DateTimeOffset.UtcNow, "the single query should be the cancelled invoice's scan");
         Assert.Empty(sdk.GetPaymentCalls);
     }
 

--- a/BTCPayServer.Plugins.Flint/Data/EfInvoiceRecordStore.cs
+++ b/BTCPayServer.Plugins.Flint/Data/EfInvoiceRecordStore.cs
@@ -103,7 +103,9 @@ public class EfInvoiceRecordStore : IInvoiceRecordStore
         var query = context.InvoiceRecords
             .AsNoTracking()
             .Where(r => r.StoreId == storeId
-                        && r.Status == InvoiceRecordStatus.Unpaid
+                        // A cancelled invoice is still payable on Spark, so it is as settleable as an
+                        // unpaid one — only a paid invoice is terminal.
+                        && r.Status != InvoiceRecordStatus.Paid
                         && r.ExpiresAt > settleableFrom);
 
         if (after is not null)
@@ -134,11 +136,12 @@ public class EfInvoiceRecordStore : IInvoiceRecordStore
         await using var context = _contextFactory.CreateContext();
 
         // Guarded on Status and on the column still being empty, so this can never overwrite the id of an
-        // already-settled payment — which for a self-payment would be the wrong leg's id.
+        // already-settled payment — which for a self-payment would be the wrong leg's id. A cancelled
+        // invoice is still settleable, so its id is recordable too.
         var updated = await context.InvoiceRecords
             .Where(r => r.PaymentHash == paymentHash
                         && r.StoreId == storeId
-                        && r.Status == InvoiceRecordStatus.Unpaid
+                        && r.Status != InvoiceRecordStatus.Paid
                         && r.SdkPaymentId == null)
             .ExecuteUpdateAsync(
                 setters => setters.SetProperty(r => r.SdkPaymentId, sdkPaymentId),
@@ -168,15 +171,17 @@ public class EfInvoiceRecordStore : IInvoiceRecordStore
             var updated = await context.InvoiceRecords
                 .Where(r => r.PaymentHash == paymentHash
                             && r.StoreId == storeId
-                            && r.Status == InvoiceRecordStatus.Unpaid)
+                            // Paid is the only terminal status: an Unpaid or cancelled invoice may still
+                            // receive the payment being applied.
+                            && r.Status != InvoiceRecordStatus.Paid)
                 .ExecuteUpdateAsync(
                     setters => setters
                         .SetProperty(r => r.Status, InvoiceRecordStatus.Paid)
                         .SetProperty(r => r.SdkPaymentId, sdkPaymentId)
                         .SetProperty(r => r.AmountReceivedMsat, amountReceivedMsat)
                         .SetProperty(r => r.SettledAt, settledAt)
-                        // A plain assignment, not a coalesce: the guard above means this row was Unpaid, and
-                        // an unpaid invoice never has a preimage.
+                        // A plain assignment, not a coalesce: the guard above means this row was unsettled,
+                        // and an unsettled invoice never has a preimage.
                         .SetProperty(r => r.Preimage, preimage),
                     cancellationToken);
 
@@ -218,13 +223,9 @@ public class EfInvoiceRecordStore : IInvoiceRecordStore
 
                     return new InvoiceSettlementResult(InvoiceSettlementOutcome.AlreadySettled, record);
 
-                case InvoiceRecordStatus.Expired:
-                    // Cancelled locally. The money is in the wallet; the BTCPay invoice must stay unpaid.
-                    return new InvoiceSettlementResult(InvoiceSettlementOutcome.RefusedCancelled, record);
-
                 default:
-                    // Unpaid, yet the update matched nothing: the row was inserted between the two
-                    // statements. Retry the compare-and-set against the row that now exists.
+                    // Unsettled, yet the update matched nothing: the row was inserted or reworked between
+                    // the two statements. Retry the compare-and-set against the row that now exists.
                     continue;
             }
         }

--- a/BTCPayServer.Plugins.Flint/Data/InvoiceRecord.cs
+++ b/BTCPayServer.Plugins.Flint/Data/InvoiceRecord.cs
@@ -90,36 +90,49 @@ public class InvoiceRecord
     /// <remarks>
     /// <para>
     /// Natural expiry is computed rather than persisted, and that distinction is load-bearing.
-    /// <see cref="InvoiceRecordStatus.Expired"/> in the database means "cancelled locally, refuse to
-    /// settle" (see <see cref="TryCancel"/>). If natural expiry were persisted the same way, a
-    /// payment arriving a second after expiry — which the SSP will happily accept, because the Spark
-    /// SDK has no way to stop it — would be silently dropped instead of recorded.
+    /// <see cref="InvoiceRecordStatus.Expired"/> in the database means "cancelled locally" (see
+    /// <see cref="TryCancel"/>), not "no longer payable". If natural expiry were persisted the same way, a
+    /// payment arriving a second after expiry — which the SSP will happily accept, because the Spark SDK
+    /// has no way to stop it — would be silently dropped instead of recorded.
+    /// </para>
+    /// <para>
+    /// A <em>cancelled</em> invoice is reported <b>unpaid</b>, not expired. Cancellation cannot withdraw
+    /// the invoice from the service provider, so it remains payable, and BTCPay's Lightning listener drops
+    /// an invoice whose status reads expired (<c>LightningInstanceListener.AddPaymentCore</c>) — the one
+    /// listener that could still deliver a late payment's credit. Reporting it unpaid keeps that listener
+    /// attached until a payment settles it or BTCPay's own invoice expiry lets it go.
     /// </para>
     /// <para>
     /// <b>How far that capability actually reaches.</b> A late payment settles through any path that gets
-    /// to <see cref="IInvoiceRecordStore.SettleAsync"/>, whose only refusal is a cancelled invoice. The
-    /// recurring reconciliation pass therefore keeps looking for an hour past expiry rather than stopping
-    /// at it. Beyond that hour an invoice is no longer re-checked and a late payment stays unattributed
-    /// in the wallet balance — a deliberate bound, since the alternative is rescanning every invoice ever
-    /// created on every pass. Note also that BTCPay stops listening for an invoice once it expires
-    /// (<c>LightningInstanceListener.RemoveExpiredInvoices</c>), so a settlement recorded after expiry
-    /// keeps this plugin's own ledger truthful but will usually not revive the BTCPay invoice.
+    /// to <see cref="IInvoiceRecordStore.SettleAsync"/>. The recurring reconciliation pass keeps looking
+    /// for an hour past expiry rather than stopping at it; beyond that hour an invoice is no longer
+    /// re-checked and a late payment stays unattributed in the wallet balance — a deliberate bound, since
+    /// the alternative is rescanning every invoice ever created on every pass. Note also that a settlement
+    /// recorded after BTCPay has stopped listening for the invoice (its own expiry —
+    /// <c>LightningInstanceListener.RemoveExpiredInvoices</c>) keeps this plugin's own ledger truthful but
+    /// will usually not revive the BTCPay invoice.
     /// </para>
     /// </remarks>
     public InvoiceRecordStatus EffectiveStatus(DateTimeOffset now) =>
-        Status is InvoiceRecordStatus.Unpaid && now > ExpiresAt
-            ? InvoiceRecordStatus.Expired
-            : Status;
+        Status switch
+        {
+            // Cancelled locally but still payable on Spark: report unpaid, so BTCPay's listener stays
+            // attached and a late payment can still be credited (see the remarks above).
+            InvoiceRecordStatus.Expired => InvoiceRecordStatus.Unpaid,
+            InvoiceRecordStatus.Unpaid when now > ExpiresAt => InvoiceRecordStatus.Expired,
+            _ => Status
+        };
 
     /// <summary>
-    /// Applies a settlement to this record, refusing to do so if the invoice was cancelled.
+    /// Applies a settlement to this record, crediting a late payment of a cancelled invoice too.
     /// </summary>
     /// <remarks>
-    /// The refusal is the substance of the plugin's <c>CancelInvoice</c>: the Spark SDK has no
-    /// invoice-cancellation primitive, so a cancelled invoice can still be paid on the SSP's side.
-    /// Those funds do land in the store's Spark balance (and will be swept), but the BTCPay invoice
-    /// must not be marked paid — BTCPay was told the invoice was cancelled and may have issued a
-    /// replacement. Callers log a warning when this happens.
+    /// The Spark SDK has no invoice-cancellation primitive, so a cancelled invoice can still be paid on
+    /// the SSP's side. That payment is real money into the store's wallet, and refusing to credit it would
+    /// leave it unattributed: the funds in the Spark balance, swept later, with no BTCPay invoice ever
+    /// marked paid and no record of what the money was for. Cancellation therefore marks the invoice
+    /// locally (<see cref="TryCancel"/>) but never bars the settlement — the invoice is credited exactly
+    /// as if it had not been cancelled, and the payment's hash identifies which invoice that is.
     /// </remarks>
     public InvoiceSettlementOutcome TrySettle(
         string sdkPaymentId,
@@ -129,9 +142,6 @@ public class InvoiceRecord
     {
         ArgumentException.ThrowIfNullOrEmpty(sdkPaymentId);
         ArgumentOutOfRangeException.ThrowIfNegative(amountReceivedMsat);
-
-        if (Status is InvoiceRecordStatus.Expired)
-            return InvoiceSettlementOutcome.RefusedCancelled;
 
         if (Status is InvoiceRecordStatus.Paid)
         {
@@ -175,8 +185,8 @@ public enum InvoiceRecordStatus
     Paid,
 
     /// <summary>
-    /// Cancelled locally. Also what <see cref="InvoiceRecord.EffectiveStatus"/> reports for an unpaid
-    /// invoice past its expiry.
+    /// Cancelled locally: no longer offered to payers, but still payable on the service provider, so a
+    /// late payment still settles and credits the invoice (see <see cref="InvoiceRecord.EffectiveStatus"/>).
     /// </summary>
     Expired
 }
@@ -189,9 +199,6 @@ public enum InvoiceSettlementOutcome
 
     /// <summary>The record was already paid. Do not notify BTCPay again.</summary>
     AlreadySettled,
-
-    /// <summary>The invoice was cancelled; the settlement must not be reported. Log a warning.</summary>
-    RefusedCancelled,
 
     /// <summary>No record exists for this payment hash — a receive this plugin did not create.</summary>
     NotFound

--- a/BTCPayServer.Plugins.Flint/Resources/swagger.json
+++ b/BTCPayServer.Plugins.Flint/Resources/swagger.json
@@ -1077,7 +1077,7 @@
             },
             "SparkLightningWiringState": {
                 "type": "string",
-                "description": "What a store's Lightning payment method points at. `StaleSpark` is this store's Spark wallet under a superseded payment key — still ours, and dead. `OtherStoreSpark` is another store's Spark wallet, which the plugin refuses to overwrite or clear.",
+                "description": "What a store's Lightning payment method points at. `StaleSpark` is this store's Spark wallet under a superseded payment key — still ours, and dead. `OtherStoreSpark` is another store's Spark wallet — refused at save time, and cleared at startup with the victim's payment key rotated.",
                 "enum": [
                     "StoreNotFound",
                     "NotConfigured",

--- a/BTCPayServer.Plugins.Flint/Services/BTCPayStoreIdSource.cs
+++ b/BTCPayServer.Plugins.Flint/Services/BTCPayStoreIdSource.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Services.Stores;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>
+/// <see cref="ISparkStoreIdSource"/> over BTCPay's whole store table.
+/// </summary>
+/// <remarks>
+/// The concrete <see cref="StoreRepository"/> is resolved through a deferred <c>Func</c> rather than injected:
+/// this is reachable from the configuration sweep, which <c>SparkService</c> triggers at startup, and
+/// <c>SparkService</c> is itself a dependency of the sweep — the same deferral the connection-string handler
+/// and the value oracle use to keep the container's graph acyclic.
+/// </remarks>
+public sealed class BTCPayStoreIdSource : ISparkStoreIdSource
+{
+    private readonly Func<StoreRepository> _repository;
+
+    public BTCPayStoreIdSource(Func<StoreRepository> repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<string[]> GetStoreIdsAsync(CancellationToken cancellationToken = default)
+    {
+        var stores = await _repository().GetStores().ConfigureAwait(false);
+        return stores.Select(store => store.Id).ToArray();
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/ISparkStoreIdSource.cs
+++ b/BTCPayServer.Plugins.Flint/Services/ISparkStoreIdSource.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>
+/// Every store id on the server, for the startup configuration sweep.
+/// </summary>
+/// <remarks>
+/// A seam so <see cref="SparkLightningConfigSweeper"/> can be tested without a database: the sweep must see
+/// every store — including the ones with no Spark settings, which is exactly the store a hijacked Lightning
+/// configuration lives on — so the enumeration has to come from BTCPay's whole store table rather than from
+/// this plugin's settings bucket.
+/// </remarks>
+public interface ISparkStoreIdSource
+{
+    Task<string[]> GetStoreIdsAsync(CancellationToken cancellationToken = default);
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkLightningConfigSweeper.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkLightningConfigSweeper.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>Outcome of one sweep of every store's Lightning configuration.</summary>
+/// <param name="Cleared">Cross-store configurations cleared — each a store whose Lightning payment method pointed at another store's Spark wallet.</param>
+/// <param name="Rotated">Victim payment keys rotated so every previously leaked copy of the victim's connection string stops resolving.</param>
+public sealed record SparkLightningConfigSweepResult(int Cleared, int Rotated);
+
+/// <summary>
+/// Enforces store binding on Lightning configurations that are already saved — the boundary
+/// <see cref="ISparkClientResolver"/> cannot police, because BTCPay's connection-string handler is never
+/// told which store a string is being configured for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Save-time (a store's own UI saving a mismatched string, or the Greenfield PUT) is refused by
+/// <c>SparkLightningClient.Validate</c>, which runs inside the request with the configured store on the
+/// <c>HttpContext</c>. <c>Validate</c> is skipped when the saved string is unchanged, and a configuration
+/// could in principle land without ever passing it (a string saved by an older version, or written straight
+/// to the database), so this sweep is the second layer: on every startup it walks <em>every</em> store's
+/// Lightning payment-method configuration, and one that embeds another store's id is cleared and its
+/// victim's payment key rotated.
+/// </para>
+/// <para>
+/// Clearing removes the hijacking store's Lightning payment method — the configuration itself is the
+/// attack, and there is no legitimate reason for store A's Lightning config to embed store B's id. Rotating
+/// the victim's payment key is what kills copies of the victim's connection string that were never saved on
+/// any store: the string embeds the key, and the resolver only honours the key the settings currently hold,
+/// so a fresh key makes every older copy a dead <c>StaleSpark</c> string. Rotation deliberately rewrites
+/// only a victim configuration that still points at Spark; a merchant who has since moved their Lightning to
+/// their own node keeps that configuration untouched, and their settings simply carry a key nothing uses
+/// until they come back.
+/// </para>
+/// <para>
+/// The sweep is idempotent: before it runs, a cross-store configuration both exists and is broken (the
+/// status page marks it <see cref="SparkLightningWiringState.OtherStoreSpark"/>); after it runs, nothing
+/// does, so a repeat pass finds nothing to do. It is a startup action, not a repeating one, because the
+/// save-time layer already blocks new mismatches from every HTTP path.
+/// </para>
+/// </remarks>
+public sealed class SparkLightningConfigSweeper
+{
+    private readonly ISparkStoreIdSource _storeIds;
+    private readonly SparkLightningWiring _wiring;
+    private readonly ISparkStoreSettingsStore _settingsStore;
+    private readonly ILogger<SparkLightningConfigSweeper> _logger;
+
+    public SparkLightningConfigSweeper(
+        ISparkStoreIdSource storeIds,
+        SparkLightningWiring wiring,
+        ISparkStoreSettingsStore settingsStore,
+        ILogger<SparkLightningConfigSweeper> logger)
+    {
+        _storeIds = storeIds;
+        _wiring = wiring;
+        _settingsStore = settingsStore;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Walks every store, clears every cross-store Lightning configuration found, and rotates the victim
+    /// keys those configurations referenced. Never throws; one broken store must not stop the rest of the
+    /// walk.
+    /// </summary>
+    public async Task<SparkLightningConfigSweepResult> SweepAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var storeIds = await _storeIds.GetStoreIdsAsync(cancellationToken).ConfigureAwait(false);
+
+        var victims = new List<string>();
+        var cleared = 0;
+
+        foreach (var storeId in storeIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var report = await _wiring
+                    .InspectAsync(storeId, paymentKey: null, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (report.State is not SparkLightningWiringState.OtherStoreSpark)
+                    continue;
+
+                if (await _wiring.ClearCrossStoreAsync(storeId, cancellationToken).ConfigureAwait(false)
+                    is { } victimStoreId)
+                {
+                    victims.Add(victimStoreId);
+                }
+
+                cleared++;
+            }
+            catch (Exception ex)
+            {
+                // One broken store must not stop the walk: the next store's configuration may still be a
+                // hijack, and skipping it would leave the victim exposed another startup.
+                _logger.LogWarning(ex,
+                    "Store {StoreId}: its Lightning configuration could not be swept; it will be retried "
+                    + "on the next startup", storeId);
+            }
+        }
+
+        var rotated = 0;
+        foreach (var victim in victims.Distinct(StringComparer.Ordinal))
+        {
+            if (await RotateVictimKeyAsync(victim, cancellationToken).ConfigureAwait(false))
+                rotated++;
+        }
+
+        if (victims.Count > 0)
+        {
+            _logger.LogWarning(
+                "Cross-store Lightning configuration sweep: cleared {Cleared} configuration(s) and rotated "
+                + "{Rotated} of {VictimCount} victim payment key(s)",
+                cleared, rotated, victims.Distinct(StringComparer.Ordinal).Count());
+        }
+
+        return new SparkLightningConfigSweepResult(cleared, rotated);
+    }
+
+    /// <summary>
+    /// Mints a fresh payment key for the victim store, persists it, restarts its wallet, and rewrites its
+    /// Lightning configuration with the new string — invalidating every previously issued copy of the old
+    /// string. Restores the old settings verbatim if the wallet declines to restart.
+    /// </summary>
+    private async Task<bool> RotateVictimKeyAsync(string victimStoreId, CancellationToken cancellationToken)
+    {
+        SparkSettings? settings;
+        try
+        {
+            settings = await _settingsStore.GetAsync(victimStoreId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Store {StoreId}: could not read its settings to rotate the payment key", victimStoreId);
+            return false;
+        }
+
+        // No wallet to revoke: clearing the cross-store configuration was the whole remediation.
+        if (settings is null)
+            return false;
+
+        var rotated = settings.Clone();
+        rotated.PaymentKey = SparkConnectionString.GeneratePaymentKey();
+
+        try
+        {
+            var applied = await _settingsStore.SetAsync(victimStoreId, rotated).ConfigureAwait(false);
+            if (!applied.WalletRunning)
+            {
+                _logger.LogWarning(
+                    "Store {StoreId}: its wallet declined to restart with a rotated payment key; restoring "
+                    + "the previous key", victimStoreId);
+                await _settingsStore.SetAsync(victimStoreId, settings).ConfigureAwait(false);
+                return false;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Store {StoreId}: could not rotate its payment key; restoring the previous key", victimStoreId);
+            try
+            {
+                await _settingsStore.SetAsync(victimStoreId, settings).ConfigureAwait(false);
+            }
+            catch (Exception rollbackEx)
+            {
+                _logger.LogError(rollbackEx,
+                    "Store {StoreId}: could not restore the previous payment key after a failed rotation",
+                    victimStoreId);
+            }
+
+            return false;
+        }
+
+        // Only a configuration that still points at Spark is rewritten; a merchant who moved their
+        // Lightning to their own node keeps that configuration untouched.
+        try
+        {
+            var current = await _wiring.InspectAsync(victimStoreId, paymentKey: null, cancellationToken)
+                .ConfigureAwait(false);
+            if (current.State is SparkLightningWiringState.Spark or SparkLightningWiringState.StaleSpark)
+            {
+                var wired = await _wiring.EnableAsync(victimStoreId, rotated.PaymentKey, cancellationToken)
+                    .ConfigureAwait(false);
+                if (!wired)
+                {
+                    _logger.LogWarning(
+                        "Store {StoreId}: its payment key was rotated, but its Lightning configuration could "
+                        + "not be rewritten; the store's own copy of the connection string is now stale",
+                        victimStoreId);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Store {StoreId}: its payment key was rotated, but its Lightning configuration could not be "
+                + "re-inspected or rewritten", victimStoreId);
+        }
+
+        _logger.LogInformation(
+            "Store {StoreId}: payment key rotated because another store's Lightning configuration pointed at "
+            + "this wallet", victimStoreId);
+        return true;
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkLightningWiring.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkLightningWiring.cs
@@ -32,9 +32,11 @@ public enum SparkLightningWiringState
     StaleSpark,
 
     /// <summary>
-    /// The store points at <em>another</em> store's Spark wallet. Also not ours to clear: the connection
-    /// string is store-bound and the handler will refuse it, but overwriting another store's intent is worse
-    /// than leaving a visibly broken configuration.
+    /// The store points at <em>another</em> store's Spark wallet — the one configuration that is broken by
+    /// definition, because there is no legitimate reason for one store's Lightning payment method to drive
+    /// another store's wallet. It is refused at save time (<c>SparkLightningClient.Validate</c>) and cleared
+    /// by <see cref="SparkLightningConfigSweeper"/> at startup; until then the status page reports it in red
+    /// as the configuration to repair.
     /// </summary>
     OtherStoreSpark
 }
@@ -163,6 +165,44 @@ public sealed class SparkLightningWiring
         }
 
         return cleared;
+    }
+
+    /// <summary>
+    /// Removes a store's Lightning payment method because it points at <em>another</em> store's Spark
+    /// wallet. Returns the embedded id of the victim wallet, or null when there is nothing cross-store to
+    /// clear.
+    /// </summary>
+    /// <remarks>
+    /// The sweep's remediation, deliberately narrower than <see cref="ClearIfOursAsync"/>: only a valid
+    /// Spark connection string embedding a <em>different</em> store id is cleared, so this can never touch
+    /// an <c>OtherNode</c> configuration (a merchant's own Lightning node), the internal node, or a
+    /// malformed string whose owner is unknown.
+    /// </remarks>
+    public async Task<string?> ClearCrossStoreAsync(string storeId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(storeId);
+
+        var config = await _configStore.GetAsync(storeId, cancellationToken).ConfigureAwait(false);
+        if (config?.ConnectionString is not { } connectionString)
+            return null;
+
+        var parsed = SparkConnectionString.Parse(connectionString, out var configuredStoreId, out _, out _);
+        if (parsed is not SparkConnectionStringParseResult.Ok ||
+            configuredStoreId is null ||
+            string.Equals(configuredStoreId, storeId, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var cleared = await _configStore.SetAsync(storeId, null, cancellationToken).ConfigureAwait(false);
+        if (cleared)
+        {
+            _logger.LogWarning(
+                "Store {StoreId}: removed its Lightning payment method, which pointed at store "
+                + "{VictimStoreId}'s Spark wallet", storeId, configuredStoreId);
+        }
+
+        return configuredStoreId;
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint/Services/SparkReconciliationTask.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkReconciliationTask.cs
@@ -44,11 +44,16 @@ namespace BTCPayServer.Plugins.Flint.Services;
 public class SparkReconciliationTask : IPeriodicTask
 {
     private readonly SparkService _sparkService;
+    private readonly SparkLightningConfigSweeper _configSweeper;
     private readonly ILogger<SparkReconciliationTask> _logger;
 
-    public SparkReconciliationTask(SparkService sparkService, ILogger<SparkReconciliationTask> logger)
+    public SparkReconciliationTask(
+        SparkService sparkService,
+        SparkLightningConfigSweeper configSweeper,
+        ILogger<SparkReconciliationTask> logger)
     {
         _sparkService = sparkService;
+        _configSweeper = configSweeper;
         _logger = logger;
     }
 
@@ -60,5 +65,11 @@ public class SparkReconciliationTask : IPeriodicTask
             _logger.LogInformation(
                 "Spark reconciliation settled {Settled} Lightning invoice(s) across all stores", settled);
         }
+
+        // The same backstop the startup path runs, repeated on the reconciliation cadence so a cross-store
+        // Lightning configuration written outside HTTP (a direct database edit, another plugin) survives at
+        // most one interval rather than until the next restart. Idempotent: once a cross-store configuration
+        // is cleared and its victim's key rotated, later passes find nothing to do.
+        await _configSweeper.SweepAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -128,6 +128,11 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<SparkService> _logger;
 
+    // Deferred, not injected: SparkLightningConfigSweeper depends on this service (its settings store), so
+    // resolving it eagerly would close a singleton cycle the container cannot always report cleanly. This is
+    // the same deferral the connection-string handler and the value oracle use, for the same reason.
+    private readonly Func<SparkLightningConfigSweeper> _configSweeperFactory;
+
     /// <summary>
     /// Cached per-store settings, keyed by store id. Populated once in <see cref="StartAsync"/> and kept in
     /// sync by <see cref="Set"/>.
@@ -184,6 +189,7 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
         SparkLightningWiring lightningWiring,
         IBolt11Parser bolt11Parser,
         TimeProvider timeProvider,
+        Func<SparkLightningConfigSweeper> configSweeperFactory,
         ILoggerFactory loggerFactory,
         ILogger<SparkService> logger) : base(eventAggregator, logger)
     {
@@ -206,6 +212,7 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
         _mnemonicProtector = mnemonicProtector;
         _lightningWiring = lightningWiring;
         _bolt11Parser = bolt11Parser;
+        _configSweeperFactory = configSweeperFactory;
         _loggerFactory = loggerFactory;
         _logger = logger;
     }
@@ -301,10 +308,20 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
             _startupGate.TrySetResult();
         }
 
-        // Catch up on anything that settled while the process was down. Not awaited: it is a database and SSP
-        // walk over every store, and the host must not wait on it. The scheduled task then repeats it.
+        // Catch up on anything that settled while the process was down, and clear any cross-store Lightning
+        // configuration saved before the save-time guard existed. Not awaited: both are walks over every
+        // store, and the host must not wait on them.
         _ = Task.Run(async () =>
         {
+            try
+            {
+                await SweepLightningConfigsAsync(CancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (!CancellationToken.IsCancellationRequested)
+            {
+                _logger.LogError(ex, "The Spark startup Lightning configuration sweep failed");
+            }
+
             try
             {
                 await ReconcileAllStoresAsync(CancellationToken).ConfigureAwait(false);
@@ -954,6 +971,16 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
         await _startupGate.Task.ConfigureAwait(false);
         return _instances.Keys.ToList();
     }
+
+    /// <summary>
+    /// One pass of the cross-store Lightning configuration sweep: clears any store whose Lightning payment
+    /// method embeds another store's Spark wallet, and rotates that victim's payment key. See
+    /// <see cref="SparkLightningConfigSweeper"/> for why this exists and why clearing cannot damage a
+    /// deliberate configuration.
+    /// </summary>
+    public async Task<SparkLightningConfigSweepResult> SweepLightningConfigsAsync(
+        CancellationToken cancellationToken = default) =>
+        await _configSweeperFactory().SweepAsync(cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// The live client for a store, or null when the store has not configured Spark or its instance failed to

--- a/BTCPayServer.Plugins.Flint/Services/SparkSettlementReconciler.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSettlementReconciler.cs
@@ -158,15 +158,6 @@ public class SparkSettlementReconciler
                     storeId, paymentHash);
                 break;
 
-            case InvoiceSettlementOutcome.RefusedCancelled:
-                // Spark has no way to withdraw an invoice from the service provider, so a cancelled invoice
-                // can still be paid. The funds are in the wallet; the BTCPay invoice must stay unpaid.
-                _logger.LogWarning(
-                    "Store {StoreId}: received {AmountSats} sat for cancelled invoice {PaymentHash}. The funds "
-                    + "are in the Spark balance but the BTCPay invoice will not be marked paid",
-                    storeId, payment.AmountSats, paymentHash);
-                break;
-
             default:
                 _logger.LogWarning(
                     "Store {StoreId}: received {AmountSats} sat for payment hash {PaymentHash}, which this "
@@ -288,7 +279,9 @@ public class SparkSettlementReconciler
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(record);
-        if (record.Status is not InvoiceRecordStatus.Unpaid)
+        // Paid is terminal. A cancelled invoice is still scanned: on Spark it remains payable, so a late
+        // payment must be found and credited here (see InvoiceRecord.EffectiveStatus).
+        if (record.Status is InvoiceRecordStatus.Paid)
             return record;
 
         var payment = await FindReceiveAsync(sdk, record, cancellationToken).ConfigureAwait(false);

--- a/BTCPayServer.Plugins.Flint/SparkConnectionStringHandler.cs
+++ b/BTCPayServer.Plugins.Flint/SparkConnectionStringHandler.cs
@@ -44,17 +44,27 @@ namespace BTCPayServer.Plugins.Flint;
 /// store. That closes the <em>key-without-a-store-id</em> hole in the prior-art plugin, where a bare key
 /// could be pointed at any wallet.</para>
 /// <para>
-/// <b>It does not make the string safe to leak.</b> <see cref="Create"/> receives only the string and the
-/// network — <see cref="ILightningConnectionStringHandler"/> passes no owning store — so the store is
-/// resolved from <em>inside</em> the string and nothing compares it to the store whose payment-method
-/// config is being saved. Copy a store's whole string onto another store on the same server and that
-/// store drives the original's wallet: confirmed live in the 2026-08-07 audit, which read the victim's
-/// balance and minted an invoice into the victim's wallet through the attacker's store. The string is
-/// therefore a <b>bearer spend credential</b>, exactly like an LND macaroon.
+/// <b>Store binding is enforced now, in two plugin layers, neither of which lives in
+/// <see cref="Create"/>.</b> This handler still receives only the string and the network —
+/// <see cref="ILightningConnectionStringHandler"/> passes no owning store — so the store is resolved from
+/// <em>inside</em> the string and nothing in here can compare it to the store being configured. What
+/// closes the cross-store copy is the plugin around this handler. Saving a string on a store it does not
+/// belong to is refused by <see cref="SparkLightningClient.Validate"/>, which runs inside the save request
+/// where core has placed the configured store on the <c>HttpContext</c>; a configuration that predates
+/// that check is cleared by <see cref="Services.SparkLightningConfigSweeper"/> at startup, which also
+/// rotates the victim's payment key so previously leaked copies of the string stop resolving. The
+/// 2026-08-07 audit's "copy store B's whole string onto store A" reproduction now fails validation on
+/// every HTTP save path, and a copy that already exists is swept on the next startup.
+/// </para>
+/// <para>
+/// The string remains a <b>bearer spend credential</b> within that bound — exactly like an LND macaroon,
+/// anyone who holds it may still save it on the store it names — so it still must be treated as a secret,
+/// and the residual exposure is this handler's own limitation, unchanged: <see cref="Create"/> resolves
+/// from the string alone, so enforcement depends on the two plugin layers, not on the string itself.
 /// <see cref="Services.SparkStoreProvisioner"/> rotates the payment key on every provision, so re-running
-/// setup revokes every previously issued string; between provisions the string never expires. Treat it as
-/// a secret, and do not restate the older, stronger claim that store binding closes cross-store hijack
-/// outright.
+/// setup revokes every previously issued string; between provisions the string never expires. Do not
+/// restate the older claim that store binding closes cross-store hijack outright — it now closes the
+/// <em>save</em> paths and sweeps what predates them.
 /// </para>
 /// <para>There is deliberately no <c>server=</c> key, so
 /// BTCPay's <c>IsSafe</c> check passes and non-admin store owners can save the configuration.</para>

--- a/BTCPayServer.Plugins.Flint/SparkLightningClient.cs
+++ b/BTCPayServer.Plugins.Flint/SparkLightningClient.cs
@@ -11,6 +11,7 @@ using BTCPayServer.Payments.Lightning;
 using BTCPayServer.Plugins.Flint.Data;
 using BTCPayServer.Plugins.Flint.Sdk;
 using BTCPayServer.Plugins.Flint.Services;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 
@@ -109,6 +110,7 @@ public class SparkLightningClient : IExtendedLightningClient, IDisposable
     private readonly SparkSettlementReconciler _reconciler;
     private readonly ISparkSettlementSubscriber _settlements;
     private readonly IBolt11Parser _bolt11Parser;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger _logger;
 
     public SparkLightningClient(
@@ -120,7 +122,8 @@ public class SparkLightningClient : IExtendedLightningClient, IDisposable
         SparkSettlementReconciler reconciler,
         ISparkSettlementSubscriber settlements,
         IBolt11Parser bolt11Parser,
-        ILogger logger)
+        ILogger logger,
+        IHttpContextAccessor? httpContextAccessor = null)
     {
         _storeId = storeId ?? throw new ArgumentNullException(nameof(storeId));
         _paymentKey = paymentKey ?? throw new ArgumentNullException(nameof(paymentKey));
@@ -130,6 +133,10 @@ public class SparkLightningClient : IExtendedLightningClient, IDisposable
         _reconciler = reconciler ?? throw new ArgumentNullException(nameof(reconciler));
         _settlements = settlements ?? throw new ArgumentNullException(nameof(settlements));
         _bolt11Parser = bolt11Parser ?? throw new ArgumentNullException(nameof(bolt11Parser));
+        // A bare HttpContextAccessor reads the process-wide AsyncLocal, so a fresh instance per client is
+        // every bit as correct as a shared one; the optional parameter is what keeps the test fixtures that
+        // build clients outside a request from having to supply one.
+        _httpContextAccessor = httpContextAccessor ?? new HttpContextAccessor();
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -147,16 +154,43 @@ public class SparkLightningClient : IExtendedLightningClient, IDisposable
 
     /// <summary>
     /// Called by BTCPay when the merchant saves the Lightning payment method, to tell them what is wrong
-    /// before the configuration is accepted.
+    /// before the configuration is accepted. Refuses to accept another store's connection string, then
+    /// proves the wallet this string names is alive.
     /// </summary>
     /// <remarks>
-    /// Uses the cached, non-syncing <c>GetInfo</c>: it returns in ~0 ms and proves the native handle is
-    /// alive and this store's instance has not been torn down. It deliberately does not force a sync — a
-    /// ~2.2 s SSP round trip on a settings save is not worth the extra certainty, and a wallet that cannot
-    /// reach the SSP is reported by the startup warm-up instead.
+    /// <para>
+    /// <b>The store-binding check is the plugin's cross-store defence.</b> A connection string embeds the
+    /// store it belongs to (<c>store-id=…</c>) and the resolver returns that store's wallet, so saving store
+    /// B's complete string on store A would make A receive into and spend from B's wallet. The handler
+    /// cannot detect this — BTCPay's <c>ILightningConnectionStringHandler.Create</c> is never told which
+    /// store is being configured — but <c>Validate</c> runs inside the save request itself, where core's
+    /// authorisation has placed the store being configured on the <see cref="HttpContext"/>
+    /// (<c>GetStoreDataOrNull</c>). If that store differs from the one this client is bound to, the string
+    /// is being saved on the wrong store: refuse with a generic error that names neither store. A missing
+    /// context (a background call, a route core has not authorised) means there is nothing to compare, and
+    /// the check passes — the startup sweep (<c>SparkLightningConfigSweeper</c>) is the backstop for
+    /// configurations that predate this check or that were written without one.
+    /// </para>
+    /// <para>
+    /// The live check uses the cached, non-syncing <c>GetInfo</c>: it returns in ~0 ms and proves the native
+    /// handle is alive and this store's instance has not been torn down. It deliberately does not force a
+    /// sync — a ~2.2 s SSP round trip on a settings save is not worth the extra certainty, and a wallet that
+    /// cannot reach the SSP is reported by the startup warm-up instead. The store check runs first, so a
+    /// mismatched string is refused without contacting the wallet it names.
+    /// </para>
     /// </remarks>
     public async Task<ValidationResult?> Validate()
     {
+        var configuredStoreId = _httpContextAccessor.HttpContext?.GetStoreDataOrNull()?.Id;
+        if (configuredStoreId is not null &&
+            !string.Equals(configuredStoreId, _storeId, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "Refusing to save a connection string for store {EmbeddedStoreId} on store {TargetStoreId}",
+                _storeId, configuredStoreId);
+            return new ValidationResult("This connection string belongs to another store on this server.");
+        }
+
         try
         {
             await _sdk.GetInfoAsync(ensureSynced: false).ConfigureAwait(false);
@@ -347,9 +381,10 @@ public class SparkLightningClient : IExtendedLightningClient, IDisposable
     /// </summary>
     /// <remarks>
     /// The Spark SDK has no invoice-cancellation primitive, so this is implemented locally: the record is
-    /// marked cancelled and the settlement path then refuses to report it paid. A payment that arrives for a
-    /// cancelled invoice still credits the store's Spark balance — it cannot be turned away — but it will not
-    /// settle the BTCPay invoice, and the refusal is logged as a warning both here and in the event consumer.
+    /// marked cancelled and no longer offered to payers, but the invoice stays payable on the service
+    /// provider and a late payment still settles it and credits the BTCPay invoice it was minted for. The
+    /// money is real and the alternative is unattributed sats in the wallet; cancellation buys bookkeeping,
+    /// not withdrawal.
     /// <para>
     /// Deliberately does not throw when there is nothing to cancel: BTCPay calls this speculatively, and a
     /// throw would be logged as an error for every invoice that had already been paid.
@@ -365,7 +400,7 @@ public class SparkLightningClient : IExtendedLightningClient, IDisposable
         {
             _logger.LogInformation(
                 "Store {StoreId}: invoice {PaymentHash} cancelled locally. Spark cannot withdraw it from the " +
-                "service provider, so a late payment would credit the wallet balance without settling it",
+                "service provider, so a late payment still settles and credits the BTCPay invoice it belongs to",
                 _storeId, paymentHash);
             return;
         }

--- a/BTCPayServer.Plugins.Flint/SparkPlugin.cs
+++ b/BTCPayServer.Plugins.Flint/SparkPlugin.cs
@@ -9,6 +9,7 @@ using BTCPayServer.Plugins.Flint.Services;
 using BTCPayServer.Services.Invoices;
 using BTCPayServer.Services.Rates;
 using BTCPayServer.Services.Stores;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
@@ -89,6 +90,19 @@ public class SparkPlugin : BaseBTCPayServerPlugin
         // itself is the thin part that talks to BTCPay.
         services.AddSingleton<IStoreLightningConfigStore, BTCPayStoreLightningConfigStore>();
         services.AddSingleton<SparkLightningWiring>();
+
+        // Cross-store enforcement. The save-time refusal lives in SparkLightningClient.Validate (which reads
+        // the configured store off the request via IHttpContextAccessor below); this sweep is the backstop
+        // for configurations that predate it. Registered as itself and through a deferred Func, because it
+        // depends on SparkService (its settings store) and SparkService reaches it back through that Func.
+        services.AddSingleton<ISparkStoreIdSource, BTCPayStoreIdSource>();
+        services.AddSingleton<SparkLightningConfigSweeper>();
+        services.TryAddSingleton<Func<SparkLightningConfigSweeper>>(provider =>
+            provider.GetRequiredService<SparkLightningConfigSweeper>);
+
+        // The request context Validate reads to learn which store a connection string is being saved on.
+        // ASP.NET does not register this by default (BTCPay does not either), so the plugin does, idempotently.
+        services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
         // Per-store SDK lifecycle owner. Registered once and exposed as itself (views and the setup
         // controller resolve it directly), as the connection-string resolver, as the settings store the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,19 @@ All notable changes to this plugin are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-The version in [`BTCPayServer.Plugins.Flint.csproj`](BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj)
-is the single source of truth, and `PluginVersionTests` asserts that it matches the newest heading
-below — so a release that forgets this file fails the test suite.
+## [Unreleased]
+
+### Security
+
+- **A late payment of a superseded or cancelled invoice now credits the BTCPay invoice it was minted
+  for.** The Spark SDK has no way to withdraw an invoice from the service provider, so a bolt11 that
+  BTCPay replaced (a sequential request to a public TopUp LNURL callback, for example) remains
+  payable. Previously the plugin marked the invoice cancelled locally and refused the later
+  server-confirmed settlement, leaving the funds unattributed in the merchant's Spark balance while
+  the BTCPay invoice stayed unpaid. Now the settlement is recorded and published like any other: the
+  payment's hash names the invoice it pays, and that invoice is the one BTCPay credits. A cancelled
+  invoice is also reported as unpaid rather than expired until it settles, so BTCPay's listener does
+  not drop it before a late payment can arrive.
 
 ## [0.1.5.2] — 2026-08-22
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -94,7 +94,9 @@ that could lead to:
   cross-chain destination resolution, idempotency of sends, and the classification of a send whose
   outcome is unknown.
 - **Cross-store isolation failures** — one store reading, configuring, sweeping or spending
-  another store's wallet, through the UI or the Greenfield API.
+  another store's wallet, through the UI or the Greenfield API. (The Lightning connection string is
+  store-bound at save time and cross-store configurations are swept at startup with the victim's key
+  rotated; the exact model and its residual are in [docs/trust-model.md](docs/trust-model.md).)
 - **Authorisation failures** — any plugin route reachable without the BTCPay permission it should
   require.
 - **Request amplification** against third-party providers through the plugin's own endpoints.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -7,8 +7,11 @@
   plain description goes into the BOLT11 `d` tag and the `h` tag is left unset. Most wallets tolerate
   this; a strict one may reject the invoice. Pending an upstream Breez feature request.
 - **Cancelling an invoice is local only.** Spark has no way to withdraw an invoice from the service
-  provider, so a payment arriving for a cancelled invoice still credits the store's Spark balance. It
-  will not settle the BTCPay invoice, and the mismatch is logged as a warning.
+  provider, so a payment arriving for a cancelled — even a superseded — invoice still settles and
+  credits the BTCPay invoice it was minted for. What cancellation actually buys is bookkeeping: the
+  invoice is no longer offered to payers, and a late payment is attributed to it, not to its
+  replacement. The plugin keeps reporting a cancelled invoice as unpaid (never expired) until it
+  settles, so BTCPay's Lightning listener stays attached and can deliver that credit.
 - **Testnet and signet are unsupported**, because the SDK only offers mainnet and regtest.
 - **The SDK's own log cannot be turned up to `trace`, on purpose.** The plugin installs the Rust SDK's
   logging subscriber, which writes `<DataDir>/Plugins/Flint/logs/sdk.log` *and* forwards every line into

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -25,16 +25,22 @@ wallet as an ordinary transfer to the provider's address and depend on the provi
 side; until it does, they are neither on Spark nor at the destination. The plugin records the provider's own
 quote id before sending and reports what it says it delivered, which is the most the SDK exposes.
 
-**The store's Lightning connection string is a bearer spend credential.** Setup writes a
-`type=flint;store-id=…;key=…` string into the store's Lightning payment method. Anyone who can read it
-— any principal with `CanModifyStoreSettings` on the store, plus anything that string was ever pasted into —
-can save it on *another* store on the same server and drive this store's wallet from there: receive into it
-and spend from it. The embedded store id binds the key to a wallet; it does not bind the string to the store
-it was saved on, because BTCPay's `ILightningConnectionStringHandler` never tells a handler which store is
-being configured. This is the same property an LND macaroon has, with one difference worth knowing: the
-plugin generated this credential for you rather than you choosing to issue it. It **is rotated on every
-provision** — setting Spark up again (same seed or a new one) mints a fresh key and rewrites the store's
-Lightning configuration with it, invalidating every copy of the old string — so a leaked string is revoked
-by re-running setup, without waiting for a removal. Between provisions it never expires. Treat it like a
-macaroon, and keep the sweep threshold low enough that the balance it could reach is a balance you can
-afford to lose.
+**The store's Lightning connection string is a bearer spend credential, store-bound at save time.**
+Setup writes a `type=flint;store-id=…;key=…` string into the store's Lightning payment method. The
+embedded store id binds the key to a wallet, and the plugin refuses to save the string on any *other*
+store: `SparkLightningClient.Validate` runs inside every save request — the store's own Lightning settings
+page and the Greenfield PUT alike — where core has placed the store being configured, and rejects a string
+naming a different store. A cross-store configuration that predates or bypasses that check is cleared at
+startup by the plugin's configuration sweep, which also rotates the victim's payment key so every
+previously leaked copy of the victim's string stops resolving. What this leaves: anyone who can *read* the
+string still holds a live credential for the wallet it names — save it on the victim's own store and it
+works — so it must still be treated as a secret; what is closed is the import onto another store through
+any HTTP save path, which is exactly the cross-store drive this paragraph used to describe as open. The
+caveats on the enforcement are that BTCPay's `ILightningConnectionStringHandler` is still never told which
+store is being configured, so the two plugin layers (*save-time refusal* and *startup sweep*) carry the
+enforcement rather than the string itself, and that the plugin generated this credential for you rather
+than you choosing to issue it. It **is rotated on every provision** — setting Spark up again (same seed or
+a new one) mints a fresh key and rewrites the store's Lightning configuration with it, invalidating every
+copy of the old string — so a leaked string is revoked by re-running setup, without waiting for a removal.
+Between provisions it never expires. Treat it like a macaroon, and keep the sweep threshold low enough that
+the balance it could reach is a balance you can afford to lose.


### PR DESCRIPTION
Closes both audit findings on `main` (v0.1.5.2):

**1. A late payment of a superseded/cancelled BOLT11 now credits the BTCPay invoice it was minted for.**
Spark has no invoice-cancellation primitive; previously the plugin marked the invoice cancelled locally and refused the later server-confirmed settlement, orphanating the funds in the merchant's Spark balance. Now a cancelled invoice still settles (store CAS widens to `Status != Paid`, `RefusedCancelled` removed) and stays reported `Unpaid` (never `Expired`) until it settles, so BTCPay's Lightning listener keeps it and can deliver the credit. Reconciliation re-checks cancelled rows within the grace window; the SDK payment id stays recordable after a cancel.

**2. Connection strings are now store-bound at save time, with a startup sweep as backstop.**
The handler resolves the wallet from the `store-id` embedded in the string and core never tells a handler which store is being configured. Now:
- `SparkLightningClient.Validate` (run by core on both the UI and Greenfield payment-method save paths) reads the configured store off the `HttpContext` and refuses a string naming a different store.
- `SparkLightningConfigSweeper` runs at startup: clears any cross-store (`OtherStoreSpark`) Lightning configuration and rotates the victim's payment key, so every leaked copy of the victim's string stops resolving.
- Fixed the `SparkLightningWiring` comment that incorrectly claimed the handler refuses cross-store strings; trust-model/SECURITY/swagger updated.

Residual (documented): the handler itself still resolves string-only, so enforcement rests on the two plugin layers; a string remains a bearer credential for its own store.

Verification: 1,181 tests, 0 failures (1,174 pass, 7 skipped = funded regtest only) against real Postgres 17.

Test targets: after merge, build and deploy to **btcpay-stg** and **btcpay-dev**.