### PR TITLE
Route every settled BOLT11 to its BTCPay invoice, surviving restarts

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/BTCPayInvoiceCreditGatewayTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/BTCPayInvoiceCreditGatewayTests.cs
@@ -1,0 +1,231 @@
+using BTCPayServer.Lightning;
+using BTCPayServer.Payments;
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using NBitcoin;
+using NBitcoin.Crypto;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The load-bearing details of the real credit gateway, tested away from BTCPay's database.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why these are here rather than as an integration test.</b> <see cref="BTCPayInvoiceCreditGateway"/> writes
+/// through core's <c>InvoiceRepository</c> and <c>PaymentService</c>, which need a real
+/// <c>ApplicationDbContext</c> and a Postgres database to construct — out of reach of this suite. What can be
+/// tested, and what actually carries the risk, is the pure logic those calls are wrapped around: a byte-order
+/// convention, a unit conversion, and a decision about whose preimage may be written where. Every one of them
+/// was hand-verified against core and nothing else, which is exactly the state a regression hides in.
+/// </para>
+/// <para>
+/// The remaining seam — that the container really can hand this class the deferred <c>PaymentService</c> and
+/// <c>PaymentMethodHandlerDictionary</c> it resolves on first use — is covered in
+/// <see cref="SparkPluginStartupTests"/>, because that needs BTCPay's own container and this does not.
+/// </para>
+/// </remarks>
+public class BTCPayInvoiceCreditGatewayTests
+{
+    private static uint256 HashOf(string preimageHex) =>
+        new(Convert.ToHexStringLower(Hashes.SHA256(Convert.FromHexString(preimageHex))));
+
+    // -----------------------------------------------------------------------------------------------------------
+    // Preimage validation: two byte orders, and they are not interchangeable
+    // -----------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_preimage_that_hashes_to_the_payment_hash_is_stored_in_BTCPays_byte_order()
+    {
+        // The convention core uses for this field, replicated — and the reversal in it is not cosmetic. What is
+        // stored is a uint256 built from the *reversed* wire bytes, because uint256 takes its bytes
+        // little-endian and renders them big-endian; the two cancel, and the field reads back as the preimage
+        // hex. That readback is the whole point: LUD-21 verify serves this value to the payer as their proof of
+        // payment. Drop the reversal and the payment is still credited, the field still looks populated, and
+        // every proof it serves is byte-reversed garbage that nothing in a running server would flag.
+        var paymentHash = HashOf(PaymentFixture.Preimage);
+
+        var validity = BTCPayInvoiceCreditGateway.ValidatePreimage(
+            PaymentFixture.Preimage, paymentHash, out var stored);
+
+        Assert.Equal(BTCPayInvoiceCreditGateway.PreimageValidity.Valid, validity);
+        Assert.NotNull(stored);
+        Assert.Equal(PaymentFixture.Preimage, stored.ToString());
+
+        // And the check a payer performs on what they were served: hash it, and land back on the payment hash.
+        Assert.Equal(
+            paymentHash.ToString(),
+            Convert.ToHexStringLower(Hashes.SHA256(Convert.FromHexString(stored.ToString()))));
+    }
+
+    [Fact]
+    public void The_known_fixture_pair_is_the_pair_this_validation_accepts()
+    {
+        // Against the vector recorded out of band — the pair the service provider actually produced for the
+        // funded regtest self-payment — so this suite's fixture and core's check are pinned to each other rather
+        // than to the same expression evaluated twice.
+        var paymentHash = new uint256(PaymentFixture.KnownPaymentHashVector);
+
+        Assert.Equal(
+            BTCPayInvoiceCreditGateway.PreimageValidity.Valid,
+            BTCPayInvoiceCreditGateway.ValidatePreimage(PaymentFixture.Preimage, paymentHash, out _));
+    }
+
+    [Fact]
+    public void A_preimage_that_does_not_hash_to_the_payment_hash_is_dropped_rather_than_stored()
+    {
+        // A preimage is a proof. Storing an unverifiable one as though it had been verified would let a future
+        // dispute be settled with a value nothing ever checked. Dropping it costs only the proof — the payment
+        // is recorded regardless — and the caller logs it at operator level.
+        var wrongHash = HashOf(
+            "aa03f7557bae8ffda088b42ee758edd048ae8689f87f7de41d9fb3b132341238");
+
+        var validity = BTCPayInvoiceCreditGateway.ValidatePreimage(
+            PaymentFixture.Preimage, wrongHash, out var stored);
+
+        Assert.Equal(BTCPayInvoiceCreditGateway.PreimageValidity.Mismatched, validity);
+        Assert.Null(stored);
+    }
+
+    /// <remarks>
+    /// The expected outcome travels as its name rather than as the enum value, because the enum is internal and
+    /// an xUnit theory method has to be public. Named through <c>nameof</c> so a rename is a compile error
+    /// rather than a test that silently stops distinguishing anything.
+    /// </remarks>
+    [Theory]
+    // The service provider's HTLC details make the preimage optional, so absent is ordinary, not an error.
+    [InlineData(null, nameof(BTCPayInvoiceCreditGateway.PreimageValidity.Absent))]
+    [InlineData("", nameof(BTCPayInvoiceCreditGateway.PreimageValidity.Absent))]
+    // Too short, too long, and the right length but not hex. None of them can be checked against a hash, so
+    // none is reported as a mismatch — that distinction is what decides whether an operator is warned.
+    [InlineData("4ec10d84", nameof(BTCPayInvoiceCreditGateway.PreimageValidity.Malformed))]
+    [InlineData(
+        "4ec10d840654ca609a1aa33dd5db662934f9fb0a3cda6656b9a138409493954e00",
+        nameof(BTCPayInvoiceCreditGateway.PreimageValidity.Malformed))]
+    [InlineData(
+        "zzc10d840654ca609a1aa33dd5db662934f9fb0a3cda6656b9a138409493954e",
+        nameof(BTCPayInvoiceCreditGateway.PreimageValidity.Malformed))]
+    public void An_unusable_preimage_is_told_apart_from_a_wrong_one(string? preimage, string expected)
+    {
+        var validity = BTCPayInvoiceCreditGateway.ValidatePreimage(
+            preimage, HashOf(PaymentFixture.Preimage), out var stored);
+
+        Assert.Equal(expected, validity.ToString());
+        Assert.Null(stored);
+    }
+
+    // -----------------------------------------------------------------------------------------------------------
+    // Whose preimage may be written onto the prompt
+    // -----------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void The_prompt_preimage_is_filled_in_only_for_the_bolt11_the_prompt_is_offering()
+    {
+        // The guard that makes one backfill correct in two opposite situations. On an ordinary checkout the
+        // prompt is offering the BOLT11 that was paid, and LUD-21 verify serves proof-of-payment out of that
+        // field — so it has to be written, because core's listener writes it only when core's own insert wins
+        // and this path usually wins instead. On a superseded BOLT11 the prompt is offering the replacement,
+        // whose preimage this is not, and writing it would hand a payer a proof for an invoice they never paid.
+        var paid = HashOf(PaymentFixture.Preimage);
+        var replacement = HashOf("aa03f7557bae8ffda088b42ee758edd048ae8689f87f7de41d9fb3b132341238");
+
+        Assert.True(BTCPayInvoiceCreditGateway.ShouldBackfillPromptPreimage(
+            promptPaymentHash: paid, promptPreimage: null, paymentHash: paid));
+        Assert.False(BTCPayInvoiceCreditGateway.ShouldBackfillPromptPreimage(
+            promptPaymentHash: replacement, promptPreimage: null, paymentHash: paid));
+    }
+
+    [Fact]
+    public void A_prompt_that_already_has_a_preimage_is_left_alone()
+    {
+        // Core's own condition, and it means the same thing here: whoever filled it in got there first, and
+        // their value is the one that matches the prompt.
+        var paid = HashOf(PaymentFixture.Preimage);
+
+        Assert.False(BTCPayInvoiceCreditGateway.ShouldBackfillPromptPreimage(
+            promptPaymentHash: paid, promptPreimage: paid, paymentHash: paid));
+    }
+
+    [Fact]
+    public void A_prompt_with_no_payment_hash_at_all_is_left_alone()
+    {
+        // The field is nullable on core's details type. Absent is not "matches anything".
+        Assert.False(BTCPayInvoiceCreditGateway.ShouldBackfillPromptPreimage(
+            promptPaymentHash: null, promptPreimage: null, paymentHash: HashOf(PaymentFixture.Preimage)));
+    }
+
+    // -----------------------------------------------------------------------------------------------------------
+    // The amount, and the id
+    // -----------------------------------------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(0L, "0")]
+    [InlineData(1_000L, "0.00000001")]
+    [InlineData(100_000L, "0.000001")]
+    [InlineData(100_000_000_000L, "1")]
+    // Not a whole satoshi. BTCPay's payment amount is BTC-denominated, so a millisatoshi remainder has to
+    // survive the conversion rather than being truncated away from the merchant.
+    [InlineData(1_500L, "0.000000015")]
+    public void The_credited_amount_is_the_received_millisatoshis_expressed_in_BTC(long msat, string expected)
+    {
+        Assert.Equal(decimal.Parse(expected, System.Globalization.CultureInfo.InvariantCulture),
+            BTCPayInvoiceCreditGateway.ToBtc(msat));
+    }
+
+    [Fact]
+    public void The_amount_conversion_is_the_one_core_uses()
+    {
+        // Through LightMoney rather than by dividing, so it cannot drift from core's own arithmetic — which is
+        // what decides whether the merchant's invoice reads as fully paid.
+        Assert.Equal(
+            LightMoney.MilliSatoshis(123_456_789).ToDecimal(LightMoneyUnit.BTC),
+            BTCPayInvoiceCreditGateway.ToBtc(123_456_789));
+    }
+
+    [Fact]
+    public void The_payment_id_is_the_lower_case_payment_hash_core_itself_would_write()
+    {
+        // The whole exactly-once guarantee rests on this. Core's listener ids a Lightning payment with
+        // paymentHash.ToString(); this gateway ids it with the hash string it was given, which the record store
+        // guarantees is lower-case hex. If those two ever differed in case, the inserts would not collide on the
+        // payments primary key and a merchant could be credited twice for one payment.
+        var hash = PaymentFixture.PaymentHash;
+
+        Assert.Equal(hash, hash.ToLowerInvariant());
+        Assert.Equal(hash, uint256.Parse(hash).ToString());
+    }
+
+    // -----------------------------------------------------------------------------------------------------------
+    // Where a payment hash is looked for
+    // -----------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public void A_payment_hash_is_looked_for_under_lightning_first_and_LNURL_second()
+    {
+        // Order, not membership. A plain Lightning checkout always indexes the hash under BTC-LN, so probing it
+        // first makes the common case one query. BTC-LNURL is probed second because BTCPay indexes an LNURL
+        // prompt's hash only when LUD-21 is enabled — which this plugin forces on when it provisions a store, so
+        // for a Flint store both rails are covered.
+        Assert.Equal(
+            [
+                PaymentTypes.LN.GetPaymentMethodId("BTC").ToString(),
+                PaymentTypes.LNURL.GetPaymentMethodId("BTC").ToString()
+            ],
+            BTCPayInvoiceCreditGateway.CreditablePaymentMethods.Select(p => p.ToString()).ToArray());
+    }
+
+    [Fact]
+    public void The_probed_payment_methods_are_the_strings_the_credit_decision_passes_back()
+    {
+        // The decision layer carries the payment method as a string so it needs no BTCPay types, and the gateway
+        // parses it back on the way in. A round trip, because crediting under the wrong payment method would
+        // insert a second payment for the same money rather than colliding with core's.
+        foreach (var paymentMethodId in BTCPayInvoiceCreditGateway.CreditablePaymentMethods)
+            Assert.Equal(paymentMethodId, PaymentMethodId.Parse(paymentMethodId.ToString()));
+
+        Assert.Equal(
+            [FakeInvoiceCreditGateway.LightningPaymentMethodId, FakeInvoiceCreditGateway.LnurlPaymentMethodId],
+            BTCPayInvoiceCreditGateway.CreditablePaymentMethods.Select(p => p.ToString()).ToArray());
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeInvoiceCreditGateway.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeInvoiceCreditGateway.cs
@@ -1,0 +1,174 @@
+using BTCPayServer.Plugins.Flint.Services;
+
+namespace BTCPayServer.Plugins.Flint.Tests.Fakes;
+
+/// <summary>
+/// An <see cref="IInvoiceCreditGateway"/> that models the two BTCPay tables the real one talks to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Not a stub that returns configured answers: the properties the credit path depends on are properties of
+/// BTCPay's schema, and a fake that did not have them would make every assertion here hollow. Two things are
+/// modelled, and both are load-bearing.
+/// </para>
+/// <para>
+/// <b><c>AddressInvoices</c> is insert-only.</b> BTCPay writes the payment hash of every prompt it issues
+/// into that table when the prompt is minted and never removes it, so superseding BOLT11 X with BOLT11 Y
+/// leaves <em>both</em> hashes pointing at the same invoice. That is the entire basis for crediting a payment
+/// to a replaced BOLT11, so <see cref="Mint"/> only ever adds.
+/// </para>
+/// <para>
+/// <b><c>Payments</c> has primary key <c>(Id, PaymentMethodId)</c>.</b> That collision — not any ordering or
+/// lock — is what makes the credit exactly-once when BTCPay's own listener and this plugin both try. A second
+/// insert for the same pair is refused with <see cref="SparkInvoiceCreditOutcome.AlreadyRecorded"/>, exactly
+/// as core's <c>PaymentService.AddPayment</c> answers null on the <c>DbUpdateException</c>.
+/// </para>
+/// <para>
+/// <b>An invoice has exactly one <em>current</em> payment prompt, and it carries the preimage.</b> The third
+/// property, and the one that is easiest to get wrong in the opposite direction from the first: the hash index
+/// keeps every BOLT11 an invoice ever offered, but the prompt holds only the latest, and the prompt is where
+/// LUD-21 <c>verify</c> reads proof-of-payment from. So <see cref="Mint"/> <em>replaces</em> the prompt while
+/// only adding to the index — that asymmetry is the superseding — and a credit fills the prompt's preimage only
+/// when the prompt is still offering the BOLT11 that was paid.
+/// </para>
+/// </remarks>
+public sealed class FakeInvoiceCreditGateway : IInvoiceCreditGateway
+{
+    /// <summary>The payment method ids BTCPay indexes a Lightning payment hash under.</summary>
+    public const string LightningPaymentMethodId = "BTC-LN";
+
+    /// <inheritdoc cref="LightningPaymentMethodId" />
+    public const string LnurlPaymentMethodId = "BTC-LNURL";
+
+    private readonly Dictionary<string, Row> _addressInvoices = new(StringComparer.Ordinal);
+    private readonly HashSet<(string Id, string PaymentMethodId)> _payments = [];
+    private readonly Dictionary<string, Prompt> _prompts = new(StringComparer.Ordinal);
+
+    private sealed record Row(string InvoiceId, string StoreId, string PaymentMethodId);
+
+    /// <summary>An invoice's current payment prompt: the BOLT11 it offers now, and its preimage once known.</summary>
+    private sealed class Prompt
+    {
+        public required string PaymentHash { get; init; }
+        public string? Preimage { get; set; }
+    }
+
+    /// <summary>Every accepted insert, in order. One entry per payment actually credited.</summary>
+    public List<SparkInvoiceCreditRequest> Credits { get; } = [];
+
+    /// <summary>Every attempt, accepted or not — so a test can tell "refused" from "never tried".</summary>
+    public List<SparkInvoiceCreditRequest> Attempts { get; } = [];
+
+    /// <summary>How many times a payment hash has been looked up.</summary>
+    public int Lookups { get; private set; }
+
+    /// <summary>
+    /// Payment hashes whose invoice reports no usable payment prompt, to exercise the not-retryable path.
+    /// </summary>
+    public HashSet<string> PromptMissingFor { get; } = [];
+
+    /// <summary>Thrown by both methods when set, to exercise the failure path.</summary>
+    public Exception? FailWith { get; set; }
+
+    /// <summary>
+    /// Records that BTCPay issued this payment hash for an invoice, as it does when a prompt is minted.
+    /// </summary>
+    public FakeInvoiceCreditGateway Mint(
+        string paymentHash,
+        string invoiceId,
+        string storeId,
+        string paymentMethodId = LightningPaymentMethodId)
+    {
+        // Insert-only, like the real table: superseding a BOLT11 does not remove the old hash's row.
+        _addressInvoices.TryAdd(paymentHash, new Row(invoiceId, storeId, paymentMethodId));
+        // The prompt, by contrast, is replaced — this invoice now offers this BOLT11 and no longer the previous
+        // one. Minting X then Y is exactly the supersession the credit path exists for.
+        _prompts[invoiceId] = new Prompt { PaymentHash = paymentHash };
+        return this;
+    }
+
+    /// <summary>
+    /// The preimage on an invoice's current payment prompt, or null when nothing has filled it in.
+    /// </summary>
+    /// <remarks>
+    /// This is the field LUD-21 <c>verify</c> serves proof-of-payment from — not the payment row's copy — which
+    /// is why it is asserted on separately. BTCPay's own listener fills it only when its own insert wins, so
+    /// whenever this plugin wins the race instead, filling it is this plugin's job.
+    /// </remarks>
+    public string? PromptPreimageFor(string invoiceId) =>
+        _prompts.GetValueOrDefault(invoiceId)?.Preimage;
+
+    /// <summary>The BOLT11 payment hash an invoice's prompt currently offers.</summary>
+    public string? PromptPaymentHashFor(string invoiceId) =>
+        _prompts.GetValueOrDefault(invoiceId)?.PaymentHash;
+
+    /// <summary>
+    /// Records a payment against an invoice the way BTCPay's own Lightning listener would, so a test can set
+    /// up "core got there first".
+    /// </summary>
+    public FakeInvoiceCreditGateway CreditedByBTCPay(
+        string paymentHash,
+        string paymentMethodId = LightningPaymentMethodId)
+    {
+        _payments.Add((paymentHash, paymentMethodId));
+        return this;
+    }
+
+    /// <summary>Payments recorded against one BTCPay invoice, whoever recorded them.</summary>
+    public IReadOnlyList<SparkInvoiceCreditRequest> CreditsFor(string invoiceId) =>
+        Credits.Where(c => c.InvoiceId == invoiceId).ToList();
+
+    public Task<SparkInvoiceCreditMatch?> FindByPaymentHashAsync(
+        string paymentHash,
+        CancellationToken cancellationToken = default)
+    {
+        if (FailWith is not null)
+            throw FailWith;
+
+        Lookups++;
+        if (!_addressInvoices.TryGetValue(paymentHash, out var row))
+            return Task.FromResult<SparkInvoiceCreditMatch?>(null);
+
+        return Task.FromResult<SparkInvoiceCreditMatch?>(new SparkInvoiceCreditMatch(
+            row.InvoiceId,
+            row.StoreId,
+            row.PaymentMethodId,
+            _payments.Contains((paymentHash, row.PaymentMethodId))));
+    }
+
+    public Task<SparkInvoiceCreditOutcome> AddSettledPaymentAsync(
+        SparkInvoiceCreditRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (FailWith is not null)
+            throw FailWith;
+
+        Attempts.Add(request);
+
+        if (!_addressInvoices.ContainsKey(request.PaymentHash))
+            return Task.FromResult(SparkInvoiceCreditOutcome.InvoiceGone);
+
+        if (PromptMissingFor.Contains(request.PaymentHash))
+            return Task.FromResult(SparkInvoiceCreditOutcome.PromptMissing);
+
+        // The primary key decides, exactly as it does in Postgres.
+        if (!_payments.Add((request.PaymentHash, request.PaymentMethodId)))
+            return Task.FromResult(SparkInvoiceCreditOutcome.AlreadyRecorded);
+
+        Credits.Add(request);
+
+        // And the winner of that insert backfills the prompt's preimage — but only if the prompt is still
+        // offering the BOLT11 that was paid. Crediting a superseded X must not stamp X's preimage onto the
+        // prompt now offering Y, which would have LUD-21 verify hand a payer a proof for an invoice they did not
+        // pay.
+        if (request.Preimage is not null
+            && _prompts.TryGetValue(request.InvoiceId, out var prompt)
+            && prompt.Preimage is null
+            && string.Equals(prompt.PaymentHash, request.PaymentHash, StringComparison.Ordinal))
+        {
+            prompt.Preimage = request.Preimage;
+        }
+
+        return Task.FromResult(SparkInvoiceCreditOutcome.CreditedNow);
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemoryInvoiceRecordStore.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemoryInvoiceRecordStore.cs
@@ -24,6 +24,17 @@ public sealed class InMemoryInvoiceRecordStore : IInvoiceRecordStore
     /// </remarks>
     public HashSet<string> FailSettleFor { get; } = [];
 
+    /// <summary>
+    /// Thrown by <see cref="ListForReconciliationAsync"/> when set, to exercise the reconciler's isolation of
+    /// the two walks.
+    /// </summary>
+    /// <remarks>
+    /// The settlement walk and the credit walk read different queries of the same table, and the credit of money
+    /// already received must not depend on the other query succeeding — a property that only a test which breaks
+    /// one of them can pin.
+    /// </remarks>
+    public Exception? FailReconciliationListWith { get; set; }
+
     public IReadOnlyDictionary<string, InvoiceRecord> Records => _records;
 
     public Task AddAsync(InvoiceRecord record, CancellationToken cancellationToken = default)
@@ -66,6 +77,9 @@ public sealed class InMemoryInvoiceRecordStore : IInvoiceRecordStore
         int limit,
         CancellationToken cancellationToken = default)
     {
+        if (FailReconciliationListWith is not null)
+            throw FailReconciliationListWith;
+
         IEnumerable<InvoiceRecord> query = _records.Values
             .Where(r => r.StoreId == storeId
                         && r.Status is not InvoiceRecordStatus.Paid
@@ -123,6 +137,67 @@ public sealed class InMemoryInvoiceRecordStore : IInvoiceRecordStore
         return Task.FromResult(new InvoiceSettlementResult(outcome, record));
     }
 
+    public Task<bool> MarkCreditedAsync(
+        string storeId,
+        string paymentHash,
+        DateTimeOffset creditedAt,
+        CancellationToken cancellationToken = default)
+    {
+        var record = _records.GetValueOrDefault(paymentHash);
+        if (record is null || record.StoreId != storeId)
+            return Task.FromResult(false);
+        return Task.FromResult(record.TryMarkCredited(creditedAt));
+    }
+
+    public Task<bool> MarkCreditAbandonedAsync(
+        string storeId,
+        string paymentHash,
+        DateTimeOffset abandonedAt,
+        CancellationToken cancellationToken = default)
+    {
+        var record = _records.GetValueOrDefault(paymentHash);
+        if (record is null || record.StoreId != storeId)
+            return Task.FromResult(false);
+        return Task.FromResult(record.TryMarkCreditAbandoned(abandonedAt));
+    }
+
+    public Task<IReadOnlyList<string>> ListStoreIdsAwaitingCreditAsync(
+        DateTimeOffset settledFrom,
+        int limit,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult<IReadOnlyList<string>>(_records.Values
+            .Where(r => AwaitingCredit(r, settledFrom))
+            .Select(r => r.StoreId)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(storeId => storeId, StringComparer.Ordinal)
+            .Take(limit)
+            .ToList());
+
+    public Task<IReadOnlyList<InvoiceRecord>> ListUncreditedAsync(
+        string storeId,
+        DateTimeOffset settledFrom,
+        InvoiceReconciliationCursor? after,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        IEnumerable<InvoiceRecord> query = _records.Values
+            .Where(r => r.StoreId == storeId && AwaitingCredit(r, settledFrom));
+
+        if (after is not null)
+        {
+            query = query.Where(r => r.CreatedAt > after.CreatedAt
+                                     || (r.CreatedAt == after.CreatedAt
+                                         && string.Compare(r.PaymentHash, after.PaymentHash,
+                                             StringComparison.Ordinal) > 0));
+        }
+
+        return Task.FromResult<IReadOnlyList<InvoiceRecord>>(query
+            .OrderBy(r => r.CreatedAt)
+            .ThenBy(r => r.PaymentHash, StringComparer.Ordinal)
+            .Take(limit)
+            .ToList());
+    }
+
     public Task<bool> CancelAsync(string storeId, string paymentHash, CancellationToken cancellationToken = default)
     {
         var record = _records.GetValueOrDefault(paymentHash);
@@ -130,6 +205,16 @@ public sealed class InMemoryInvoiceRecordStore : IInvoiceRecordStore
             return Task.FromResult(false);
         return Task.FromResult(record.TryCancel());
     }
+
+    /// <summary>
+    /// The uncredited predicate, shared by both listings so they cannot drift apart the way the EF store's two
+    /// <c>Where</c> clauses could not.
+    /// </summary>
+    private static bool AwaitingCredit(InvoiceRecord record, DateTimeOffset settledFrom) =>
+        record.Status is InvoiceRecordStatus.Paid
+        && record.CreditedAt is null
+        && record.CreditAbandonedAt is null
+        && record.SettledAt > settledFrom;
 
     public void Seed(InvoiceRecord record) => _records[record.PaymentHash] = record;
 }

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkServiceHarness.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkServiceHarness.cs
@@ -31,37 +31,70 @@ namespace BTCPayServer.Plugins.Flint.Tests.Fakes;
 public sealed class SparkServiceHarness : IDisposable
 {
     private readonly string _dataDir;
+    private readonly Durable _durable;
+    private readonly Deadlines _deadlines;
+    private bool _ownsDataDir = true;
+
+    /// <summary>
+    /// Everything that outlives a restart of the process, and nothing that does not.
+    /// </summary>
+    /// <remarks>
+    /// The split is the point of the restart seam. The database, BTCPay's store settings, BTCPay's invoice
+    /// index and the data-protection keys survive a restart on a real server, so <see cref="Restart"/> carries
+    /// them across; the service instance, the SDK connections and the settlement broadcaster do not, and are
+    /// rebuilt. Carrying the wrong thing across would hide exactly the class of defect this exists to catch —
+    /// notably an in-memory broadcaster that appears to keep working because the test kept it alive.
+    /// </remarks>
+    private sealed record Durable(
+        FakeStoreRepository Stores,
+        FakeStoreLightningConfigStore Lightning,
+        SparkMnemonicProtector Protector,
+        InMemoryInvoiceRecordStore Invoices,
+        FakeInvoiceCreditGateway Credits,
+        StubBolt11Parser Bolt11);
+
+    private sealed record Deadlines(
+        TimeSpan Connect,
+        TimeSpan ConfirmStatus,
+        TimeSpan AbandonedConnectGrace);
 
     private SparkServiceHarness(
         TestableSparkService service,
-        FakeStoreRepository stores,
         FakeSparkSdkClientFactory sdk,
-        FakeStoreLightningConfigStore lightning,
-        SparkMnemonicProtector protector,
-        InMemoryInvoiceRecordStore invoices,
         SparkSettlementBroadcaster broadcaster,
         CapturingLogger<SparkService> log,
-        string dataDir)
+        string dataDir,
+        Durable durable,
+        Deadlines deadlines)
     {
         Service = service;
-        Stores = stores;
         Sdk = sdk;
-        Lightning = lightning;
-        Protector = protector;
-        Invoices = invoices;
         Broadcaster = broadcaster;
         Log = log;
         _dataDir = dataDir;
+        _durable = durable;
+        _deadlines = deadlines;
     }
 
     public SparkService Service { get; }
-    public FakeStoreRepository Stores { get; }
+    public FakeStoreRepository Stores => _durable.Stores;
     public FakeSparkSdkClientFactory Sdk { get; }
-    public FakeStoreLightningConfigStore Lightning { get; }
-    public SparkMnemonicProtector Protector { get; }
+    public FakeStoreLightningConfigStore Lightning => _durable.Lightning;
+    public SparkMnemonicProtector Protector => _durable.Protector;
 
     /// <summary>The invoice records the service settles against — the far end of the event wiring.</summary>
-    public InMemoryInvoiceRecordStore Invoices { get; }
+    public InMemoryInvoiceRecordStore Invoices => _durable.Invoices;
+
+    /// <summary>
+    /// BTCPay's side of the settlement: the payment-hash index it keeps and the payments it holds.
+    /// </summary>
+    public FakeInvoiceCreditGateway Credits => _durable.Credits;
+
+    /// <summary>
+    /// What a BOLT11 means. Carried across a restart because real BOLT11 parsing is deterministic — the
+    /// registrations stand in for the invoices themselves, which of course outlive the process.
+    /// </summary>
+    public StubBolt11Parser Bolt11 => _durable.Bolt11;
 
     /// <summary>What a settled invoice is announced on, which is what wakes BTCPay's listening session.</summary>
     public SparkSettlementBroadcaster Broadcaster { get; }
@@ -99,19 +132,65 @@ public sealed class SparkServiceHarness : IDisposable
             Path.GetTempPath(), "spark-service-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dataDir);
 
+        return Create(
+            dataDir,
+            new Durable(
+                new FakeStoreRepository(),
+                FakeStoreLightningConfigStore.WithStore("unused"),
+                new SparkMnemonicProtector(new EphemeralDataProtectionProvider()),
+                new InMemoryInvoiceRecordStore(),
+                new FakeInvoiceCreditGateway(),
+                new StubBolt11Parser()),
+            new Deadlines(
+                connectDeadline ?? TimeSpan.FromMilliseconds(250),
+                confirmStatusDeadline ?? Constants.SdkCallDeadline,
+                // Long by default so the existing abandon tests still observe a late connect being adopted and
+                // shut down; the release-the-lock test shortens it deliberately.
+                abandonedConnectGrace ?? TimeSpan.FromMinutes(5)));
+    }
+
+    /// <summary>
+    /// Stops this service and brings a fresh one up over the same durable state, as a server restart does.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The returned harness is the live one and owns the data directory; this one must not be used again, and
+    /// disposing it no longer deletes the directory. Disposing the replacement tears everything down.
+    /// </para>
+    /// <para>
+    /// The data-protection provider is deliberately carried across rather than rebuilt: it is ephemeral, so a
+    /// new one could not unprotect the mnemonics the seeded store settings already hold, and every store would
+    /// fail to start for a reason that has nothing to do with what the test is asking.
+    /// </para>
+    /// </remarks>
+    public SparkServiceHarness Restart()
+    {
+        StopService();
+        _ownsDataDir = false;
+        return Create(_dataDir, _durable, _deadlines);
+    }
+
+    private static SparkServiceHarness Create(string dataDir, Durable durable, Deadlines deadlines)
+    {
         var log = new CapturingLogger<SparkService>();
         var logs = new Logs();
         logs.Configure(NullLoggerFactory.Instance);
 
-        var stores = new FakeStoreRepository();
+        var stores = durable.Stores;
         var sdk = new FakeSparkSdkClientFactory();
-        var lightning = FakeStoreLightningConfigStore.WithStore("unused");
-        var protector = new SparkMnemonicProtector(new EphemeralDataProtectionProvider());
+        var lightning = durable.Lightning;
+        var protector = durable.Protector;
 
+        // Rebuilt on every start, exactly as on a real restart: it is in-memory fan-out to whatever listening
+        // sessions exist now, and it is precisely the thing that cannot carry a pending notification across.
         var broadcaster = new SparkSettlementBroadcaster(NullLogger<SparkSettlementBroadcaster>.Instance);
-        var invoices = new InMemoryInvoiceRecordStore();
+        var invoices = durable.Invoices;
         var reconciler = new SparkSettlementReconciler(
-            invoices, broadcaster, NullLogger<SparkSettlementReconciler>.Instance);
+            invoices,
+            broadcaster,
+            new SparkInvoiceCreditor(
+                durable.Credits, invoices, NullLogger<SparkInvoiceCreditor>.Instance),
+            NullLogger<SparkSettlementReconciler>.Instance);
         var wiring = new SparkLightningWiring(lightning, NullLogger<SparkLightningWiring>.Instance);
 
         // The startup sweep is real here — it runs against the stores this harness knows about — so the
@@ -120,11 +199,9 @@ public sealed class SparkServiceHarness : IDisposable
         SparkLightningConfigSweeper? sweeper = null;
 
         var service = new TestableSparkService(
-            connectDeadline ?? TimeSpan.FromMilliseconds(250),
-            confirmStatusDeadline ?? Constants.SdkCallDeadline,
-            // Long by default so the existing abandon tests still observe a late connect being adopted and shut
-            // down; the release-the-lock test shortens it deliberately.
-            abandonedConnectGrace ?? TimeSpan.FromMinutes(5),
+            deadlines.Connect,
+            deadlines.ConfirmStatus,
+            deadlines.AbandonedConnectGrace,
             new BTCPayServer.EventAggregator(logs),
             stores,
             Options.Create(new DataDirectories { DataDir = dataDir }),
@@ -136,7 +213,7 @@ public sealed class SparkServiceHarness : IDisposable
             broadcaster,
             protector,
             wiring,
-            new StubBolt11Parser(),
+            durable.Bolt11,
             TimeProvider.System,
             () => sweeper ?? throw new InvalidOperationException("harness sweep not wired"),
             NullLoggerFactory.Instance,
@@ -148,8 +225,7 @@ public sealed class SparkServiceHarness : IDisposable
             service,
             NullLogger<SparkLightningConfigSweeper>.Instance);
 
-        return new SparkServiceHarness(
-            service, stores, sdk, lightning, protector, invoices, broadcaster, log, dataDir);
+        return new SparkServiceHarness(service, sdk, broadcaster, log, dataDir, durable, deadlines);
     }
 
     /// <summary>Stores a store's Spark settings the way a previous run would have left them.</summary>
@@ -166,18 +242,10 @@ public sealed class SparkServiceHarness : IDisposable
 
     public void Dispose()
     {
-        // Bounded, because StopAsync takes the same instance lock the startup loop holds. If a regression has
-        // put a never-returning await back on the startup path, that lock is held forever and an unbounded
-        // teardown here would turn a failed assertion into a hung test run — hiding the very failure the
-        // assertion just reported.
-        try
-        {
-            Service.StopAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(10));
-        }
-        catch (Exception)
-        {
-            // Teardown of a service that never fully started is not worth failing a test over.
-        }
+        StopService();
+
+        if (!_ownsDataDir)
+            return;
 
         try
         {
@@ -185,6 +253,27 @@ public sealed class SparkServiceHarness : IDisposable
         }
         catch (IOException)
         {
+        }
+    }
+
+    /// <summary>
+    /// Shuts the service down without touching the durable state, bounded so a hang cannot hide a failure.
+    /// </summary>
+    /// <remarks>
+    /// Bounded because <c>StopAsync</c> takes the same instance lock the startup loop holds. If a regression
+    /// has put a never-returning await back on the startup path, that lock is held forever and an unbounded
+    /// teardown would turn a failed assertion into a hung test run — hiding the very failure the assertion
+    /// just reported.
+    /// </remarks>
+    private void StopService()
+    {
+        try
+        {
+            Service.StopAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(10));
+        }
+        catch (Exception)
+        {
+            // Teardown of a service that never fully started is not worth failing a test over.
         }
     }
 

--- a/BTCPayServer.Plugins.Flint.Tests/FundedRegtest/SparkFundedRegtestTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/FundedRegtest/SparkFundedRegtestTests.cs
@@ -88,7 +88,13 @@ public class SparkFundedRegtestTests
         var store = new InMemoryInvoiceRecordStore();
         var broadcaster = new SparkSettlementBroadcaster(NullLogger<SparkSettlementBroadcaster>.Instance);
         var reconciler = new SparkSettlementReconciler(
-            store, broadcaster, NullLogger<SparkSettlementReconciler>.Instance);
+            store,
+            broadcaster,
+            // There is no BTCPay here, so no invoice to credit; an empty gateway keeps the settlement path
+            // whole while leaving crediting to the tests that own it.
+            new SparkInvoiceCreditor(
+                new FakeInvoiceCreditGateway(), store, NullLogger<SparkInvoiceCreditor>.Instance),
+            NullLogger<SparkSettlementReconciler>.Instance);
         var client = new SparkLightningClient(
             _wallet.StoreId,
             "funded-regtest-key",

--- a/BTCPayServer.Plugins.Flint.Tests/InvoiceRecordStoreContractTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/InvoiceRecordStoreContractTests.cs
@@ -1,4 +1,5 @@
 using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Services;
 using BTCPayServer.Plugins.Flint.Tests.Fakes;
 using BTCPayServer.Plugins.Flint.Tests.Postgres;
 using Xunit;
@@ -478,6 +479,357 @@ public abstract class InvoiceRecordStoreContractTests
 
         var listed = await store.ListForReconciliationAsync(
             StoreId, DateTimeOffset.UtcNow.AddHours(-1), after: null, limit: 10, Ct);
+
+        Assert.Equal(PaymentFixture.PaymentHash, Assert.Single(listed).PaymentHash);
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // Crediting: whether a settlement has reached the BTCPay invoice its BOLT11 was minted for
+    // -------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Marking_credited_succeeds_once_and_keeps_the_first_timestamp()
+    {
+        // Two callers genuinely race here — the settlement path and the reconciliation pass both attempt the
+        // credit for the same row — and only one of them may be told it stamped it. The timestamp is when the
+        // merchant's invoice was credited, not when a pass last looked.
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(), Ct);
+        await store.SettleAsync(
+            StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        var first = DateTimeOffset.UtcNow;
+
+        Assert.True(await store.MarkCreditedAsync(StoreId, PaymentFixture.PaymentHash, first, Ct));
+        Assert.False(await store.MarkCreditedAsync(
+            StoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow.AddHours(1), Ct));
+
+        var reread = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
+        Assert.NotNull(reread!.CreditedAt);
+        Assert.Equal(first.ToUnixTimeMilliseconds(), reread.CreditedAt!.Value.ToUnixTimeMilliseconds());
+    }
+
+    [Fact]
+    public async Task Marking_an_unsettled_invoice_credited_is_refused()
+    {
+        // The interlock. Stamping an unpaid row would tell every later pass the credit is done, and the payment
+        // that eventually arrives would settle here and never reach the merchant's BTCPay invoice. A cancelled
+        // invoice is refused for the same reason: on Spark it is still payable.
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(), Ct);
+        Assert.False(await store.MarkCreditedAsync(
+            StoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+
+        Assert.True(await store.CancelAsync(StoreId, PaymentFixture.PaymentHash, Ct));
+        Assert.False(await store.MarkCreditedAsync(
+            StoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+
+        var reread = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
+        Assert.Null(reread!.CreditedAt);
+    }
+
+    [Fact]
+    public async Task Marking_credited_is_scoped_to_the_owning_store()
+    {
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(), Ct);
+        await store.SettleAsync(
+            StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+
+        Assert.False(await store.MarkCreditedAsync(
+            OtherStoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+        Assert.False(await store.MarkCreditedAsync(
+            StoreId, PaymentFixture.OtherPaymentHash, DateTimeOffset.UtcNow, Ct));
+
+        var reread = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
+        Assert.Null(reread!.CreditedAt);
+    }
+
+    [Fact]
+    public async Task A_settlement_stays_uncredited_until_it_is_marked()
+    {
+        // This is the retry queue, so what it contains decides what can still be recovered. A settled row is in
+        // it from the moment it settles until the credit lands — including one settled long after expiry, which
+        // is exactly the case BTCPay's listener is no longer watching for.
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(
+            createdAt: DateTimeOffset.UtcNow.AddHours(-5),
+            expiresAt: DateTimeOffset.UtcNow.AddHours(-4)), Ct);
+        await store.SettleAsync(
+            StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+
+        var pending = await store.ListUncreditedAsync(
+            StoreId, DateTimeOffset.UtcNow.AddDays(-7), after: null, limit: 10, Ct);
+        Assert.Equal(PaymentFixture.PaymentHash, Assert.Single(pending).PaymentHash);
+
+        Assert.True(await store.MarkCreditedAsync(
+            StoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+
+        Assert.Empty(await store.ListUncreditedAsync(
+            StoreId, DateTimeOffset.UtcNow.AddDays(-7), after: null, limit: 10, Ct));
+    }
+
+    [Fact]
+    public async Task Uncredited_excludes_invoices_that_never_settled()
+    {
+        // An unpaid or cancelled invoice has no settlement to credit. Including one would have every pass
+        // attempt a credit for money that has not arrived.
+        var store = await CreateStoreAsync();
+        var cancelledHash = "e".PadLeft(64, '0');
+        await store.AddAsync(NewRecord(), Ct);
+        await store.AddAsync(NewRecord(cancelledHash), Ct);
+        await store.CancelAsync(StoreId, cancelledHash, Ct);
+
+        Assert.Empty(await store.ListUncreditedAsync(
+            StoreId, DateTimeOffset.UtcNow.AddDays(-7), after: null, limit: 10, Ct));
+    }
+
+    [Fact]
+    public async Task Uncredited_stops_at_the_listing_bound()
+    {
+        // The bound on the size of the set, not on the retry: a settlement old enough that even the abandoned
+        // report has had its chance is no longer worth a query on every pass for the life of the server. The
+        // caller passes SparkInvoiceCreditor.ListableFrom here, which is deliberately older than the retry
+        // horizon — see the interface's remarks for why those two must not be the same value.
+        var store = await CreateStoreAsync();
+        var recentHash = PaymentFixture.PaymentHash;
+        var ancientHash = PaymentFixture.OtherPaymentHash;
+        await store.AddAsync(NewRecord(recentHash), Ct);
+        await store.AddAsync(NewRecord(ancientHash, createdAt: DateTimeOffset.UtcNow.AddDays(-30)), Ct);
+        await store.SettleAsync(StoreId, recentHash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        await store.SettleAsync(
+            StoreId, ancientHash, "sdk-2", 100_000, null, DateTimeOffset.UtcNow.AddDays(-30), Ct);
+
+        var listed = await store.ListUncreditedAsync(
+            StoreId, DateTimeOffset.UtcNow.AddDays(-7), after: null, limit: 10, Ct);
+
+        Assert.Equal(recentHash, Assert.Single(listed).PaymentHash);
+    }
+
+    [Fact]
+    public async Task Uncredited_still_lists_a_settlement_past_the_retry_horizon()
+    {
+        // The regression this exists for. A record has to stay listed *after* the credit retry horizon passes,
+        // or no pass can ever classify it as abandoned: it would leave the walk at the instant it became
+        // eligible to be reported, so the operator warning would never fire and the row would sit with both
+        // credit columns null forever — indistinguishable from one still in flight.
+        var store = await CreateStoreAsync();
+        var settledAt = DateTimeOffset.UtcNow - SparkInvoiceCreditor.CreditRetryHorizon - TimeSpan.FromDays(1);
+        await store.AddAsync(NewRecord(createdAt: settledAt.AddMinutes(-5)), Ct);
+        await store.SettleAsync(StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, null, settledAt, Ct);
+
+        var listed = await store.ListUncreditedAsync(
+            StoreId,
+            SparkInvoiceCreditor.ListableFrom(DateTimeOffset.UtcNow),
+            after: null,
+            limit: 10,
+            Ct);
+
+        Assert.Equal(PaymentFixture.PaymentHash, Assert.Single(listed).PaymentHash);
+    }
+
+    [Fact]
+    public async Task An_abandoned_settlement_leaves_the_uncredited_set_without_claiming_a_credit()
+    {
+        // The terminal marker, and the reason it is a column of its own. Stamping CreditedAt would have removed
+        // the record from the walk too — and told every later reader that the merchant had been paid on an
+        // invoice that in fact records nothing.
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(), Ct);
+        await store.SettleAsync(
+            StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+
+        Assert.True(await store.MarkCreditAbandonedAsync(
+            StoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+
+        Assert.Empty(await store.ListUncreditedAsync(
+            StoreId, DateTimeOffset.UtcNow.AddDays(-14), after: null, limit: 10, Ct));
+
+        var record = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
+        Assert.NotNull(record);
+        Assert.Null(record.CreditedAt);
+        Assert.NotNull(record.CreditAbandonedAt);
+    }
+
+    [Fact]
+    public async Task Abandoning_a_settlement_twice_stamps_it_once()
+    {
+        // What makes the operator report exactly-once: the caller logs only when this compare-and-set says it
+        // was the one that stamped the row.
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(), Ct);
+        await store.SettleAsync(
+            StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        var first = DateTimeOffset.UtcNow.AddMinutes(-5);
+
+        Assert.True(await store.MarkCreditAbandonedAsync(StoreId, PaymentFixture.PaymentHash, first, Ct));
+        Assert.False(await store.MarkCreditAbandonedAsync(
+            StoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+
+        var record = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
+        Assert.NotNull(record?.CreditAbandonedAt);
+        Assert.Equal(first.ToUnixTimeMilliseconds(), record.CreditAbandonedAt.Value.ToUnixTimeMilliseconds());
+    }
+
+    [Fact]
+    public async Task An_already_credited_settlement_is_never_labelled_abandoned()
+    {
+        // The race that matters. Two passes can be examining the same row; if one credits it while the other is
+        // about to give up on it, the row must keep saying the money arrived. Otherwise the operator is told to
+        // go looking for funds that were in fact accounted for.
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(), Ct);
+        await store.SettleAsync(
+            StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        Assert.True(await store.MarkCreditedAsync(
+            StoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+
+        Assert.False(await store.MarkCreditAbandonedAsync(
+            StoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+
+        var record = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
+        Assert.NotNull(record?.CreditedAt);
+        Assert.Null(record.CreditAbandonedAt);
+    }
+
+    [Fact]
+    public async Task An_unsettled_invoice_is_never_labelled_abandoned()
+    {
+        // Same interlock as the credit stamp, and for the same reason: an unpaid row has no settlement to give
+        // up on, and stamping one would permanently suppress the credit of the payment that later arrives.
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(), Ct);
+
+        Assert.False(await store.MarkCreditAbandonedAsync(
+            StoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+    }
+
+    [Fact]
+    public async Task Abandoning_is_scoped_to_the_store_that_owns_the_settlement()
+    {
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(), Ct);
+        await store.SettleAsync(
+            StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+
+        Assert.False(await store.MarkCreditAbandonedAsync(
+            OtherStoreId, PaymentFixture.PaymentHash, DateTimeOffset.UtcNow, Ct));
+
+        var record = await store.GetAsync(StoreId, PaymentFixture.PaymentHash, Ct);
+        Assert.Null(record?.CreditAbandonedAt);
+    }
+
+    [Fact]
+    public async Task The_stores_awaiting_a_credit_are_listed_without_needing_a_running_wallet()
+    {
+        // What lets the credit walk reach a store whose Spark connection is broken. Crediting touches only
+        // BTCPay's tables and these rows, so the store id is the only thing the walk needs — and this is where
+        // it comes from, rather than from the set of live SDK instances the settlement walk is limited to.
+        var store = await CreateStoreAsync();
+        var credited = "0".PadLeft(64, 'a');
+        await store.AddAsync(NewRecord(PaymentFixture.PaymentHash), Ct);
+        await store.AddAsync(NewRecord(PaymentFixture.OtherPaymentHash, storeId: OtherStoreId), Ct);
+        await store.AddAsync(NewRecord(credited, storeId: "store-3"), Ct);
+        foreach (var (hash, owner) in new[]
+                 {
+                     (PaymentFixture.PaymentHash, StoreId),
+                     (PaymentFixture.OtherPaymentHash, OtherStoreId),
+                     (credited, "store-3")
+                 })
+        {
+            await store.SettleAsync(owner, hash, $"sdk-{hash[..4]}", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        }
+
+        // One of the three has been resolved, so its store is no longer awaiting anything.
+        Assert.True(await store.MarkCreditedAsync("store-3", credited, DateTimeOffset.UtcNow, Ct));
+
+        var storeIds = await store.ListStoreIdsAwaitingCreditAsync(
+            DateTimeOffset.UtcNow.AddDays(-14), limit: 10, Ct);
+
+        Assert.Equal(2, storeIds.Count);
+        Assert.Contains(StoreId, storeIds);
+        Assert.Contains(OtherStoreId, storeIds);
+    }
+
+    [Fact]
+    public async Task A_store_is_listed_once_however_many_settlements_it_is_owed()
+    {
+        // Distinct, because the caller feeds this to a store-pass scheduler that walks ids: a repeated id would
+        // be a repeated visit, and the visit's own paging already covers every one of the store's rows.
+        var store = await CreateStoreAsync();
+        var hashes = Enumerable.Range(0, 3).Select(i => i.ToString("x64")).ToArray();
+        foreach (var hash in hashes)
+        {
+            await store.AddAsync(NewRecord(hash), Ct);
+            await store.SettleAsync(StoreId, hash, $"sdk-{hash[..4]}", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        }
+
+        var storeIds = await store.ListStoreIdsAwaitingCreditAsync(
+            DateTimeOffset.UtcNow.AddDays(-14), limit: 10, Ct);
+
+        Assert.Equal(StoreId, Assert.Single(storeIds));
+    }
+
+    [Fact]
+    public async Task The_stores_awaiting_a_credit_exclude_resolved_and_aged_out_settlements()
+    {
+        // The same predicate as the per-store listing, asserted separately because the two are different
+        // queries: an abandoned or aged-out row must not keep pulling its store into every pass.
+        var store = await CreateStoreAsync();
+        var abandoned = PaymentFixture.PaymentHash;
+        var ancient = PaymentFixture.OtherPaymentHash;
+        await store.AddAsync(NewRecord(abandoned), Ct);
+        await store.AddAsync(NewRecord(ancient, storeId: OtherStoreId,
+            createdAt: DateTimeOffset.UtcNow.AddDays(-30)), Ct);
+        await store.SettleAsync(StoreId, abandoned, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        await store.SettleAsync(
+            OtherStoreId, ancient, "sdk-2", 100_000, null, DateTimeOffset.UtcNow.AddDays(-30), Ct);
+        Assert.True(await store.MarkCreditAbandonedAsync(StoreId, abandoned, DateTimeOffset.UtcNow, Ct));
+
+        Assert.Empty(await store.ListStoreIdsAwaitingCreditAsync(
+            DateTimeOffset.UtcNow.AddDays(-14), limit: 10, Ct));
+    }
+
+    [Fact]
+    public async Task Uncredited_pages_by_keyset_oldest_first_and_is_stable_when_a_record_is_credited()
+    {
+        // Keyset for the same reason the reconciliation walk uses one: crediting a record removes it from this
+        // result set, so an offset-based second page would skip whatever shifted into the vacated slot. Oldest
+        // first because the oldest settlement is the closest to its retry horizon.
+        var store = await CreateStoreAsync();
+        var hashes = Enumerable.Range(0, 4).Select(i => i.ToString("x64")).ToArray();
+        for (var i = 0; i < hashes.Length; i++)
+        {
+            await store.AddAsync(NewRecord(hashes[i], createdAt: DateTimeOffset.UtcNow.AddMinutes(-30 + i)), Ct);
+            await store.SettleAsync(StoreId, hashes[i], $"sdk-{i}", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        }
+
+        var firstPage = await store.ListUncreditedAsync(
+            StoreId, DateTimeOffset.UtcNow.AddDays(-7), after: null, limit: 2, Ct);
+        Assert.Equal([hashes[0], hashes[1]], firstPage.Select(r => r.PaymentHash).ToArray());
+
+        foreach (var record in firstPage)
+            await store.MarkCreditedAsync(StoreId, record.PaymentHash, DateTimeOffset.UtcNow, Ct);
+
+        var cursor = new InvoiceReconciliationCursor(firstPage[^1].CreatedAt, firstPage[^1].PaymentHash);
+        var secondPage = await store.ListUncreditedAsync(
+            StoreId, DateTimeOffset.UtcNow.AddDays(-7), cursor, limit: 2, Ct);
+
+        Assert.Equal([hashes[2], hashes[3]], secondPage.Select(r => r.PaymentHash).ToArray());
+    }
+
+    [Fact]
+    public async Task Uncredited_does_not_leak_another_stores_settlements()
+    {
+        var store = await CreateStoreAsync();
+        await store.AddAsync(NewRecord(PaymentFixture.PaymentHash), Ct);
+        await store.AddAsync(NewRecord(PaymentFixture.OtherPaymentHash, storeId: OtherStoreId), Ct);
+        await store.SettleAsync(
+            StoreId, PaymentFixture.PaymentHash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        await store.SettleAsync(
+            OtherStoreId, PaymentFixture.OtherPaymentHash, "sdk-2", 100_000, null, DateTimeOffset.UtcNow, Ct);
+
+        var listed = await store.ListUncreditedAsync(
+            StoreId, DateTimeOffset.UtcNow.AddDays(-7), after: null, limit: 10, Ct);
 
         Assert.Equal(PaymentFixture.PaymentHash, Assert.Single(listed).PaymentHash);
     }

--- a/BTCPayServer.Plugins.Flint.Tests/InvoiceRecordTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/InvoiceRecordTests.cs
@@ -42,6 +42,7 @@ public class InvoiceRecordTests
         Assert.Equal(InvoiceRecordStatus.Expired, record.Status);
     }
 
+    [Fact]
     public void A_cancelled_invoice_reports_unpaid_until_it_settles()
     {
         // Cancellation marks the invoice locally but cannot withdraw it from the service provider, so it
@@ -57,6 +58,8 @@ public class InvoiceRecordTests
         Assert.Equal(InvoiceRecordStatus.Paid, record.Status);
         Assert.Equal(InvoiceRecordStatus.Paid, record.EffectiveStatus(record.ExpiresAt.AddYears(1)));
     }
+
+    [Fact]
     public void A_naturally_expired_invoice_still_settles()
     {
         // The SSP will accept a payment after expiry and Spark has no way to stop it. Dropping that payment
@@ -76,6 +79,83 @@ public class InvoiceRecordTests
         record.TrySettle("sdk-1", 100_000, null, Created);
 
         Assert.Equal(InvoiceRecordStatus.Paid, record.EffectiveStatus(record.ExpiresAt.AddYears(1)));
+    }
+
+    [Fact]
+    public void Only_the_first_call_marks_a_settlement_credited()
+    {
+        // "Did anything change", the same predicate the store's conditional UPDATE evaluates
+        // (WHERE Status = Paid AND CreditedAt IS NULL). The timestamp records when the merchant's BTCPay
+        // invoice was actually credited, so a second caller must not move it.
+        var record = Unpaid();
+        record.TrySettle("sdk-1", 100_000, null, Created);
+        var first = Created.AddMinutes(1);
+
+        Assert.True(record.TryMarkCredited(first));
+        Assert.False(record.TryMarkCredited(Created.AddHours(5)));
+        Assert.Equal(first, record.CreditedAt);
+    }
+
+    [Fact]
+    public void An_unsettled_invoice_cannot_be_marked_credited()
+    {
+        // The interlock that stops a credit being suppressed before it is owed: if an unpaid row could be
+        // stamped, the payment that later arrived would be settled and then never routed to BTCPay, because
+        // every retry pass would consider the credit already done.
+        var unpaid = Unpaid();
+        Assert.False(unpaid.TryMarkCredited(Created));
+        Assert.Null(unpaid.CreditedAt);
+
+        // Including a cancelled one, which is still payable on the service provider.
+        var cancelled = Unpaid();
+        Assert.True(cancelled.TryCancel());
+        Assert.False(cancelled.TryMarkCredited(Created));
+        Assert.Null(cancelled.CreditedAt);
+    }
+
+    [Fact]
+    public void Only_the_first_call_marks_a_settlement_abandoned()
+    {
+        // Same shape as the credit stamp, and the reason the return value is used rather than ignored: the
+        // operator warning about money that no BTCPay invoice accounts for is emitted by whoever wins this
+        // compare-and-set, so a second winner would mean a second report — on every pass, forever.
+        var record = Unpaid();
+        record.TrySettle("sdk-1", 100_000, null, Created);
+        var first = Created.AddMinutes(1);
+
+        Assert.True(record.TryMarkCreditAbandoned(first));
+        Assert.False(record.TryMarkCreditAbandoned(Created.AddHours(5)));
+        Assert.Equal(first, record.CreditAbandonedAt);
+    }
+
+    [Fact]
+    public void An_unsettled_invoice_cannot_be_marked_abandoned()
+    {
+        // The same interlock as the credit stamp: an unpaid row has no settlement to give up on, and stamping
+        // one would permanently suppress the credit of the payment that later arrives.
+        var unpaid = Unpaid();
+        Assert.False(unpaid.TryMarkCreditAbandoned(Created));
+        Assert.Null(unpaid.CreditAbandonedAt);
+
+        var cancelled = Unpaid();
+        Assert.True(cancelled.TryCancel());
+        Assert.False(cancelled.TryMarkCreditAbandoned(Created));
+        Assert.Null(cancelled.CreditAbandonedAt);
+    }
+
+    [Fact]
+    public void A_credited_settlement_is_never_relabelled_abandoned()
+    {
+        // The race the two stamps are guarded against. Two passes can be examining the same row; if one credits
+        // it while the other is about to give up on it, the row has to keep saying the money arrived — otherwise
+        // the operator is sent looking for funds that were in fact accounted for.
+        var record = Unpaid();
+        record.TrySettle("sdk-1", 100_000, null, Created);
+        Assert.True(record.TryMarkCredited(Created.AddMinutes(1)));
+
+        Assert.False(record.TryMarkCreditAbandoned(Created.AddMinutes(2)));
+        Assert.Null(record.CreditAbandonedAt);
+        Assert.NotNull(record.CreditedAt);
     }
 
     [Fact]

--- a/BTCPayServer.Plugins.Flint.Tests/SparkInvoiceCreditorTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkInvoiceCreditorTests.cs
@@ -1,0 +1,311 @@
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// Which BTCPay invoice a recorded settlement is credited to, and when it is refused.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The decision this pins is the one that closes the superseded-BOLT11 hole: BTCPay's Lightning listener
+/// watches only each invoice's current payment prompt, so a payment to a replaced BOLT11 after a restart
+/// settles in this plugin and reaches no invoice unless it is routed there deliberately. The end-to-end proof
+/// of that lives in <see cref="SparkSupersededInvoiceCreditTests"/>; what is here is the mapping from each
+/// answer BTCPay can give to what this plugin does about it — including the two answers that must <b>not</b>
+/// mark the credit done, because doing so would abandon real money.
+/// </para>
+/// <para>
+/// Driven against <see cref="FakeInvoiceCreditGateway"/>, which models the two properties of BTCPay's schema
+/// the design rests on: an insert-only payment-hash index, and a payments primary key that refuses a duplicate.
+/// </para>
+/// </remarks>
+public class SparkInvoiceCreditorTests
+{
+    private const string StoreId = "store-1";
+    private const string OtherStoreId = "store-2";
+    private const string InvoiceId = "btcpay-invoice-1";
+
+    private static readonly string Hash = PaymentFixture.PaymentHash;
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static (SparkInvoiceCreditor Creditor, InMemoryInvoiceRecordStore Store,
+        FakeInvoiceCreditGateway Credits, CapturingLogger<SparkInvoiceCreditor> Log) Create()
+    {
+        var store = new InMemoryInvoiceRecordStore();
+        var credits = new FakeInvoiceCreditGateway();
+        var log = new CapturingLogger<SparkInvoiceCreditor>();
+        return (new SparkInvoiceCreditor(credits, store, log), store, credits, log);
+    }
+
+    /// <summary>A settled record, as the settlement path leaves one.</summary>
+    private static InvoiceRecord Settled(
+        InMemoryInvoiceRecordStore store,
+        string? paymentHash = null,
+        string storeId = StoreId,
+        DateTimeOffset? settledAt = null)
+    {
+        var record = new InvoiceRecord
+        {
+            PaymentHash = paymentHash ?? Hash,
+            StoreId = storeId,
+            Bolt11 = "lnbcrt-one",
+            AmountMsat = 100_000,
+            AmountReceivedMsat = 100_000,
+            SdkPaymentId = "sdk-1",
+            Preimage = PaymentFixture.Preimage,
+            CreatedAt = (settledAt ?? DateTimeOffset.UtcNow).AddMinutes(-5),
+            ExpiresAt = (settledAt ?? DateTimeOffset.UtcNow).AddHours(1),
+            SettledAt = settledAt ?? DateTimeOffset.UtcNow,
+            Status = InvoiceRecordStatus.Paid
+        };
+        store.Seed(record);
+        return record;
+    }
+
+    [Fact]
+    public async Task A_settlement_BTCPay_never_saw_is_credited_and_marked()
+    {
+        // The case the whole design exists for: BTCPay issued this BOLT11, then stopped watching it, and the
+        // payment arrived anyway.
+        var (creditor, store, credits, _) = Create();
+        var record = Settled(store);
+        credits.Mint(Hash, InvoiceId, StoreId);
+
+        Assert.Equal(SparkInvoiceCreditResult.Credited, await creditor.CreditAsync(record, Ct));
+
+        var credit = Assert.Single(credits.Credits);
+        Assert.Equal(InvoiceId, credit.InvoiceId);
+        Assert.Equal(Hash, credit.PaymentHash);
+        // What arrived, never what was invoiced.
+        Assert.Equal(100_000, credit.AmountReceivedMsat);
+        Assert.Equal(PaymentFixture.Preimage, credit.Preimage);
+        Assert.NotNull(store.Records[Hash].CreditedAt);
+    }
+
+    [Fact]
+    public async Task A_settlement_BTCPay_already_holds_is_marked_without_a_second_insert()
+    {
+        // The ordinary path, and the one that runs on almost every checkout: core's listener was watching and
+        // credited it. Marking it here is what stops every later pass asking again.
+        var (creditor, store, credits, _) = Create();
+        var record = Settled(store);
+        credits.Mint(Hash, InvoiceId, StoreId).CreditedByBTCPay(Hash);
+
+        Assert.Equal(SparkInvoiceCreditResult.AlreadyRecorded, await creditor.CreditAsync(record, Ct));
+
+        Assert.Empty(credits.Attempts);
+        Assert.Empty(credits.Credits);
+        Assert.NotNull(store.Records[Hash].CreditedAt);
+    }
+
+    [Fact]
+    public async Task Crediting_twice_records_the_payment_once()
+    {
+        // Exactly-once, asserted through the mechanism that provides it rather than around it: the second
+        // attempt is refused by the payments primary key, not by this plugin remembering it tried.
+        var (creditor, store, credits, _) = Create();
+        var record = Settled(store);
+        credits.Mint(Hash, InvoiceId, StoreId);
+
+        Assert.Equal(SparkInvoiceCreditResult.Credited, await creditor.CreditAsync(record, Ct));
+
+        // As a fresh pass would see it: the stamp is on the row, so the credit is not attempted again at all.
+        Assert.Equal(SparkInvoiceCreditResult.AlreadyCredited,
+            await creditor.CreditAsync(store.Records[Hash], Ct));
+
+        // And even with the stamp cleared — a crash between the insert and the mark — the insert is refused.
+        store.Records[Hash].CreditedAt = null;
+        Assert.Equal(SparkInvoiceCreditResult.AlreadyRecorded,
+            await creditor.CreditAsync(store.Records[Hash], Ct));
+
+        Assert.Single(credits.Credits);
+        Assert.Single(credits.CreditsFor(InvoiceId));
+    }
+
+    [Fact]
+    public async Task Another_stores_invoice_is_never_credited()
+    {
+        // The security boundary. BTCPay's index is keyed on the payment hash alone, so a hash that resolved to
+        // another store's invoice would credit that store for money that arrived in this one's wallet. Nothing
+        // in the normal flow produces it, which is why it is checked rather than assumed — and nothing is
+        // marked, so if the mismatch is ever explained the credit is still owed.
+        var (creditor, store, credits, log) = Create();
+        var record = Settled(store);
+        credits.Mint(Hash, InvoiceId, OtherStoreId);
+
+        Assert.Equal(SparkInvoiceCreditResult.RefusedCrossStore, await creditor.CreditAsync(record, Ct));
+
+        Assert.Empty(credits.Attempts);
+        Assert.Null(store.Records[Hash].CreditedAt);
+        Assert.Contains("Refusing to credit", log.AllText);
+        Assert.Contains(OtherStoreId, log.AllText);
+    }
+
+    [Fact]
+    public async Task A_hash_BTCPay_has_not_indexed_yet_is_left_for_the_next_pass()
+    {
+        // BTCPay writes its payment-hash row just after CreateInvoice returns, so a payment that lands in that
+        // window finds nothing. Leaving the record uncredited *is* the retry queue.
+        var (creditor, store, credits, _) = Create();
+        var record = Settled(store);
+
+        Assert.Equal(SparkInvoiceCreditResult.Deferred, await creditor.CreditAsync(record, Ct));
+        Assert.Null(store.Records[Hash].CreditedAt);
+
+        // …and the next pass, once BTCPay has caught up, credits it.
+        credits.Mint(Hash, InvoiceId, StoreId);
+        Assert.Equal(SparkInvoiceCreditResult.Credited, await creditor.CreditAsync(record, Ct));
+        Assert.NotNull(store.Records[Hash].CreditedAt);
+    }
+
+    [Fact]
+    public async Task A_settlement_past_the_retry_horizon_stops_being_retried_and_says_so()
+    {
+        // A BOLT11 that was never issued for a BTCPay invoice — minted through this plugin's own API, say —
+        // can never be credited. It is reported once at operator level rather than retried forever, and it is
+        // deliberately not marked credited: it was not.
+        var (creditor, store, credits, log) = Create();
+        var record = Settled(store, settledAt: DateTimeOffset.UtcNow - SparkInvoiceCreditor.CreditRetryHorizon
+            - TimeSpan.FromDays(1));
+
+        Assert.Equal(SparkInvoiceCreditResult.Abandoned, await creditor.CreditAsync(record, Ct));
+
+        Assert.Empty(credits.Credits);
+        // The two stamps say different things and only one of them is true here: the money is in the wallet and
+        // no BTCPay invoice records it, so claiming a credit would misreport the merchant's position.
+        Assert.Null(store.Records[Hash].CreditedAt);
+        Assert.NotNull(store.Records[Hash].CreditAbandonedAt);
+        Assert.Contains("no longer be retried", log.AllText);
+        // With the figures a human needs to find the money by hand.
+        Assert.Contains(Hash, log.AllText);
+        Assert.Contains("100", log.AllText);
+    }
+
+    [Fact]
+    public async Task A_settlement_already_given_up_on_is_not_reported_again()
+    {
+        // The other half of "reported once". The stamp is what removes the record from the walk's listing, but a
+        // caller holding the record — the settlement path does — must also stop, and stop silently: repeating an
+        // operator warning on every pass for the life of the server buries it.
+        var (creditor, store, credits, log) = Create();
+        var record = Settled(store, settledAt: DateTimeOffset.UtcNow - SparkInvoiceCreditor.CreditRetryHorizon
+            - TimeSpan.FromDays(1));
+
+        Assert.Equal(SparkInvoiceCreditResult.Abandoned, await creditor.CreditAsync(record, Ct));
+        var lookups = credits.Lookups;
+        var reported = log.Lines.Count;
+
+        Assert.Equal(SparkInvoiceCreditResult.AlreadyAbandoned, await creditor.CreditAsync(record, Ct));
+
+        // Not even asked about again, and not logged about again.
+        Assert.Equal(lookups, credits.Lookups);
+        Assert.Equal(reported, log.Lines.Count);
+    }
+
+    [Fact]
+    public async Task An_invoice_that_cannot_hold_the_payment_is_marked_and_reported()
+    {
+        // A payment prompt is never removed from an invoice's blob, so retrying cannot change this answer.
+        // Stamped terminal to stop an endless retry — as abandoned rather than credited, because the money is
+        // not on the invoice — and logged loudly because only a human can reconcile it.
+        var (creditor, store, credits, log) = Create();
+        var record = Settled(store);
+        credits.Mint(Hash, InvoiceId, StoreId);
+        credits.PromptMissingFor.Add(Hash);
+
+        Assert.Equal(SparkInvoiceCreditResult.Unrecordable, await creditor.CreditAsync(record, Ct));
+
+        Assert.Empty(credits.Credits);
+        Assert.Null(store.Records[Hash].CreditedAt);
+        Assert.NotNull(store.Records[Hash].CreditAbandonedAt);
+        Assert.Contains("cannot be credited automatically", log.AllText);
+    }
+
+    [Fact]
+    public async Task The_preimage_reaches_the_payment_prompt_of_the_bolt11_that_was_paid()
+    {
+        // Not decoration. LUD-21 verify serves proof-of-payment out of the *prompt*, not out of the payment
+        // row, and this plugin forces LUD-21 on for every store it provisions. Core's own listener performs
+        // this backfill only when its own insert wins — and this path usually wins the race from it — so
+        // skipping it would have cost every ordinary Flint checkout its proof-of-payment.
+        var (creditor, store, credits, _) = Create();
+        var record = Settled(store);
+        credits.Mint(Hash, InvoiceId, StoreId);
+
+        Assert.Equal(SparkInvoiceCreditResult.Credited, await creditor.CreditAsync(record, Ct));
+
+        Assert.Equal(PaymentFixture.Preimage, credits.PromptPreimageFor(InvoiceId));
+    }
+
+    [Fact]
+    public async Task Crediting_a_superseded_bolt11_leaves_the_replacements_prompt_alone()
+    {
+        // The other side of the same guard, and the reason it is a guard rather than an unconditional copy.
+        // BTCPay's hash index still points X at this invoice, but the invoice's prompt now offers replacement
+        // Y — whose preimage this is not. Stamping it there would have LUD-21 verify hand a payer a proof of
+        // payment for an invoice they never paid.
+        var (creditor, store, credits, _) = Create();
+        var record = Settled(store);
+        credits.Mint(Hash, InvoiceId, StoreId);
+        credits.Mint(PaymentFixture.OtherPaymentHash, InvoiceId, StoreId);
+        Assert.Equal(PaymentFixture.OtherPaymentHash, credits.PromptPaymentHashFor(InvoiceId));
+
+        Assert.Equal(SparkInvoiceCreditResult.Credited, await creditor.CreditAsync(record, Ct));
+
+        // The payment is on the invoice…
+        Assert.Equal(Hash, Assert.Single(credits.Credits).PaymentHash);
+        // …and the replacement's prompt is untouched.
+        Assert.Null(credits.PromptPreimageFor(InvoiceId));
+    }
+
+    [Fact]
+    public async Task A_gateway_failure_leaves_the_credit_owed_rather_than_throwing()
+    {
+        // Both callers are paths that must not be derailed: the settlement is already committed and its
+        // notification already published by the time this runs, and the reconciliation pass has other stores
+        // behind it. So a BTCPay database that is briefly unreachable costs a pass, not a settlement.
+        var (creditor, store, credits, log) = Create();
+        var record = Settled(store);
+        credits.Mint(Hash, InvoiceId, StoreId);
+        credits.FailWith = new InvalidOperationException("BTCPay's database is unreachable");
+
+        Assert.Equal(SparkInvoiceCreditResult.Failed, await creditor.CreditAsync(record, Ct));
+        Assert.Null(store.Records[Hash].CreditedAt);
+        Assert.Contains("will be retried", log.AllText);
+
+        credits.FailWith = null;
+        Assert.Equal(SparkInvoiceCreditResult.Credited, await creditor.CreditAsync(record, Ct));
+    }
+
+    [Fact]
+    public async Task An_unsettled_record_is_refused_outright()
+    {
+        // A caller that got here with an unpaid row has a bug, and the safe answer is to do nothing loudly:
+        // marking anything would suppress the credit of the payment that may still arrive.
+        var (creditor, store, _, _) = Create();
+        var record = Settled(store);
+        record.Status = InvoiceRecordStatus.Unpaid;
+
+        await Assert.ThrowsAsync<ArgumentException>(() => creditor.CreditAsync(record, Ct));
+    }
+
+    [Fact]
+    public async Task An_LNURL_indexed_hash_is_credited_under_the_payment_method_it_was_found_on()
+    {
+        // BTCPay indexes an LNURL prompt's hash under BTC-LNURL, not BTC-LN, and the payments primary key is
+        // (id, payment method). Crediting under the wrong one would insert a second payment for the same money
+        // rather than colliding with core's.
+        var (creditor, store, credits, _) = Create();
+        var record = Settled(store);
+        credits.Mint(Hash, InvoiceId, StoreId, FakeInvoiceCreditGateway.LnurlPaymentMethodId);
+
+        Assert.Equal(SparkInvoiceCreditResult.Credited, await creditor.CreditAsync(record, Ct));
+
+        Assert.Equal(
+            FakeInvoiceCreditGateway.LnurlPaymentMethodId, Assert.Single(credits.Credits).PaymentMethodId);
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/SparkLightningClientTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkLightningClientTests.cs
@@ -33,8 +33,15 @@ public class SparkLightningClientTests
         var broadcaster = new SparkSettlementBroadcaster(NullLogger<SparkSettlementBroadcaster>.Instance);
         var parser = new StubBolt11Parser();
         parser.Register(Bolt11, bolt11Info ?? new Bolt11Info(Hash, DateTimeOffset.UtcNow.AddHours(1), 100_000));
+        // An empty credit gateway: BTCPay knows of none of these payment hashes, which is the honest shape for
+        // a test of the client. Crediting is covered where it belongs, in SparkInvoiceCreditorTests and
+        // SparkSupersededInvoiceCreditTests.
         var reconciler = new SparkSettlementReconciler(
-            store, broadcaster, NullLogger<SparkSettlementReconciler>.Instance);
+            store,
+            broadcaster,
+            new SparkInvoiceCreditor(
+                new FakeInvoiceCreditGateway(), store, NullLogger<SparkInvoiceCreditor>.Instance),
+            NullLogger<SparkSettlementReconciler>.Instance);
 
         var client = new SparkLightningClient(
             StoreId, PaymentKey, sdk, store, outgoing, reconciler, broadcaster, parser, NullLogger.Instance,

--- a/BTCPayServer.Plugins.Flint.Tests/SparkMigrationTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkMigrationTests.cs
@@ -1,5 +1,6 @@
 using BTCPayServer.Plugins.Flint.Data;
 using BTCPayServer.Plugins.Flint.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Xunit;
 
@@ -62,5 +63,77 @@ public class SparkMigrationTests
                 .Where(o => o.Name == nameof(SweepRecord.DestinationKind)));
 
         Assert.Equal((int)Services.SweepDestinationKind.BitcoinAddress, operation.DefaultValue);
+    }
+
+    /// <summary>
+    /// Settlements that predate the credit column are treated as <em>not yet credited</em>.
+    /// </summary>
+    /// <remarks>
+    /// <b>A default would be the wrong answer in the direction that loses money.</b> Backfilling a timestamp —
+    /// <c>now()</c>, or the settlement time — would tell the first reconciliation pass that every historical
+    /// settlement had already reached its BTCPay invoice. For the ones BTCPay's own listener credited that
+    /// happens to be true, and the pass would have confirmed it in a single indexed lookup; for the ones it
+    /// missed, which is the very defect the column exists to close, it is false and the credit would never be
+    /// attempted. Null costs one lookup per historical settlement inside the listing bound, once.
+    /// </remarks>
+    [Fact]
+    public void Settlements_that_predate_the_credit_column_are_left_uncredited()
+    {
+        var operation = Assert.Single(
+            new InvoiceRecordCreditedAt().UpOperations
+                .OfType<AddColumnOperation>()
+                .Where(o => o.Name == nameof(InvoiceRecord.CreditedAt)));
+
+        Assert.Equal("InvoiceRecords", operation.Table);
+        Assert.True(operation.IsNullable);
+        Assert.Null(operation.DefaultValue);
+        Assert.Null(operation.DefaultValueSql);
+    }
+
+    /// <summary>
+    /// Settlements that predate the abandoned column are treated as <em>not given up on</em>.
+    /// </summary>
+    /// <remarks>
+    /// The mirror of the column above, and the default matters in the same direction. A backfilled timestamp
+    /// here would mark every historical settlement as one this plugin had already given up on and reported —
+    /// removing it from the credit walk on the first pass, so the ones BTCPay's listener genuinely missed would
+    /// never be routed and never be mentioned to anyone. Null means the walk classifies each of them on its
+    /// merits, exactly once, which is what the column is for.
+    /// </remarks>
+    [Fact]
+    public void Settlements_that_predate_the_abandoned_column_are_not_treated_as_given_up_on()
+    {
+        var operation = Assert.Single(
+            new InvoiceRecordCreditAbandonedAt().UpOperations
+                .OfType<AddColumnOperation>()
+                .Where(o => o.Name == nameof(InvoiceRecord.CreditAbandonedAt)));
+
+        Assert.Equal("InvoiceRecords", operation.Table);
+        Assert.True(operation.IsNullable);
+        Assert.Null(operation.DefaultValue);
+        Assert.Null(operation.DefaultValueSql);
+    }
+
+    /// <summary>
+    /// The two credit columns are separate, because they record opposite facts about the same money.
+    /// </summary>
+    /// <remarks>
+    /// Pinned as a schema property rather than left to the classes that read it. The cheap way to retire a
+    /// settlement that can never be credited is to stamp <c>CreditedAt</c> and be done — it leaves the retry set
+    /// and stops warning — and it would silently turn this table, which is what an operator reconciles a wallet
+    /// balance against, into one that claims every abandoned payment was collected. A future "simplification"
+    /// that dropped one column in favour of the other fails here.
+    /// </remarks>
+    [Fact]
+    public void The_credited_and_abandoned_stamps_are_distinct_columns()
+    {
+        var added = new[] { nameof(InvoiceRecord.CreditedAt), nameof(InvoiceRecord.CreditAbandonedAt) };
+        var operations = new Migration[] { new InvoiceRecordCreditedAt(), new InvoiceRecordCreditAbandonedAt() }
+            .SelectMany(m => m.UpOperations.OfType<AddColumnOperation>())
+            .Where(o => added.Contains(o.Name))
+            .ToList();
+
+        Assert.Equal(added.Length, operations.Count);
+        Assert.Equal(added.Length, operations.Select(o => o.Name).Distinct().Count());
     }
 }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkPluginStartupTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkPluginStartupTests.cs
@@ -177,6 +177,16 @@ public class SparkPluginStartupTests
                      typeof(CrossChainCatalog),
                      typeof(SparkReconciliationTask),
                      typeof(SweepTask),
+                     // Reaches core's InvoiceRepository directly and its PaymentService through a Func, because
+                     // PaymentService's own constructor takes PaymentMethodHandlerDictionary — one leg of the
+                     // graph whose eager injection deadlocked BTCPay's startup once already. The deferral there
+                     // is belt-and-braces consistency with that established pattern rather than the only thing
+                     // holding the cycle open (it is broken at SparkConnectionStringHandler's
+                     // Func<ISparkClientResolver>), but this resolution is bounded either way so a regression
+                     // that did reintroduce a hang fails here instead of on a merchant's server.
+                     typeof(IInvoiceCreditGateway),
+                     typeof(SparkInvoiceCreditor),
+                     typeof(SparkSettlementReconciler),
                      typeof(SparkConnectionStringHandler),
                      typeof(ISparkSdkClientFactory),
                      typeof(ISparkNetworkStatusProbe),
@@ -190,6 +200,44 @@ public class SparkPluginStartupTests
             var resolved = host.Resolve(type.Name, provider => provider.GetRequiredService(type));
             Assert.NotNull(resolved);
         }
+    }
+
+    /// <summary>
+    /// The deferred core factories the credit path resolves on first use are registered <em>and</em> invocable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Resolving the <c>Func</c> proves nothing on its own — the container hands back a delegate whatever is
+    /// behind it, and <c>BTCPayInvoiceCreditGateway</c> only calls it when a real settlement needs crediting. So
+    /// a mis-registration, or a core refactor that made <c>PaymentService</c> unresolvable from the root
+    /// provider, would first surface as a failed credit on a merchant's server: money in the wallet, invoice
+    /// unpaid, and a warning about a payment that was in fact recorded nowhere. Invoking both factories here is
+    /// what turns that into a test failure.
+    /// </para>
+    /// <para>
+    /// Bounded and off-thread like every other resolution in this class, because these are precisely the two
+    /// core types whose construction enumerates plugin contributions.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void The_deferred_core_factories_the_credit_path_uses_can_be_invoked()
+    {
+        using var host = SparkTestHost.Create(_output);
+
+        var paymentService = host.Resolve(
+            "Func<PaymentService> (invoked, as BTCPayInvoiceCreditGateway invokes it)",
+            provider => provider.GetRequiredService<Func<PaymentService>>()());
+        Assert.NotNull(paymentService);
+
+        var handlers = host.Resolve(
+            "Func<PaymentMethodHandlerDictionary> (invoked)",
+            provider => provider.GetRequiredService<Func<PaymentMethodHandlerDictionary>>()());
+        Assert.NotNull(handlers);
+
+        // And the dictionary really holds the two payment methods the credit path probes, so a core rename that
+        // moved Lightning out from under BTC-LN would fail here rather than making every credit unrecordable.
+        foreach (var paymentMethodId in BTCPayInvoiceCreditGateway.CreditablePaymentMethods)
+            Assert.True(handlers.TryGetValue(paymentMethodId, out _), $"no handler for {paymentMethodId}");
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint.Tests/SparkRegtestIntegrationTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkRegtestIntegrationTests.cs
@@ -67,7 +67,11 @@ public class SparkRegtestIntegrationTests
                 store,
                 new InMemoryOutgoingPaymentStore(),
                 new SparkSettlementReconciler(
-                    store, broadcaster, NullLogger<SparkSettlementReconciler>.Instance),
+                    store,
+                    broadcaster,
+                    new SparkInvoiceCreditor(
+                        new FakeInvoiceCreditGateway(), store, NullLogger<SparkInvoiceCreditor>.Instance),
+                    NullLogger<SparkSettlementReconciler>.Instance),
                 broadcaster,
                 new NBitcoinBolt11Parser(Network.RegTest, NullLogger<NBitcoinBolt11Parser>.Instance),
                 NullLogger.Instance);

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSettlementBroadcasterTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSettlementBroadcasterTests.cs
@@ -154,9 +154,11 @@ public class SparkSettlementBroadcasterTests
     public async Task A_saturated_settlement_is_retried_once_the_consumer_catches_up()
     {
         // The refusal is not the end of the story: BTCPay does not re-poll listened invoices and the
-        // reconciliation task only scans unpaid rows, so a refused push that is simply dropped would leave
-        // the BTCPay invoice unpaid until a restart. The broadcaster must hold it and re-deliver when the
-        // listener drains.
+        // reconciliation task's settlement walk only scans unpaid rows, so a refused push that is simply
+        // dropped is a notification nobody ever receives. The invoice is still credited — the credit path
+        // routes the settlement onto it without any listener (SparkInvoiceCreditor) — but that takes a
+        // reconciliation pass, where re-delivering here takes milliseconds. So the broadcaster must hold the
+        // push and re-deliver it when the listener drains.
         var broadcaster = Create();
         using var subscription = broadcaster.Subscribe("store-1");
 

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSettlementReconcilerTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSettlementReconcilerTests.cs
@@ -34,10 +34,50 @@ public class SparkSettlementReconcilerTests
     private static (SparkSettlementReconciler Reconciler, InMemoryInvoiceRecordStore Store,
         SparkSettlementBroadcaster Broadcaster, CapturingLogger<SparkSettlementReconciler> Log) CreateWithLog()
     {
+        var (reconciler, store, broadcaster, log, _) = CreateWithCredits();
+        return (reconciler, store, broadcaster, log);
+    }
+
+    /// <summary>
+    /// The same reconciler with BTCPay's side of the settlement visible, for the tests about crediting.
+    /// </summary>
+    private static (SparkSettlementReconciler Reconciler, InMemoryInvoiceRecordStore Store,
+        SparkSettlementBroadcaster Broadcaster, CapturingLogger<SparkSettlementReconciler> Log,
+        FakeInvoiceCreditGateway Credits) CreateWithCredits()
+    {
         var store = new InMemoryInvoiceRecordStore();
         var broadcaster = new SparkSettlementBroadcaster(NullLogger<SparkSettlementBroadcaster>.Instance);
         var log = new CapturingLogger<SparkSettlementReconciler>();
-        return (new SparkSettlementReconciler(store, broadcaster, log), store, broadcaster, log);
+        var credits = new FakeInvoiceCreditGateway();
+        var reconciler = new SparkSettlementReconciler(
+            store,
+            broadcaster,
+            new SparkInvoiceCreditor(credits, store, NullLogger<SparkInvoiceCreditor>.Instance),
+            log);
+        return (reconciler, store, broadcaster, log, credits);
+    }
+
+    /// <summary>
+    /// The same reconciler again, with the <em>creditor's</em> log visible rather than the reconciler's.
+    /// </summary>
+    /// <remarks>
+    /// A separate factory because the operator report about a settlement that can never be credited is emitted
+    /// by <see cref="SparkInvoiceCreditor"/>, and the property worth pinning — that it fires once per record and
+    /// not once per pass — is only observable by counting lines on that logger while driving the walk this class
+    /// owns.
+    /// </remarks>
+    private static (SparkSettlementReconciler Reconciler, InMemoryInvoiceRecordStore Store,
+        FakeInvoiceCreditGateway Credits, CapturingLogger<SparkInvoiceCreditor> CreditLog) CreateWithCreditLog()
+    {
+        var store = new InMemoryInvoiceRecordStore();
+        var credits = new FakeInvoiceCreditGateway();
+        var creditLog = new CapturingLogger<SparkInvoiceCreditor>();
+        var reconciler = new SparkSettlementReconciler(
+            store,
+            new SparkSettlementBroadcaster(NullLogger<SparkSettlementBroadcaster>.Instance),
+            new SparkInvoiceCreditor(credits, store, creditLog),
+            NullLogger<SparkSettlementReconciler>.Instance);
+        return (reconciler, store, credits, creditLog);
     }
 
     [Fact]
@@ -508,6 +548,201 @@ public class SparkSettlementReconcilerTests
         Assert.Empty(sdk.GetPaymentCalls);
     }
 
+    // -------------------------------------------------------------------------------------------------------
+    // Crediting: settling records that money arrived, which is not the same as BTCPay knowing about it
+    // -------------------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task A_settlement_is_routed_to_its_BTCPay_invoice_as_well_as_announced()
+    {
+        // Both, not either. The announcement only reaches a listener that is still watching this BOLT11, and
+        // for a superseded one after a restart there is none — so the credit is not an alternative path, it is
+        // the one that does not depend on who is listening.
+        var (reconciler, store, broadcaster, _, credits) = CreateWithCredits();
+        Seed(store);
+        credits.Mint(Hash, "btcpay-invoice-1", StoreId);
+        using var subscription = broadcaster.Subscribe(StoreId);
+
+        await reconciler.ApplyAsync(StoreId, Receive(), Ct);
+
+        var announced = await subscription.ReadAsync(Ct);
+        Assert.Equal(Hash, announced.PaymentHash);
+        var credit = Assert.Single(credits.Credits);
+        Assert.Equal("btcpay-invoice-1", credit.InvoiceId);
+        Assert.NotNull(store.Records[Hash].CreditedAt);
+    }
+
+    [Fact]
+    public async Task A_credit_that_fails_leaves_the_settlement_intact_and_is_retried_by_the_next_pass()
+    {
+        // The ordering guarantee. By the time the credit is attempted the settlement is committed and the
+        // notification published, so a BTCPay database that is briefly unreachable must cost a pass and not a
+        // settlement — and the pass afterwards has to pick it up.
+        var (reconciler, store, _, _, credits) = CreateWithCredits();
+        Seed(store);
+        credits.Mint(Hash, "btcpay-invoice-1", StoreId);
+        credits.FailWith = new InvalidOperationException("BTCPay's database is unreachable");
+
+        var result = await reconciler.ApplyAsync(StoreId, Receive(), Ct);
+
+        Assert.Equal(InvoiceSettlementOutcome.Settled, result.Outcome);
+        Assert.Equal(InvoiceRecordStatus.Paid, store.Records[Hash].Status);
+        Assert.Null(store.Records[Hash].CreditedAt);
+
+        credits.FailWith = null;
+        Assert.Equal(1, await reconciler.CreditStoreAsync(StoreId, Ct));
+
+        Assert.Equal(Hash, Assert.Single(credits.Credits).PaymentHash);
+        Assert.NotNull(store.Records[Hash].CreditedAt);
+    }
+
+    [Fact]
+    public async Task A_duplicate_settlement_event_retries_a_credit_that_had_not_landed()
+    {
+        // The SDK does duplicate its events, and a duplicate is the cheapest retry available — no waiting for
+        // the next pass. It must not, however, credit an already-credited settlement a second time.
+        var (reconciler, store, _, _, credits) = CreateWithCredits();
+        Seed(store);
+        credits.Mint(Hash, "btcpay-invoice-1", StoreId);
+        credits.FailWith = new InvalidOperationException("BTCPay's database is unreachable");
+        await reconciler.ApplyAsync(StoreId, Receive(), Ct);
+        credits.FailWith = null;
+
+        var second = await reconciler.ApplyAsync(StoreId, Receive(), Ct);
+        Assert.Equal(InvoiceSettlementOutcome.AlreadySettled, second.Outcome);
+        Assert.Single(credits.Credits);
+
+        // A third event finds the credit done and does not even ask.
+        var lookups = credits.Lookups;
+        await reconciler.ApplyAsync(StoreId, Receive(), Ct);
+        Assert.Equal(lookups, credits.Lookups);
+        Assert.Single(credits.Credits);
+    }
+
+    [Fact]
+    public async Task A_reconciliation_pass_credits_a_settlement_BTCPay_never_heard_about()
+    {
+        // The restart case, at the reconciler's own altitude: a paid row whose credit never landed, and whose
+        // invoice has since expired — so the settlement walk skips it and only the credit walk reaches it.
+        var (reconciler, store, _, _, credits) = CreateWithCredits();
+        Seed(store, createdAt: DateTimeOffset.UtcNow.AddHours(-5),
+            expiresAt: DateTimeOffset.UtcNow.AddHours(-4));
+        await store.SettleAsync(StoreId, Hash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        credits.Mint(Hash, "btcpay-invoice-1", StoreId);
+
+        Assert.Equal(0, await reconciler.ReconcileStoreAsync(StoreId, new FakeSparkSdkClient(), Ct));
+
+        Assert.Equal(Hash, Assert.Single(credits.Credits).PaymentHash);
+        Assert.NotNull(store.Records[Hash].CreditedAt);
+    }
+
+    [Fact]
+    public async Task A_reconciliation_pass_credits_each_settlement_at_most_once()
+    {
+        // Idempotence across passes, which is what a timer makes unavoidable: the pass runs every minute for
+        // the life of the server.
+        var (reconciler, store, _, _, credits) = CreateWithCredits();
+        Seed(store);
+        await store.SettleAsync(StoreId, Hash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        credits.Mint(Hash, "btcpay-invoice-1", StoreId);
+
+        Assert.Equal(1, await reconciler.CreditStoreAsync(StoreId, Ct));
+        Assert.Equal(0, await reconciler.CreditStoreAsync(StoreId, Ct));
+        Assert.Equal(0, await reconciler.CreditStoreAsync(StoreId, Ct));
+
+        Assert.Single(credits.Credits);
+    }
+
+    [Fact]
+    public async Task A_credit_pass_does_not_touch_another_stores_settlements()
+    {
+        var (reconciler, store, _, _, credits) = CreateWithCredits();
+        Seed(store);
+        await store.SettleAsync(StoreId, Hash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        credits.Mint(Hash, "btcpay-invoice-1", StoreId);
+
+        Assert.Equal(0, await reconciler.CreditStoreAsync("some-other-store", Ct));
+        Assert.Empty(credits.Credits);
+        Assert.Null(store.Records[Hash].CreditedAt);
+    }
+
+    [Fact]
+    public async Task A_settlement_that_can_never_be_credited_is_reported_by_the_walk_exactly_once()
+    {
+        // The defect this pins is a silence, which is the hardest kind to notice. The walk's listing bound and
+        // the creditor's retry horizon were the same value, so a settlement crossed out of the listing at the
+        // exact instant it became eligible to be reported: the operator warning was unreachable from the pass,
+        // the money stayed unaccounted for, and the row was indistinguishable from one still in flight.
+        //
+        // Driven through the walk and not by calling the creditor directly — deliberately. The creditor's own
+        // test proves the classification; only the walk can prove the record is *reachable* to be classified.
+        var (reconciler, store, credits, creditLog) = CreateWithCreditLog();
+        var settledAt = DateTimeOffset.UtcNow - SparkInvoiceCreditor.CreditRetryHorizon - TimeSpan.FromDays(1);
+        Seed(store, createdAt: settledAt.AddMinutes(-5), expiresAt: settledAt.AddHours(1));
+        await store.SettleAsync(StoreId, Hash, "sdk-1", 100_000, PaymentFixture.Preimage, settledAt, Ct);
+        // No Mint: BTCPay has no invoice for this hash and never will, which is what a BOLT11 minted through
+        // this plugin's own Greenfield endpoints looks like from here.
+
+        Assert.Equal(0, await reconciler.CreditStoreAsync(StoreId, Ct));
+
+        // Reported, at operator level, with the amount and the hash a human needs to trace the money.
+        var reports = creditLog.Lines.Where(l => l.Contains("no longer be retried")).ToList();
+        Assert.Single(reports);
+        Assert.StartsWith("Warning:", reports[0]);
+        Assert.Contains(Hash, reports[0]);
+        Assert.Contains("100 sat", reports[0]);
+
+        // Recorded as abandoned rather than credited: the row must not claim the merchant was paid.
+        Assert.Null(store.Records[Hash].CreditedAt);
+        Assert.NotNull(store.Records[Hash].CreditAbandonedAt);
+
+        // And that is the end of it — no further attempt, and above all no second report, however many passes
+        // run afterwards.
+        var lookups = credits.Lookups;
+        Assert.Equal(0, await reconciler.CreditStoreAsync(StoreId, Ct));
+        Assert.Equal(0, await reconciler.CreditStoreAsync(StoreId, Ct));
+
+        Assert.Equal(lookups, credits.Lookups);
+        Assert.Single(creditLog.Lines.Where(l => l.Contains("no longer be retried")));
+    }
+
+    [Fact]
+    public async Task A_settlement_still_inside_the_retry_horizon_is_retried_rather_than_reported()
+    {
+        // The other side of the boundary, and the reason the report cannot simply be moved earlier: BTCPay
+        // writes its payment-hash row just after CreateInvoice returns, so a payment landing in that window
+        // finds nothing. An operator-level line there would fire on ordinary checkouts.
+        var (reconciler, store, _, creditLog) = CreateWithCreditLog();
+        Seed(store);
+        await store.SettleAsync(StoreId, Hash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+
+        Assert.Equal(0, await reconciler.CreditStoreAsync(StoreId, Ct));
+
+        Assert.DoesNotContain("no longer be retried", creditLog.AllText);
+        Assert.Null(store.Records[Hash].CreditAbandonedAt);
+        // Still in the queue, so the pass after BTCPay catches up credits it.
+        Assert.Null(store.Records[Hash].CreditedAt);
+    }
+
+    [Fact]
+    public async Task A_failed_settlement_listing_does_not_skip_the_credit_walk()
+    {
+        // The two walks read different queries of the same table and neither is a precondition of the other.
+        // The credit walk used to run last and inside the settlement walk's control flow, so a failure loading
+        // the settlement page returned before reaching it — on exactly the store whose invoices are in trouble
+        // and therefore most likely to be holding uncredited money.
+        var (reconciler, store, credits, _) = CreateWithCreditLog();
+        Seed(store);
+        await store.SettleAsync(StoreId, Hash, "sdk-1", 100_000, null, DateTimeOffset.UtcNow, Ct);
+        credits.Mint(Hash, "btcpay-invoice-1", StoreId);
+        store.FailReconciliationListWith = new InvalidOperationException("the invoice listing is unavailable");
+
+        Assert.Equal(0, await reconciler.ReconcileStoreAsync(StoreId, new FakeSparkSdkClient(), Ct));
+
+        Assert.Equal(Hash, Assert.Single(credits.Credits).PaymentHash);
+        Assert.NotNull(store.Records[Hash].CreditedAt);
+    }
+
     /// <summary>
     /// Decorator that fails one specific point lookup and delegates everything else.
     /// </summary>
@@ -659,13 +894,23 @@ public class SparkReconcileStoresTests
 
     private static (SparkSettlementReconciler Reconciler, InMemoryInvoiceRecordStore Store) Create()
     {
+        var (reconciler, store, _) = CreateWithCredits();
+        return (reconciler, store);
+    }
+
+    private static (SparkSettlementReconciler Reconciler, InMemoryInvoiceRecordStore Store,
+        FakeInvoiceCreditGateway Credits) CreateWithCredits()
+    {
         var store = new InMemoryInvoiceRecordStore();
+        var credits = new FakeInvoiceCreditGateway();
         return (
             new SparkSettlementReconciler(
                 store,
                 new SparkSettlementBroadcaster(NullLogger<SparkSettlementBroadcaster>.Instance),
+                new SparkInvoiceCreditor(credits, store, NullLogger<SparkInvoiceCreditor>.Instance),
                 NullLogger<SparkSettlementReconciler>.Instance),
-            store);
+            store,
+            credits);
     }
 
     private static FakeSparkSdkClient SeedStore(
@@ -768,5 +1013,76 @@ public class SparkReconcileStoresTests
         var (reconciler, _) = Create();
 
         Assert.Equal(0, await reconciler.ReconcileStoresAsync([], TestPasses.Reconciliation(), Ct));
+    }
+
+    [Fact]
+    public async Task A_store_with_no_running_wallet_still_gets_its_settlements_credited()
+    {
+        // The gap this closes. The pass's stores used to come only from the live SDK instances, so a store whose
+        // Spark connection was broken — a rotated key, a service-provider outage, a wallet reconfigured away —
+        // got no credit pass either. Its money had already arrived and been recorded; only the routing onto
+        // BTCPay's invoice was outstanding, and that needs no wallet at all. So the pass takes its stores from
+        // the record store as well, and this store is in no target list whatsoever.
+        var (reconciler, store, credits) = CreateWithCredits();
+        var offline = "store-with-no-wallet";
+        store.Seed(new InvoiceRecord
+        {
+            PaymentHash = PaymentFixture.PaymentHash,
+            StoreId = offline,
+            Bolt11 = "lnbcrt-one",
+            AmountMsat = 100_000,
+            AmountReceivedMsat = 100_000,
+            SdkPaymentId = "sdk-1",
+            Preimage = PaymentFixture.Preimage,
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-5),
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(-4),
+            SettledAt = DateTimeOffset.UtcNow.AddHours(-4),
+            Status = InvoiceRecordStatus.Paid
+        });
+        credits.Mint(PaymentFixture.PaymentHash, "btcpay-invoice-1", offline);
+
+        // No targets: as far as the live wallets are concerned this store does not exist.
+        Assert.Equal(0, await reconciler.ReconcileStoresAsync([], TestPasses.Reconciliation(), Ct));
+
+        Assert.Equal(PaymentFixture.PaymentHash, Assert.Single(credits.Credits).PaymentHash);
+        Assert.NotNull(store.Records[PaymentFixture.PaymentHash].CreditedAt);
+    }
+
+    [Fact]
+    public async Task A_running_store_that_also_awaits_a_credit_does_both_and_is_counted_once()
+    {
+        // A store reached by both sources at once. The union is a set, so it is visited a single time, and that
+        // one visit has to do both jobs: settle the invoice the SDK has been paid for, and route the settlement
+        // from an earlier pass that never reached BTCPay. A settled count of two would mean the store had been
+        // walked twice.
+        var (reconciler, store, credits) = CreateWithCredits();
+        var sdk = SeedStore(store, "store-1", PaymentFixture.PaymentHash);
+        credits.Mint(PaymentFixture.PaymentHash, "btcpay-invoice-1", "store-1");
+
+        // Already settled on an earlier pass, and never credited — which is what puts this store in the record
+        // store's awaiting-credit list as well as in the target list.
+        store.Seed(new InvoiceRecord
+        {
+            PaymentHash = PaymentFixture.OtherPaymentHash,
+            StoreId = "store-1",
+            Bolt11 = "lnbcrt-two",
+            AmountMsat = 100_000,
+            AmountReceivedMsat = 100_000,
+            SdkPaymentId = "sdk-earlier",
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-5),
+            ExpiresAt = DateTimeOffset.UtcNow.AddHours(-4),
+            SettledAt = DateTimeOffset.UtcNow.AddHours(-4),
+            Status = InvoiceRecordStatus.Paid
+        });
+        credits.Mint(PaymentFixture.OtherPaymentHash, "btcpay-invoice-2", "store-1");
+
+        var settled = await reconciler.ReconcileStoresAsync(
+            [new SparkReconciliationTarget("store-1", sdk)], TestPasses.Reconciliation(), Ct);
+
+        Assert.Equal(1, settled);
+        var credited = credits.Credits.Select(c => c.PaymentHash).ToList();
+        Assert.Equal(2, credited.Count);
+        Assert.Contains(PaymentFixture.PaymentHash, credited);
+        Assert.Contains(PaymentFixture.OtherPaymentHash, credited);
     }
 }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSupersededInvoiceCreditTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSupersededInvoiceCreditTests.cs
@@ -1,0 +1,307 @@
+using System.Numerics;
+using Breez.Sdk.Spark;
+using BTCPayServer.Lightning;
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Sdk;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using NBitcoin;
+using Xunit;
+using SdkPaymentStatus = Breez.Sdk.Spark.PaymentStatus;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The audit's superseded-invoice scenario, end to end: X → Y → restart → pay X.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The defect this pins.</b> BTCPay's Lightning listener matches a settlement notification by id against a
+/// set it builds from each invoice's <em>current</em> payment prompt. Replace BOLT11 X with BOLT11 Y — which
+/// BTCPay does whenever an LNURL invoice is re-quoted — and X leaves that set; after a restart it is never
+/// re-added, because the set is rebuilt from the prompts that exist now. X is still payable, because Spark has
+/// no way to withdraw an invoice from the service provider. So a payment to X after that restart used to land
+/// in the merchant's wallet, settle in this plugin's records, and leave the BTCPay invoice unpaid: money
+/// received against an invoice that says it was not.
+/// </para>
+/// <para>
+/// <b>Why it is tested here rather than as a unit.</b> Every ingredient is a seam of its own — the record
+/// store, the broadcaster, the creditor, the gateway — and each of them can be individually correct while the
+/// scenario still fails, because what fails is the <em>composition</em>: which state survives a restart and
+/// which does not. So this drives the real <see cref="Services.SparkService"/> through
+/// <see cref="SparkServiceHarness"/>, mints and supersedes through the real
+/// <see cref="SparkLightningClient"/>, and restarts by actually discarding the service and its in-memory
+/// broadcaster while keeping the database and BTCPay's payment-hash index — the split a real restart makes.
+/// </para>
+/// </remarks>
+public class SparkSupersededInvoiceCreditTests
+{
+    private const string StoreId = "superseded-store";
+    private const string InvoiceId = "btcpay-invoice-1";
+
+    /// <summary>The superseded BOLT11 and its replacement, both minted for the same BTCPay invoice.</summary>
+    private const string Bolt11X = "lnbcrt-x";
+
+    private const string Bolt11Y = "lnbcrt-y";
+
+    private static readonly string HashX = PaymentFixture.PaymentHash;
+    private static readonly string HashY = PaymentFixture.OtherPaymentHash;
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    // -------------------------------------------------------------------------------------------------------
+    // Fixtures
+    // -------------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A completed inbound Lightning payment, in the SDK's own shape.
+    /// </summary>
+    /// <remarks>
+    /// Timestamped now rather than at a literal instant, because the settlement time is what the credit's retry
+    /// horizon is measured from: a hard-coded timestamp would put these settlements outside the horizon as soon
+    /// as the calendar moved past it, and the tests would start failing for a reason that has nothing to do
+    /// with the behaviour they name.
+    /// </remarks>
+    private static Payment Receive(string id, string hash, long amountSats = 100) =>
+        new(
+            id: id,
+            paymentType: PaymentType.Receive,
+            status: SdkPaymentStatus.Completed,
+            amount: new BigInteger(amountSats),
+            fees: BigInteger.Zero,
+            timestamp: (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            method: PaymentMethod.Lightning,
+            details: new PaymentDetails.Lightning(
+                description: "order 42",
+                invoice: "lnbcrt-one",
+                destinationPubkey: "02fe4b",
+                htlcDetails: new SparkHtlcDetails(hash, PaymentFixture.Preimage, 0, SparkHtlcStatus.PreimageShared),
+                lnurlPayInfo: null,
+                lnurlWithdrawInfo: null,
+                lnurlReceiveMetadata: null,
+                conversionInfo: null),
+            conversionDetails: null!);
+
+    private static void Pay(SparkServiceHarness h, string hash, string sdkPaymentId) =>
+        Assert.True(
+            h.Sdk.EventWriters[StoreId].TryWrite(
+                new SparkEventEnvelope(StoreId, SparkEventKind.PaymentSucceeded, Receive(sdkPaymentId, hash))),
+            "the event channel refused the envelope");
+
+    private static async Task WaitFor(Func<bool> condition, string because)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(20);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+                return;
+            await Task.Delay(10, Ct);
+        }
+
+        Assert.Fail(because);
+    }
+
+    /// <summary>A started service with one configured store, ready to mint.</summary>
+    private static async Task<(SparkServiceHarness Harness, string PaymentKey)> StartedAsync()
+    {
+        var h = SparkServiceHarness.Create();
+        var paymentKey = SparkConnectionString.GeneratePaymentKey();
+        h.SeedStore(StoreId, SparkServiceHarness.MnemonicFor(1), paymentKey);
+        var now = DateTimeOffset.UtcNow;
+        h.Bolt11.Register(Bolt11X, new Bolt11Info(HashX, now.AddHours(1), 100_000));
+        h.Bolt11.Register(Bolt11Y, new Bolt11Info(HashY, now.AddHours(1), 100_000));
+
+        await h.Service.StartAsync(CancellationToken.None);
+        return (h, paymentKey);
+    }
+
+    private static ILightningClient ClientFor(SparkServiceHarness h, string paymentKey)
+    {
+        var resolution = h.Service.Resolve(StoreId, paymentKey, NBitcoin.Network.RegTest);
+        Assert.Null(resolution.Error);
+        Assert.NotNull(resolution.Client);
+        return resolution.Client;
+    }
+
+    /// <summary>Mints one invoice through the real client and indexes it the way BTCPay does.</summary>
+    private static async Task<LightningInvoice> MintAsync(
+        SparkServiceHarness h,
+        ILightningClient client,
+        string bolt11)
+    {
+        h.Sdk.Clients[StoreId].NextPaymentRequest = bolt11;
+        var invoice = await client.CreateInvoice(
+            new CreateInvoiceParams(LightMoney.Satoshis(100), "order 42", TimeSpan.FromHours(1)), Ct);
+
+        // What core's LightningLikePaymentHandler.ConfigurePrompt does immediately after this returns: it
+        // writes the payment hash into AddressInvoices against the invoice it is prompting for. Insert-only,
+        // so superseding this BOLT11 later does not remove the row.
+        h.Credits.Mint(invoice.Id, InvoiceId, StoreId);
+        return invoice;
+    }
+
+    // -------------------------------------------------------------------------------------------------------
+    // The audit's scenario
+    // -------------------------------------------------------------------------------------------------------
+
+    [Fact(Timeout = 120_000)]
+    public async Task A_superseded_invoice_paid_after_a_restart_credits_its_BTCPay_invoice_exactly_once()
+    {
+        var (first, paymentKey) = await StartedAsync();
+        SparkServiceHarness? h = null;
+        try
+        {
+            var client = ClientFor(first, paymentKey);
+
+            // BTCPay quotes the invoice, then re-quotes it: X is cancelled and replaced by Y, both minted for
+            // the same BTCPay invoice.
+            var x = await MintAsync(first, client, Bolt11X);
+            await client.CancelInvoice(x.Id, Ct);
+            var y = await MintAsync(first, client, Bolt11Y);
+            Assert.Equal(HashX, x.Id);
+            Assert.Equal(HashY, y.Id);
+
+            // The restart. The service, its SDK connections and the settlement broadcaster are discarded; the
+            // database and BTCPay's payment-hash index survive, as they do on a real server. From here on
+            // BTCPay is watching only Y — nothing in this process knows X exists except the record store.
+            h = first.Restart();
+            await h.Service.StartAsync(CancellationToken.None);
+
+            // And X is paid.
+            Pay(h, HashX, "recv-x");
+
+            await WaitFor(
+                () => h.Invoices.Records[HashX] is { Status: InvoiceRecordStatus.Paid, CreditedAt: not null },
+                "the payment to the superseded invoice never reached its BTCPay invoice");
+
+            // Exactly one payment, on the right invoice, for the amount that actually arrived.
+            var credit = Assert.Single(h.Credits.CreditsFor(InvoiceId));
+            Assert.Equal(HashX, credit.PaymentHash);
+            Assert.Equal(100_000, credit.AmountReceivedMsat);
+            Assert.Equal(PaymentFixture.Preimage, credit.Preimage);
+
+            // And the replacement's payment prompt is untouched. X's preimage is on X's payment, not stamped
+            // onto the prompt now offering Y — which would have LUD-21 verify hand a payer a proof of payment
+            // for an invoice they never paid.
+            Assert.Equal(HashY, h.Credits.PromptPaymentHashFor(InvoiceId));
+            Assert.Null(h.Credits.PromptPreimageFor(InvoiceId));
+
+            // A duplicate event — the SDK does emit them, 57 ms apart on two threads in one observed case —
+            // must not credit it again. Nor must a reconciliation pass, which walks the same rows.
+            var seen = h.Sdk.Clients[StoreId].GetPaymentCalls.Count;
+            Pay(h, HashX, "recv-x");
+            // Waited on an observable effect of the duplicate having been consumed, so this asserts that the
+            // duplicate was processed and credited nothing — not merely that it had not arrived yet.
+            await WaitFor(
+                () => h.Sdk.Clients[StoreId].GetPaymentCalls.Count > seen,
+                "the duplicate settlement event was never consumed");
+            await h.Service.ReconcileAllStoresAsync(Ct);
+            await h.Service.ReconcileAllStoresAsync(Ct);
+
+            Assert.Single(h.Credits.CreditsFor(InvoiceId));
+
+            // The replacement still works, under its own hash, on the same BTCPay invoice: nothing about the
+            // routing above interferes with the ordinary path.
+            Pay(h, HashY, "recv-y");
+            await WaitFor(
+                () => h.Invoices.Records[HashY] is { Status: InvoiceRecordStatus.Paid, CreditedAt: not null },
+                "the replacement invoice never settled");
+
+            Assert.Equal(
+                [HashX, HashY], h.Credits.CreditsFor(InvoiceId).Select(c => c.PaymentHash).ToArray());
+
+            // Y *is* the current prompt, so crediting it does fill the prompt's preimage — the ordinary
+            // proof-of-payment path, which the superseded case above must not disturb and does not.
+            Assert.Equal(PaymentFixture.Preimage, h.Credits.PromptPreimageFor(InvoiceId));
+        }
+        finally
+        {
+            (h ?? first).Dispose();
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task A_settlement_recorded_while_the_process_was_down_is_credited_by_the_next_pass()
+    {
+        // The crash window. The settlement's compare-and-set committed, and the process died before BTCPay was
+        // told — so the row is paid, uncredited, and nothing is ever going to notify anyone about it again. The
+        // startup reconciliation pass is what has to notice.
+        var (first, _) = await StartedAsync();
+        SparkServiceHarness? h = null;
+        try
+        {
+            first.Invoices.Seed(new InvoiceRecord
+            {
+                PaymentHash = HashX,
+                StoreId = StoreId,
+                Bolt11 = Bolt11X,
+                AmountMsat = 100_000,
+                AmountReceivedMsat = 100_000,
+                SdkPaymentId = "recv-x",
+                Preimage = PaymentFixture.Preimage,
+                CreatedAt = DateTimeOffset.UtcNow.AddMinutes(-30),
+                ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-20),
+                SettledAt = DateTimeOffset.UtcNow.AddMinutes(-25),
+                Status = InvoiceRecordStatus.Paid
+            });
+            first.Credits.Mint(HashX, InvoiceId, StoreId);
+
+            h = first.Restart();
+            await h.Service.StartAsync(CancellationToken.None);
+
+            await WaitFor(
+                () => h.Invoices.Records[HashX].CreditedAt is not null,
+                "the settlement recorded before the restart was never credited");
+
+            var credit = Assert.Single(h.Credits.CreditsFor(InvoiceId));
+            Assert.Equal(HashX, credit.PaymentHash);
+
+            // Note that this row is past its expiry: the settlement walk would not look at it any more, and
+            // BTCPay's listener never would. Only the credit walk reaches it.
+            await h.Service.ReconcileAllStoresAsync(Ct);
+            Assert.Single(h.Credits.CreditsFor(InvoiceId));
+        }
+        finally
+        {
+            (h ?? first).Dispose();
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task A_settlement_BTCPay_already_credited_is_not_credited_twice_after_a_restart()
+    {
+        // The common case, which must stay cheap and silent: BTCPay's own listener credited the payment before
+        // the restart. The pass afterwards has to recognise that and stop asking, without inserting anything.
+        var (first, paymentKey) = await StartedAsync();
+        SparkServiceHarness? h = null;
+        try
+        {
+            var client = ClientFor(first, paymentKey);
+            var x = await MintAsync(first, client, Bolt11X);
+
+            Pay(first, HashX, "recv-x");
+            await WaitFor(
+                () => first.Invoices.Records[HashX] is
+                    { Status: InvoiceRecordStatus.Paid, CreditedAt: not null },
+                "the invoice never settled and credited");
+
+            // Rewritten as though core's listener had won the race and this plugin had not yet stamped the row
+            // — the exact state a crash between the two leaves behind.
+            first.Credits.CreditedByBTCPay(x.Id);
+            first.Invoices.Records[HashX].CreditedAt = null;
+            first.Credits.Credits.Clear();
+
+            h = first.Restart();
+            await h.Service.StartAsync(CancellationToken.None);
+
+            await WaitFor(
+                () => h.Invoices.Records[HashX].CreditedAt is not null,
+                "the pass never recognised that BTCPay already held the payment");
+            // Nothing inserted: the payment was already on the invoice, and finding that out is the whole job.
+            Assert.Empty(h.Credits.Credits);
+        }
+        finally
+        {
+            (h ?? first).Dispose();
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Data/EfInvoiceRecordStore.cs
+++ b/BTCPayServer.Plugins.Flint/Data/EfInvoiceRecordStore.cs
@@ -233,6 +233,118 @@ public class EfInvoiceRecordStore : IInvoiceRecordStore
         return new InvoiceSettlementResult(InvoiceSettlementOutcome.NotFound, null);
     }
 
+    public async Task<bool> MarkCreditedAsync(
+        string storeId,
+        string paymentHash,
+        DateTimeOffset creditedAt,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateContext();
+
+        // A conditional UPDATE, so the database decides which of the two racing callers — the settlement path
+        // and the reconciliation pass — actually stamps the row. Guarded on Paid because marking an unpaid row
+        // credited would permanently suppress the credit of the payment that later arrives, and on the column
+        // still being null so the timestamp keeps meaning "when the credit landed".
+        var updated = await context.InvoiceRecords
+            .Where(r => r.PaymentHash == paymentHash
+                        && r.StoreId == storeId
+                        && r.Status == InvoiceRecordStatus.Paid
+                        && r.CreditedAt == null)
+            .ExecuteUpdateAsync(
+                setters => setters.SetProperty(r => r.CreditedAt, creditedAt),
+                cancellationToken);
+        return updated == 1;
+    }
+
+    public async Task<bool> MarkCreditAbandonedAsync(
+        string storeId,
+        string paymentHash,
+        DateTimeOffset abandonedAt,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateContext();
+
+        // A conditional UPDATE for the same reason MarkCreditedAsync uses one, plus a third clause. Guarded on
+        // CreditedAt so a credit that landed on a concurrent pass is never overwritten by this claim that it
+        // never will, and on this column still being null so the caller's operator warning — which it emits only
+        // when this returns true — fires exactly once for the row rather than on every pass.
+        var updated = await context.InvoiceRecords
+            .Where(r => r.PaymentHash == paymentHash
+                        && r.StoreId == storeId
+                        && r.Status == InvoiceRecordStatus.Paid
+                        && r.CreditedAt == null
+                        && r.CreditAbandonedAt == null)
+            .ExecuteUpdateAsync(
+                setters => setters.SetProperty(r => r.CreditAbandonedAt, abandonedAt),
+                cancellationToken);
+        return updated == 1;
+    }
+
+    public async Task<IReadOnlyList<InvoiceRecord>> ListUncreditedAsync(
+        string storeId,
+        DateTimeOffset settledFrom,
+        InvoiceReconciliationCursor? after,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        await using var context = _contextFactory.CreateContext();
+        var query = context.InvoiceRecords
+            .AsNoTracking()
+            // The mirror image of ListForReconciliationAsync's predicate: that walk wants what might still be
+            // paid, this one wants what has been paid but whose money has neither reached a BTCPay invoice nor
+            // been given up on. The (StoreId, Status) index narrows it to this store's paid rows; the rest is a
+            // filter over a set that is normally empty.
+            .Where(r => r.StoreId == storeId
+                        && r.Status == InvoiceRecordStatus.Paid
+                        && r.CreditedAt == null
+                        && r.CreditAbandonedAt == null
+                        && r.SettledAt != null
+                        && r.SettledAt > settledFrom);
+
+        if (after is not null)
+        {
+            var cursorCreatedAt = after.CreatedAt;
+            var cursorHash = after.PaymentHash;
+            query = query.Where(r => r.CreatedAt > cursorCreatedAt
+                                     || (r.CreatedAt == cursorCreatedAt
+                                         && string.Compare(r.PaymentHash, cursorHash) > 0));
+        }
+
+        return await query
+            .OrderBy(r => r.CreatedAt)
+            .ThenBy(r => r.PaymentHash)
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<string>> ListStoreIdsAwaitingCreditAsync(
+        DateTimeOffset settledFrom,
+        int limit,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        await using var context = _contextFactory.CreateContext();
+
+        // The same predicate as ListUncreditedAsync minus the store scope, projected to distinct store ids. A
+        // GROUP BY over a set that is normally empty, and it is what lets the credit walk reach a store whose
+        // Spark wallet is not running — see the interface's remarks for why that matters.
+        return await context.InvoiceRecords
+            .AsNoTracking()
+            .Where(r => r.Status == InvoiceRecordStatus.Paid
+                        && r.CreditedAt == null
+                        && r.CreditAbandonedAt == null
+                        && r.SettledAt != null
+                        && r.SettledAt > settledFrom)
+            .Select(r => r.StoreId)
+            .Distinct()
+            .OrderBy(storeId => storeId)
+            .Take(limit)
+            .ToListAsync(cancellationToken);
+    }
+
     public async Task<bool> CancelAsync(
         string storeId,
         string paymentHash,

--- a/BTCPayServer.Plugins.Flint/Data/IInvoiceRecordStore.cs
+++ b/BTCPayServer.Plugins.Flint/Data/IInvoiceRecordStore.cs
@@ -114,4 +114,113 @@ public interface IInvoiceRecordStore
     /// overwrite a committed settlement and turn a paid invoice back into an expired one.
     /// </remarks>
     Task<bool> CancelAsync(string storeId, string paymentHash, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records that a settled invoice's payment has reached the BTCPay invoice it was minted for. Returns true
+    /// only when this call is what set the timestamp.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A compare-and-set on <c>Status = Paid AND CreditedAt IS NULL</c>, for two independent reasons. The
+    /// <c>Paid</c> guard is a safety interlock: marking an unpaid row credited would tell every later pass
+    /// that the credit is done, and the payment that eventually arrives would never be routed to the merchant's
+    /// invoice. The null guard keeps the timestamp meaning "when the credit landed" rather than "when a pass
+    /// last looked", which matters because two callers genuinely race here — the settlement path and the
+    /// reconciliation pass both attempt the credit for the same row.
+    /// </para>
+    /// <para>
+    /// Idempotent by construction: a second call returns false and changes nothing, which is what lets the
+    /// caller treat "we credited it" and "BTCPay already had it" as the same outcome.
+    /// </para>
+    /// </remarks>
+    Task<bool> MarkCreditedAsync(
+        string storeId,
+        string paymentHash,
+        DateTimeOffset creditedAt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records that a settled invoice will never reach a BTCPay invoice. Returns true only when this call is
+    /// what set the timestamp.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The terminal marker for the other half of <see cref="ListUncreditedAsync"/>'s exit condition. A
+    /// settlement whose payment hash BTCPay has no invoice for can never be credited, so it has to leave the
+    /// retry set — but marking it <em>credited</em> to achieve that would claim the merchant was paid on an
+    /// invoice that in fact records nothing. This stamp says what actually happened, in a column an operator can
+    /// query: see <see cref="InvoiceRecord.CreditAbandonedAt"/>.
+    /// </para>
+    /// <para>
+    /// A compare-and-set guarded on <c>Status = Paid AND CreditedAt IS NULL AND CreditAbandonedAt IS NULL</c>,
+    /// and every clause is load-bearing. <c>Paid</c> because an unsettled row has nothing to give up on;
+    /// <c>CreditedAt IS NULL</c> so a credit that landed on a concurrent pass is never overwritten with a claim
+    /// that it did not; and the self-guard so the operator warning the caller emits alongside this fires exactly
+    /// once rather than on every pass.
+    /// </para>
+    /// </remarks>
+    Task<bool> MarkCreditAbandonedAsync(
+        string storeId,
+        string paymentHash,
+        DateTimeOffset abandonedAt,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// One page of a store's settled-but-unresolved invoices, oldest first: settlements this plugin recorded
+    /// whose money has neither been put on a BTCPay invoice nor been given up on.
+    /// </summary>
+    /// <param name="settledFrom">
+    /// Lower bound on <see cref="InvoiceRecord.SettledAt"/>, which bounds the size of this set on a server that
+    /// has been running for years. It is deliberately <em>not</em> the credit retry horizon: a record has to
+    /// stay listed for a while <em>after</em> that horizon passes, or it would age out of this listing before
+    /// any pass could classify it as abandoned — reported to nobody, retried by nobody, and indistinguishable in
+    /// the database from one still in flight. See <c>SparkInvoiceCreditor.ListableFrom</c>, which is what the
+    /// reconciliation pass passes here and which adds that slack explicitly.
+    /// </param>
+    /// <param name="after">
+    /// Keyset cursor, exactly as in <see cref="ListForReconciliationAsync"/> and for the same reason: crediting
+    /// a record removes it from this result set, so an offset would skip its neighbours.
+    /// </param>
+    /// <remarks>
+    /// Normally empty — the credit is attempted the moment a settlement is recorded, and only fails when
+    /// BTCPay's own row is not there yet, when the process died in between, or when the settlement predates
+    /// this column. That is why it is ordered and paged like the reconciliation walk rather than indexed
+    /// specially: the set is small, and the (StoreId, Status) index already narrows it to a store's paid rows.
+    /// </remarks>
+    Task<IReadOnlyList<InvoiceRecord>> ListUncreditedAsync(
+        string storeId,
+        DateTimeOffset settledFrom,
+        InvoiceReconciliationCursor? after,
+        int limit,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The stores that have at least one settlement awaiting a BTCPay credit, whether or not their Spark wallet
+    /// is currently running.
+    /// </summary>
+    /// <param name="settledFrom">As in <see cref="ListUncreditedAsync"/>, and the same value is passed.</param>
+    /// <param name="limit">
+    /// Cap on the number of stores returned, so this cannot become an unbounded query. Reaching it is
+    /// pathological — it would mean hundreds of stores each holding uncredited money — and the caller says so
+    /// in the log rather than pretending it walked them all.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// <b>Why the credit walk cannot take its stores from the live SDK instances.</b> Crediting a settlement
+    /// touches only BTCPay's own tables and this plugin's own rows; it makes no SDK call at all. But the
+    /// reconciliation pass used to derive its store list from the running wallets, so a store whose Spark
+    /// connection was broken — a rotated key, a service-provider outage, a wallet reconfigured away — got no
+    /// credit pass either, and its already-received money sat uncredited until it aged out of the retry set. The
+    /// two concerns are now sourced separately: settling needs a wallet, crediting needs only a store id, and
+    /// this is where that store id comes from.
+    /// </para>
+    /// <para>
+    /// Ordered by store id so the cap is deterministic on a given server rather than picking an arbitrary
+    /// subset each pass. The exact ordering is the database's collation and is not part of this contract.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyList<string>> ListStoreIdsAwaitingCreditAsync(
+        DateTimeOffset settledFrom,
+        int limit,
+        CancellationToken cancellationToken = default);
 }

--- a/BTCPayServer.Plugins.Flint/Data/InvoiceRecord.cs
+++ b/BTCPayServer.Plugins.Flint/Data/InvoiceRecord.cs
@@ -85,6 +85,64 @@ public class InvoiceRecord
     public string? Preimage { get; set; }
 
     /// <summary>
+    /// When this settlement was recorded on the BTCPay invoice the BOLT11 was minted for. Null means it has
+    /// not been, and the credit is still owed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why a settled invoice is not necessarily a credited one.</b> Settling this row records that the money
+    /// arrived; it does not put a payment on the merchant's BTCPay invoice. Normally BTCPay's own Lightning
+    /// listener does that, having been woken by <c>SparkSettlementBroadcaster</c>. But that listener watches
+    /// only the <em>current</em> prompt of each invoice: when BTCPay supersedes BOLT11 X with BOLT11 Y — which
+    /// it does on every LNURL re-quote — and the process then restarts, only Y is watched again. X is still
+    /// payable on the service provider, and a payment to X after that restart would settle this row while the
+    /// BTCPay invoice stayed unpaid. The same hole opens when a listening session is saturated, or when the
+    /// process dies between the settle and the notification.
+    /// </para>
+    /// <para>
+    /// So the credit is tracked here as its own durable step, retried by the reconciliation pass until it
+    /// lands. "Landed" covers two outcomes and deliberately does not distinguish them: our own insert won, or
+    /// we confirmed BTCPay already holds a payment row for this hash. Both mean the merchant's invoice has the
+    /// money on it exactly once, which is the only thing a retry needs to know.
+    /// </para>
+    /// <para>
+    /// Never cleared, and only ever set on a <see cref="InvoiceRecordStatus.Paid"/> row — see
+    /// <see cref="IInvoiceRecordStore.MarkCreditedAsync"/>, which is a compare-and-set for the same reason
+    /// settling is.
+    /// </para>
+    /// </remarks>
+    public DateTimeOffset? CreditedAt { get; set; }
+
+    /// <summary>
+    /// When this settlement was given up on as never creditable. Null means it has not been.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why this is not just <see cref="CreditedAt"/>.</b> Some settlements can never reach a BTCPay invoice:
+    /// a BOLT11 minted through this plugin's own Greenfield endpoints was never attached to one, and no amount
+    /// of retrying will attach it. Such a row has to leave the retry set, or every pass re-attempts it and
+    /// re-warns about it for the life of the server. But stamping <see cref="CreditedAt"/> to achieve that would
+    /// record that the merchant <em>was</em> credited, which is exactly the opposite of what happened — and this
+    /// table is the record an operator reconciles a wallet balance against. So the two terminal states are
+    /// separate columns, and <c>Status = Paid AND "CreditedAt" IS NULL AND "CreditAbandonedAt" IS NOT NULL</c>
+    /// is a precise SQL question: money in the wallet that no BTCPay invoice accounts for.
+    /// </para>
+    /// <para>
+    /// Stamping this is also what makes the operator warning fire <em>once</em>. The warning is emitted by
+    /// <see cref="Services.SparkInvoiceCreditor"/> at the moment the row is stamped, and the stamp removes the
+    /// row from <see cref="IInvoiceRecordStore.ListUncreditedAsync"/> permanently — so the amount and the
+    /// payment hash are reported to the operator exactly once rather than on every pass forever.
+    /// </para>
+    /// <para>
+    /// A credited row is never labelled abandoned — the stamp is guarded on <see cref="CreditedAt"/> still being
+    /// null. The reverse ordering has no path to it: an abandoned row leaves the retry set, and the creditor
+    /// refuses an in-hand record that carries this stamp before it attempts anything. Were it ever to happen
+    /// anyway, <see cref="CreditedAt"/> is the authoritative half of the pair — the money did reach the invoice.
+    /// </para>
+    /// </remarks>
+    public DateTimeOffset? CreditAbandonedAt { get; set; }
+
+    /// <summary>
     /// Status as reported to BTCPay, which treats a past-expiry unpaid invoice as expired.
     /// </summary>
     /// <remarks>
@@ -107,10 +165,13 @@ public class InvoiceRecord
     /// to <see cref="IInvoiceRecordStore.SettleAsync"/>. The recurring reconciliation pass keeps looking
     /// for an hour past expiry rather than stopping at it; beyond that hour an invoice is no longer
     /// re-checked and a late payment stays unattributed in the wallet balance — a deliberate bound, since
-    /// the alternative is rescanning every invoice ever created on every pass. Note also that a settlement
-    /// recorded after BTCPay has stopped listening for the invoice (its own expiry —
-    /// <c>LightningInstanceListener.RemoveExpiredInvoices</c>) keeps this plugin's own ledger truthful but
-    /// will usually not revive the BTCPay invoice.
+    /// the alternative is rescanning every invoice ever created on every pass.
+    /// </para>
+    /// <para>
+    /// A settlement recorded after BTCPay has stopped listening for the invoice (its own expiry —
+    /// <c>LightningInstanceListener.RemoveExpiredInvoices</c>, or a restart that only re-watched the
+    /// superseding BOLT11) no longer depends on that listener at all: the credit is routed to the invoice the
+    /// BOLT11 was minted for directly, tracked by <see cref="CreditedAt"/> and retried until it lands.
     /// </para>
     /// </remarks>
     public InvoiceRecordStatus EffectiveStatus(DateTimeOffset now) =>
@@ -159,6 +220,47 @@ public class InvoiceRecord
         Preimage = preimage ?? Preimage;
         SettledAt = settledAt;
         return InvoiceSettlementOutcome.Settled;
+    }
+
+    /// <summary>
+    /// Records that this settlement has reached its BTCPay invoice. Returns true only when this call is what
+    /// set the timestamp.
+    /// </summary>
+    /// <remarks>
+    /// Guarded on <see cref="InvoiceRecordStatus.Paid"/> as well as on the column still being empty, and both
+    /// guards matter. A row that is not paid has no settlement to credit, so marking one would permanently
+    /// suppress the credit of the payment that later arrives; and re-stamping an already-credited row would
+    /// move a timestamp that records when the merchant's invoice was actually paid. Same predicate as the
+    /// store's conditional UPDATE (<c>WHERE Status = Paid AND CreditedAt IS NULL</c>), which is what keeps the
+    /// two implementations of <see cref="IInvoiceRecordStore"/> observably identical.
+    /// </remarks>
+    public bool TryMarkCredited(DateTimeOffset creditedAt)
+    {
+        if (Status is not InvoiceRecordStatus.Paid || CreditedAt is not null)
+            return false;
+        CreditedAt = creditedAt;
+        return true;
+    }
+
+    /// <summary>
+    /// Records that this settlement will never reach a BTCPay invoice. Returns true only when this call is what
+    /// set the timestamp.
+    /// </summary>
+    /// <remarks>
+    /// Guarded on <see cref="InvoiceRecordStatus.Paid"/> and on <em>both</em> credit columns still being empty.
+    /// The <see cref="CreditedAt"/> guard is the one that matters: a row the previous pass credited must not
+    /// then be labelled abandoned, which would make the wallet look short by an amount that was in fact
+    /// accounted for. The self-guard is what makes the operator warning fire exactly once — the caller emits it
+    /// only when this returns true. Same predicate as the store's conditional UPDATE
+    /// (<c>WHERE Status = Paid AND CreditedAt IS NULL AND CreditAbandonedAt IS NULL</c>), which is what keeps
+    /// the two implementations of <see cref="IInvoiceRecordStore"/> observably identical.
+    /// </remarks>
+    public bool TryMarkCreditAbandoned(DateTimeOffset abandonedAt)
+    {
+        if (Status is not InvoiceRecordStatus.Paid || CreditedAt is not null || CreditAbandonedAt is not null)
+            return false;
+        CreditAbandonedAt = abandonedAt;
+        return true;
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint/Migrations/20260825201440_InvoiceRecordCreditedAt.Designer.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260825201440_InvoiceRecordCreditedAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BTCPayServer.Plugins.Flint.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BTCPayServer.Plugins.Flint.Migrations
 {
     [DbContext(typeof(SparkPluginDbContext))]
-    partial class SparkPluginDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825201440_InvoiceRecordCreditedAt")]
+    partial class InvoiceRecordCreditedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -39,9 +42,6 @@ namespace BTCPayServer.Plugins.Flint.Migrations
                         .HasColumnType("text");
 
                     b.Property<DateTimeOffset>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<DateTimeOffset?>("CreditAbandonedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTimeOffset?>("CreditedAt")

--- a/BTCPayServer.Plugins.Flint/Migrations/20260825201440_InvoiceRecordCreditedAt.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260825201440_InvoiceRecordCreditedAt.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Plugins.Flint.Migrations
+{
+    /// <inheritdoc />
+    public partial class InvoiceRecordCreditedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreditedAt",
+                schema: "BTCPayServer.Plugins.Flint",
+                table: "InvoiceRecords",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreditedAt",
+                schema: "BTCPayServer.Plugins.Flint",
+                table: "InvoiceRecords");
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Migrations/20260825210602_InvoiceRecordCreditAbandonedAt.Designer.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260825210602_InvoiceRecordCreditAbandonedAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BTCPayServer.Plugins.Flint.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BTCPayServer.Plugins.Flint.Migrations
 {
     [DbContext(typeof(SparkPluginDbContext))]
-    partial class SparkPluginDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825210602_InvoiceRecordCreditAbandonedAt")]
+    partial class InvoiceRecordCreditAbandonedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BTCPayServer.Plugins.Flint/Migrations/20260825210602_InvoiceRecordCreditAbandonedAt.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260825210602_InvoiceRecordCreditAbandonedAt.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Plugins.Flint.Migrations
+{
+    /// <inheritdoc />
+    public partial class InvoiceRecordCreditAbandonedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "CreditAbandonedAt",
+                schema: "BTCPayServer.Plugins.Flint",
+                table: "InvoiceRecords",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreditAbandonedAt",
+                schema: "BTCPayServer.Plugins.Flint",
+                table: "InvoiceRecords");
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/BTCPayInvoiceCreditGateway.cs
+++ b/BTCPayServer.Plugins.Flint/Services/BTCPayInvoiceCreditGateway.cs
@@ -1,0 +1,380 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Data;
+using BTCPayServer.Events;
+using BTCPayServer.Lightning;
+using BTCPayServer.Payments;
+using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Services.Invoices;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBitcoin.Crypto;
+using NBitcoin.DataEncoders;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>
+/// The real <see cref="IInvoiceCreditGateway"/>, over BTCPay's invoice repository and payment service.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Does what core's own <c>LightningListener.AddPaymentCore</c> does, from outside the listener, and with the
+/// same identifiers — which is the whole point. The payment id is the payment hash, exactly as core would
+/// write it, so the two inserts collide on the <c>Payments</c> primary key <c>(Id, PaymentMethodId)</c> and
+/// exactly one of them records the money. Core's <c>PaymentService.AddPayment</c> catches the resulting
+/// <c>DbUpdateException</c> and answers null, which this class reports as
+/// <see cref="SparkInvoiceCreditOutcome.AlreadyRecorded"/>. Crediting a merchant twice for one payment is
+/// therefore not prevented by ordering or by a lock, but by the database.
+/// </para>
+/// <para>
+/// <b>The prompt preimage is backfilled, but only onto the prompt it belongs to.</b> Core's listener also
+/// writes the preimage into the invoice's <em>current</em> payment prompt, and that write is not decoration:
+/// LUD-21 <c>verify</c> serves proof-of-payment out of the prompt, not out of the payment row
+/// (<c>UILNURLController</c>), and this plugin forces LUD-21 on for every store it provisions. Skipping it
+/// would therefore have cost every ordinary Flint checkout its proof-of-payment — because core's listener
+/// performs that backfill only when <em>its own</em> insert wins, and this class usually wins the race. So the
+/// backfill is replicated here, guarded on the current prompt's payment hash being the hash of the payment
+/// being credited. The guard is what makes both cases right: an ordinary settlement is crediting the current
+/// prompt and the preimage belongs there, while a superseded BOLT11 X is being credited against a prompt that
+/// now offers replacement Y, whose preimage this is not, and the guard leaves it alone.
+/// </para>
+/// <para>
+/// A failed backfill is logged and swallowed. The payment row is already in by then, which is the part that
+/// credits the merchant; unwinding it to protect a proof-of-payment field would trade money for metadata.
+/// </para>
+/// <para>
+/// <b>The credited payment's blob describes the current prompt, not the BOLT11 that was paid.</b> Core's
+/// <c>PaymentData.Set</c> fills the payment's destination, network fee and divisibility from the invoice's
+/// current prompt, so for a superseded BOLT11 X the row's destination reads as replacement Y's BOLT11. The
+/// paid BOLT11 is still recorded — it is passed as the payment's search term — and the payment hash, which is
+/// the row's id, is X's. Cosmetic, inherent to the core helper this deliberately reuses rather than
+/// reimplements, and not worth diverging from core to prettify.
+/// </para>
+/// <para><b>Why <see cref="PaymentService"/> arrives as a factory.</b></para>
+/// <para>
+/// Belt-and-braces, and consistency with the deferral this plugin already establishes elsewhere, rather than a
+/// live hazard. Its constructor takes <c>PaymentMethodHandlerDictionary</c>, whose construction enumerates
+/// <c>IEnumerable&lt;IPaymentMethodHandler&gt;</c>, which builds core's <c>LightningLikePaymentHandler</c>,
+/// which takes <c>LightningClientFactoryService</c>, which takes
+/// <c>IEnumerable&lt;ILightningConnectionStringHandler&gt;</c> — a list this plugin contributes to. That was
+/// one leg of the cycle whose eager resolution deadlocked BTCPay's startup once already (see
+/// <see cref="BTCPayStoreLightningConfigStore"/>), but the cycle is now broken at its other end:
+/// <c>SparkConnectionStringHandler</c> takes a <c>Func&lt;ISparkClientResolver&gt;</c>, so injecting
+/// <c>PaymentService</c> directly here would not in fact re-form it. It is deferred anyway because every
+/// plugin service that touches core's payment graph defers, and a uniform rule is easier to keep true than a
+/// per-service judgement about which edges are currently harmless.
+/// <see cref="InvoiceRepository"/> is injected directly because it takes only a context factory and the event
+/// aggregator, and so is not on that graph at all.
+/// </para>
+/// </remarks>
+public sealed class BTCPayInvoiceCreditGateway : IInvoiceCreditGateway
+{
+    /// <summary>Spark is Bitcoin-only, and so is every payment this plugin can credit.</summary>
+    internal const string CryptoCode = "BTC";
+
+    /// <summary>
+    /// Where a payment hash may be indexed, in the order it is looked for.
+    /// </summary>
+    /// <remarks>
+    /// <c>BTC-LN</c> first because a plain Lightning checkout always indexes the hash there. <c>BTC-LNURL</c>
+    /// second because LNURL prompts index it only when LUD-21 is enabled — which this plugin forces on when it
+    /// provisions a store (<see cref="BTCPayStoreLightningConfigStore.SetAsync"/>), so for a Flint store both
+    /// rails are covered. A merchant who turned LUD-21 off by hand loses the LNURL half of this, and the
+    /// credit for such a payment is reported as unresolvable rather than guessed at.
+    /// </remarks>
+    internal static readonly PaymentMethodId[] CreditablePaymentMethods =
+    [
+        PaymentTypes.LN.GetPaymentMethodId(CryptoCode),
+        PaymentTypes.LNURL.GetPaymentMethodId(CryptoCode)
+    ];
+
+    private readonly InvoiceRepository _invoiceRepository;
+    private readonly Func<PaymentService> _paymentService;
+    private readonly Func<PaymentMethodHandlerDictionary> _handlers;
+    private readonly EventAggregator _eventAggregator;
+    private readonly ILogger<BTCPayInvoiceCreditGateway> _logger;
+
+    /// <param name="paymentService">
+    /// Resolved on first use rather than injected, and that is load-bearing: see the remarks on this class.
+    /// </param>
+    /// <param name="handlers">Deferred for the same reason, and shared with the rest of the plugin.</param>
+    public BTCPayInvoiceCreditGateway(
+        InvoiceRepository invoiceRepository,
+        Func<PaymentService> paymentService,
+        Func<PaymentMethodHandlerDictionary> handlers,
+        EventAggregator eventAggregator,
+        ILogger<BTCPayInvoiceCreditGateway> logger)
+    {
+        _invoiceRepository = invoiceRepository;
+        _paymentService = paymentService;
+        _handlers = handlers;
+        _eventAggregator = eventAggregator;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<SparkInvoiceCreditMatch?> FindByPaymentHashAsync(
+        string paymentHash,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(paymentHash);
+
+        foreach (var paymentMethodId in CreditablePaymentMethods)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // BTCPay's AddressInvoices table, which is insert-only: the row written when the prompt was
+            // issued survives the prompt being superseded, and is what makes a payment to a replaced BOLT11
+            // attributable at all.
+            var invoice = await _invoiceRepository
+                .GetInvoiceFromAddress(paymentMethodId, paymentHash)
+                .ConfigureAwait(false);
+            if (invoice is null)
+                continue;
+
+            // "Is the primary key already taken", not "is the invoice accounted for". A payment row with this
+            // id under this payment method — whatever its status — is a row our insert would collide with, and
+            // that is exactly the question the caller needs answered.
+            var alreadyHasPayment = invoice
+                .GetPayments(false)
+                .Any(p => p.Id == paymentHash && p.PaymentMethodId == paymentMethodId);
+
+            return new SparkInvoiceCreditMatch(
+                invoice.Id, invoice.StoreId, paymentMethodId.ToString(), alreadyHasPayment);
+        }
+
+        return null;
+    }
+
+    /// <inheritdoc />
+    public async Task<SparkInvoiceCreditOutcome> AddSettledPaymentAsync(
+        SparkInvoiceCreditRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var paymentMethodId = PaymentMethodId.Parse(request.PaymentMethodId);
+
+        // Re-read rather than trusting the entity the lookup returned: the credit may be attempted a whole
+        // reconciliation pass after the match was found, and AddPayment needs the invoice's current blob.
+        var invoice = await _invoiceRepository.GetInvoice(request.InvoiceId).ConfigureAwait(false);
+        if (invoice is null)
+            return SparkInvoiceCreditOutcome.InvoiceGone;
+
+        // Both of the next two checks exist to disambiguate AddPayment's null, which it returns for a missing
+        // invoice, a missing prompt, a missing handler *and* a duplicate key alike. Without them a payment
+        // that was never recorded would be reported as already recorded, and the credit would be marked done.
+        if (!_handlers().TryGetValue(paymentMethodId, out var handler))
+        {
+            _logger.LogWarning(
+                "BTCPay has no {PaymentMethodId} payment handler, so the settled payment {PaymentHash} cannot "
+                + "be recorded on invoice {InvoiceId}. The money is in the Spark wallet and this plugin's own "
+                + "records show it; the BTCPay invoice will not",
+                paymentMethodId, request.PaymentHash, request.InvoiceId);
+            return SparkInvoiceCreditOutcome.PromptMissing;
+        }
+
+        if (invoice.GetPaymentPrompt(paymentMethodId) is not { } prompt)
+            return SparkInvoiceCreditOutcome.PromptMissing;
+
+        if (invoice.GetPayments(false).Any(p => p.Id == request.PaymentHash
+                                                && p.PaymentMethodId == paymentMethodId))
+        {
+            return SparkInvoiceCreditOutcome.AlreadyRecorded;
+        }
+
+        var paymentHash = uint256.Parse(request.PaymentHash);
+        var preimage = ValidPreimageOrNull(request.Preimage, paymentHash, request.InvoiceId);
+        var paymentData = new PaymentData
+        {
+            // The payment hash, which is the id core's own listener would use. That collision is what makes
+            // the credit exactly-once.
+            Id = request.PaymentHash,
+            Created = request.PaidAt,
+            Status = PaymentStatus.Settled,
+            Currency = CryptoCode,
+            InvoiceDataId = request.InvoiceId,
+            Amount = ToBtc(request.AmountReceivedMsat)
+        }.Set(invoice, handler, new LightningLikePaymentData
+        {
+            PaymentHash = paymentHash,
+            Preimage = preimage
+        });
+
+        var payment = await _paymentService().AddPayment(paymentData, [request.Bolt11]).ConfigureAwait(false);
+        if (payment is null)
+        {
+            // Everything else AddPayment answers null for was ruled out above, so what is left is the primary
+            // key: core's listener, or a concurrent pass, recorded this payment between those checks and this
+            // insert. Which is the outcome this design wants — one of us wins, and neither double-credits.
+            return SparkInvoiceCreditOutcome.AlreadyRecorded;
+        }
+
+        // Our insert won, so this is also the caller that owes the prompt its preimage: core's listener performs
+        // that backfill only on the branch where its own insert won, which this one just took from it.
+        await BackfillPromptPreimageAsync(handler, prompt, paymentHash, preimage, request.InvoiceId)
+            .ConfigureAwait(false);
+
+        // Re-read so the event carries the invoice including the payment just added, exactly as core's
+        // listener does — subscribers compute the invoice's new state from it.
+        var credited = await _invoiceRepository.GetInvoice(request.InvoiceId).ConfigureAwait(false);
+        if (credited is not null)
+        {
+            _eventAggregator.Publish(
+                new InvoiceEvent(credited, InvoiceEvent.ReceivedPayment) { Payment = payment });
+        }
+
+        _logger.LogInformation(
+            "Recorded the settled Lightning payment {PaymentHash} on BTCPay invoice {InvoiceId} "
+            + "({PaymentMethodId}), which its Lightning listener was no longer watching for",
+            request.PaymentHash, request.InvoiceId, paymentMethodId);
+
+        return SparkInvoiceCreditOutcome.CreditedNow;
+    }
+
+    /// <summary>
+    /// Writes the preimage onto the payment prompt, if and only if the prompt is offering the BOLT11 that was
+    /// paid. Never throws.
+    /// </summary>
+    /// <remarks>
+    /// See the class remarks for why this is here at all and why it is guarded. Never throws because the payment
+    /// row is already committed by the time it runs: the merchant is credited either way, and an exception
+    /// escaping would turn a completed credit into a logged failure and a retry that can only conclude
+    /// "already recorded".
+    /// </remarks>
+    private async Task BackfillPromptPreimageAsync(
+        IPaymentMethodHandler handler,
+        PaymentPrompt prompt,
+        uint256 paymentHash,
+        uint256? preimage,
+        string invoiceId)
+    {
+        if (preimage is null)
+            return;
+
+        try
+        {
+            // Both BTC-LN and BTC-LNURL prompt details derive from this type — core's LNURL details class
+            // extends it — and re-serialisation goes through the handler's own serialiser on the runtime type,
+            // so an LNURL prompt keeps its extra fields.
+            var details = (LigthningPaymentPromptDetails)handler.ParsePaymentPromptDetails(prompt.Details);
+            if (!ShouldBackfillPromptPreimage(details.PaymentHash, details.Preimage, paymentHash))
+                return;
+
+            details.Preimage = preimage;
+            await _invoiceRepository.UpdatePaymentDetails(invoiceId, handler, details).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Recorded the settled Lightning payment {PaymentHash} on BTCPay invoice {InvoiceId} but could "
+                + "not write its preimage onto the payment prompt. The payment stands; LNURL proof-of-payment "
+                + "(LUD-21 verify) for this invoice will report no preimage",
+                paymentHash, invoiceId);
+        }
+    }
+
+    /// <summary>
+    /// Whether the invoice's current prompt is the one this payment's preimage belongs on.
+    /// </summary>
+    /// <remarks>
+    /// Two independent conditions, and each rules out a different wrong write. The hash comparison is the
+    /// superseded case: crediting BOLT11 X against a prompt that now offers replacement Y must not stamp X's
+    /// preimage as Y's, which would make LUD-21 <c>verify</c> hand a payer a proof for an invoice they did not
+    /// pay. The null check is core's own condition, and it means the same thing here — a prompt that already
+    /// carries a preimage was filled in by whoever got there first, and their value is the one that matches the
+    /// prompt.
+    /// </remarks>
+    internal static bool ShouldBackfillPromptPreimage(
+        uint256? promptPaymentHash,
+        uint256? promptPreimage,
+        uint256 paymentHash) =>
+        promptPreimage is null && promptPaymentHash == paymentHash;
+
+    /// <summary>The amount as BTCPay records it on a payment: millisatoshi in, BTC out.</summary>
+    /// <remarks>
+    /// Through <see cref="LightMoney"/> rather than by dividing, so the conversion is core's own and cannot
+    /// drift from it — and so the units are named in the code rather than in a comment next to a literal.
+    /// </remarks>
+    internal static decimal ToBtc(long amountReceivedMsat) =>
+        LightMoney.MilliSatoshis(amountReceivedMsat).ToDecimal(LightMoneyUnit.BTC);
+
+    /// <summary>
+    /// The preimage as BTCPay stores it, or null when it cannot be verified against the payment hash.
+    /// </summary>
+    /// <remarks>
+    /// The logging wrapper around <see cref="ValidatePreimage"/>. Split so the validation itself — which is
+    /// where the byte-order convention and the hash check live — is testable without a logger or a container.
+    /// </remarks>
+    private uint256? ValidPreimageOrNull(string? preimage, uint256 paymentHash, string invoiceId)
+    {
+        var validity = ValidatePreimage(preimage, paymentHash, out var stored);
+        if (validity is PreimageValidity.Mismatched)
+        {
+            _logger.LogWarning(
+                "The Spark service reported a preimage for {PaymentHash} that does not hash to it; BTCPay "
+                + "invoice {InvoiceId} is credited without one",
+                paymentHash, invoiceId);
+        }
+
+        return stored;
+    }
+
+    /// <summary>What a reported preimage turned out to be.</summary>
+    internal enum PreimageValidity
+    {
+        /// <summary>None was reported. The service provider's HTLC details make it optional.</summary>
+        Absent,
+
+        /// <summary>Not 32 bytes of hex. Nothing to check against the hash.</summary>
+        Malformed,
+
+        /// <summary>Well-formed, but it does not hash to the payment hash. Worth an operator line.</summary>
+        Mismatched,
+
+        /// <summary>Verified against the payment hash, and returned in the form BTCPay stores.</summary>
+        Valid
+    }
+
+    /// <summary>
+    /// Verifies a reported preimage against its payment hash and converts it to the form BTCPay stores.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The same validation core performs (<c>LightningListener.GetValidPreimage</c>), replicated rather than
+    /// skipped: a preimage is a proof, and an unverifiable one stored as though it were verified would let a
+    /// future dispute be settled with a value nothing checked. Dropping it costs only that proof — the payment
+    /// itself is recorded either way.
+    /// </para>
+    /// <para>
+    /// <b>Two byte orders are in play and they are not interchangeable.</b> The hash is computed over the
+    /// preimage's wire bytes and compared against <c>paymentHash.ToBytes(false)</c>, which is <c>uint256</c>'s
+    /// big-endian rendering — the order the hex in a BOLT11 is written in. What is <em>stored</em> is a
+    /// <c>uint256</c> built from those bytes reversed, because that is core's convention for the field; without
+    /// the reversal the recorded preimage reads back inverted and would fail anyone's verification. Both halves
+    /// are pinned by tests against a known preimage/hash pair rather than trusted to review.
+    /// </para>
+    /// </remarks>
+    internal static PreimageValidity ValidatePreimage(
+        string? preimage,
+        uint256 paymentHash,
+        out uint256? stored)
+    {
+        stored = null;
+
+        if (string.IsNullOrEmpty(preimage))
+            return PreimageValidity.Absent;
+        if (preimage.Length != 64 || !HexEncoder.IsWellFormed(preimage))
+            return PreimageValidity.Malformed;
+
+        var candidate = Encoders.Hex.DecodeData(preimage);
+        if (!Hashes.SHA256(candidate).AsSpan().SequenceEqual(paymentHash.ToBytes(false)))
+            return PreimageValidity.Mismatched;
+
+        Array.Reverse(candidate);
+        stored = new uint256(candidate);
+        return PreimageValidity.Valid;
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/IInvoiceCreditGateway.cs
+++ b/BTCPayServer.Plugins.Flint/Services/IInvoiceCreditGateway.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>
+/// The BTCPay invoice a BOLT11 was minted for, as found from the BOLT11's payment hash.
+/// </summary>
+/// <param name="InvoiceId">BTCPay's own invoice id.</param>
+/// <param name="StoreId">
+/// The store BTCPay says owns that invoice. Compared against the store the settlement arrived on before
+/// anything is credited — see <see cref="SparkInvoiceCreditor"/>.
+/// </param>
+/// <param name="PaymentMethodId">
+/// The payment method the hash was indexed under, as its string form (<c>BTC-LN</c> or <c>BTC-LNURL</c>). A
+/// string rather than BTCPay's <c>PaymentMethodId</c> so the credit decision — and its tests — need no BTCPay
+/// types; the gateway parses it back on the way in.
+/// </param>
+/// <param name="AlreadyHasPayment">
+/// True when the invoice already carries a payment for this hash, which is the normal case: BTCPay's own
+/// Lightning listener usually gets there first.
+/// </param>
+public sealed record SparkInvoiceCreditMatch(
+    string InvoiceId,
+    string StoreId,
+    string PaymentMethodId,
+    bool AlreadyHasPayment);
+
+/// <summary>One settlement, in the shape BTCPay needs to record a payment for it.</summary>
+/// <param name="Preimage">
+/// Lower-case hex, or null when the service provider never reported one. Validated against the payment hash
+/// before it is stored; an unverifiable preimage is dropped rather than recorded.
+/// </param>
+public sealed record SparkInvoiceCreditRequest(
+    string InvoiceId,
+    string PaymentMethodId,
+    string PaymentHash,
+    string Bolt11,
+    long AmountReceivedMsat,
+    string? Preimage,
+    DateTimeOffset PaidAt);
+
+/// <summary>What happened when a settlement was offered to a BTCPay invoice.</summary>
+public enum SparkInvoiceCreditOutcome
+{
+    /// <summary>
+    /// This call put the payment on the invoice. The one outcome that publishes an invoice event.
+    /// </summary>
+    CreditedNow,
+
+    /// <summary>
+    /// BTCPay already had a payment with this id on this invoice — its own listener won, or a previous
+    /// attempt did. Nothing was written and nothing was published, and the merchant's invoice is credited
+    /// exactly once either way.
+    /// </summary>
+    AlreadyRecorded,
+
+    /// <summary>
+    /// There is no BTCPay invoice for this payment hash. Either its row has not been written yet (BTCPay
+    /// indexes the hash just after <c>CreateInvoice</c> returns) or this BOLT11 was never minted for a BTCPay
+    /// invoice at all. Retryable, but not forever.
+    /// </summary>
+    InvoiceGone,
+
+    /// <summary>
+    /// The invoice exists but carries no payment prompt for that payment method, so BTCPay cannot hold a
+    /// payment against it. Not retryable — a prompt never disappears from an invoice's blob, so a second
+    /// attempt would fail identically.
+    /// </summary>
+    PromptMissing
+}
+
+/// <summary>
+/// The seam through which this plugin puts a settlement onto the BTCPay invoice its BOLT11 was minted for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why the plugin needs this at all, rather than leaving it to BTCPay.</b> BTCPay's Lightning listener
+/// matches an incoming notification by id against a set built from each invoice's <em>current</em> payment
+/// prompt. Replace BOLT11 X with BOLT11 Y — which BTCPay does whenever an LNURL invoice is re-quoted — and X
+/// leaves that set; after a restart it is never re-added, because the set is rebuilt from the prompts that
+/// exist now. X remains payable on the Spark service provider, which has no cancellation primitive, so a
+/// payment to X lands in the merchant's wallet with nothing left watching for it. Notifying a listener that
+/// is not listening cannot fix that; writing the payment onto the invoice can.
+/// </para>
+/// <para>
+/// <b>What makes that safe.</b> BTCPay retains the mint-time association permanently: the payment hash of
+/// every prompt it issues is written into its <c>AddressInvoices</c> table, insert-only, and never removed
+/// even when the prompt is superseded. That table is the authority this seam reads — not a guess, and not
+/// state this plugin keeps. And the payment id used to credit is the payment hash, which is precisely the id
+/// BTCPay's own listener would use, so the two collide on the <c>Payments</c> primary key: whichever gets
+/// there first records the money, the other is told it already exists, and the invoice is credited exactly
+/// once.
+/// </para>
+/// <para>
+/// An interface so the credit decision in <see cref="SparkInvoiceCreditor"/> — including its cross-store
+/// refusal — is unit-testable without a BTCPay host and a Postgres database. The production implementation is
+/// <see cref="BTCPayInvoiceCreditGateway"/>.
+/// </para>
+/// </remarks>
+public interface IInvoiceCreditGateway
+{
+    /// <summary>
+    /// Finds the BTCPay invoice a payment hash was minted for, or null when BTCPay has no record of it.
+    /// </summary>
+    /// <param name="paymentHash">Lower-case hex, as BTCPay indexed it.</param>
+    Task<SparkInvoiceCreditMatch?> FindByPaymentHashAsync(
+        string paymentHash,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records a settled payment against a BTCPay invoice, and announces it only if this call is what
+    /// recorded it.
+    /// </summary>
+    Task<SparkInvoiceCreditOutcome> AddSettledPaymentAsync(
+        SparkInvoiceCreditRequest request,
+        CancellationToken cancellationToken = default);
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkInvoiceCreditor.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkInvoiceCreditor.cs
@@ -1,0 +1,421 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Sdk;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>What one attempt to route a settlement to its BTCPay invoice concluded.</summary>
+public enum SparkInvoiceCreditResult
+{
+    /// <summary>This attempt put the payment on the BTCPay invoice, and the record is marked credited.</summary>
+    Credited,
+
+    /// <summary>
+    /// BTCPay already held the payment — its own listener got there first, or an earlier attempt did — and the
+    /// record is marked credited. Indistinguishable from <see cref="Credited"/> in effect, which is the point.
+    /// </summary>
+    AlreadyRecorded,
+
+    /// <summary>
+    /// The record was already marked credited before this attempt, so nothing was done.
+    /// </summary>
+    AlreadyCredited,
+
+    /// <summary>
+    /// The record was already given up on by an earlier pass, which reported it then. Nothing was done and
+    /// nothing was logged — the report is deliberately once per record, not once per pass.
+    /// </summary>
+    AlreadyAbandoned,
+
+    /// <summary>
+    /// BTCPay has no invoice indexed against this payment hash yet. Left uncredited so the next pass retries.
+    /// </summary>
+    Deferred,
+
+    /// <summary>
+    /// BTCPay has no invoice for this payment hash and the retry horizon has passed, so no further attempt will
+    /// be made. Reported to the operator with its amount, and stamped
+    /// <see cref="InvoiceRecord.CreditAbandonedAt"/> — never <see cref="InvoiceRecord.CreditedAt"/>, because it
+    /// never was credited. That stamp is what makes both the retry and the report stop.
+    /// </summary>
+    Abandoned,
+
+    /// <summary>
+    /// BTCPay's invoice for this payment hash belongs to a different store than the wallet the money arrived
+    /// in. Refused outright and nothing was marked.
+    /// </summary>
+    RefusedCrossStore,
+
+    /// <summary>
+    /// BTCPay cannot hold a payment for this payment method on that invoice. Terminal, because retrying cannot
+    /// change it — stamped <see cref="InvoiceRecord.CreditAbandonedAt"/> for the same reason
+    /// <see cref="Abandoned"/> is: the money is in the wallet and no BTCPay invoice records it, and the row has
+    /// to say so.
+    /// </summary>
+    Unrecordable,
+
+    /// <summary>
+    /// The attempt failed — BTCPay's database was unreachable, or something unexpected threw. Left uncredited
+    /// so the next pass retries.
+    /// </summary>
+    Failed
+}
+
+/// <summary>
+/// Decides whether, and to which BTCPay invoice, a recorded Spark settlement is credited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>The gap this closes.</b> Settling an <see cref="InvoiceRecord"/> records that money arrived; it does not
+/// put a payment on the merchant's BTCPay invoice. Ordinarily BTCPay's Lightning listener does that, woken by
+/// <see cref="SparkSettlementBroadcaster"/> — but that listener watches only each invoice's <em>current</em>
+/// payment prompt. When BTCPay replaces BOLT11 X with BOLT11 Y and the process then restarts, only Y is
+/// watched again; X stays payable on the service provider, which has no cancellation primitive, and a payment
+/// to X afterwards settles this plugin's record while the BTCPay invoice stays unpaid. The same gap opens when
+/// a listening session is saturated past its retry allowance, and when the process dies between the settle and
+/// the notification. In every one of those cases the money is in the merchant's wallet and their invoice says
+/// it is not.
+/// </para>
+/// <para>
+/// So the credit is a durable step of its own, attempted on the settlement path and retried by the
+/// reconciliation pass until it lands (<see cref="InvoiceRecord.CreditedAt"/>). Both callers reach the same
+/// decision here, for the same reason <see cref="SparkSettlementReconciler"/> exists: "the merchant is
+/// credited exactly once" is a property of one shared implementation, not of two that agree today.
+/// </para>
+/// <para>
+/// <b>Nothing here can lose a settlement.</b> Every failure path leaves both credit columns null, which is the
+/// retry queue, and no failure is allowed to propagate into the settlement path — a BTCPay database that is
+/// briefly unreachable must not stop this plugin recording that the money arrived, nor stop the notification
+/// that usually makes this whole class unnecessary.
+/// </para>
+/// <para>
+/// <b>And nothing here can quietly stop trying.</b> A settlement leaves the retry queue by exactly one of two
+/// stamps, and which one it is says what happened: <see cref="InvoiceRecord.CreditedAt"/> means the money is on
+/// a BTCPay invoice, <see cref="InvoiceRecord.CreditAbandonedAt"/> means it never will be and an operator has
+/// been told once, with the amount and the payment hash. Nothing else terminates a retry — in particular there
+/// is no path where a row simply ages out of the walk with both columns null, which is what an earlier revision
+/// did: the horizon check here and the walk's listing bound were the same value, so the report this class was
+/// written to emit could never fire (see <see cref="AbandonedReportingGrace"/>).
+/// </para>
+/// </remarks>
+public class SparkInvoiceCreditor
+{
+    /// <summary>
+    /// How long after settlement a credit is still retried when BTCPay has no invoice for the payment hash.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two very different situations produce "no BTCPay invoice for this hash", and the horizon is what keeps
+    /// them apart without having to tell them apart. The first is a race measured in milliseconds: BTCPay
+    /// writes its <c>AddressInvoices</c> row just <em>after</em> <c>CreateInvoice</c> returns, so a payment
+    /// that arrives in that window finds nothing, and the next pass finds it. The second is permanent: a
+    /// BOLT11 minted through this plugin's own Greenfield endpoints, or by a merchant experimenting, was never
+    /// attached to a BTCPay invoice and never will be. Without a bound the second case is re-attempted on
+    /// every pass for the lifetime of the server.
+    /// </para>
+    /// <para>
+    /// Seven days, which is far longer than the millisecond race needs and far longer than any BTCPay invoice
+    /// stays open, because the cost of being generous is one indexed lookup per pass over a set that is
+    /// normally empty, while the cost of being stingy is a merchant's payment silently never reaching their
+    /// invoice. Deliberately much longer than
+    /// <c>SparkSettlementReconciler.ExpiredReconciliationGrace</c>: that hour bounds a scan of the service
+    /// provider's payment history for money that probably never arrived, whereas this bounds the routing of
+    /// money that certainly did.
+    /// </para>
+    /// </remarks>
+    public static readonly TimeSpan CreditRetryHorizon = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// How long past <see cref="CreditRetryHorizon"/> a settlement stays visible to the credit walk, so that a
+    /// pass can classify it as abandoned and say so once.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>This exists because of a defect, and the defect is worth naming.</b> The walk's listing and this
+    /// class's horizon check were originally the same boundary, which meant a record aged out of the listing at
+    /// the exact moment it became eligible to be reported: the <see cref="SparkInvoiceCreditResult.Abandoned"/>
+    /// branch was unreachable from the pass, no operator warning was ever emitted for a settlement that could
+    /// never be credited, and the row sat with a null credit timestamp forever — indistinguishable in the
+    /// database from one still in flight. The listing therefore has to outlast the horizon.
+    /// </para>
+    /// <para>
+    /// Seven days again, which is enormously more than needed: the pass runs every few minutes, so a record
+    /// crossing the horizon is classified, reported and stamped on the pass after it crosses. The slack is
+    /// generous because the cost of it is nothing — a record is stamped terminal the first time it is examined
+    /// past the horizon and permanently leaves the set — while the cost of it being too tight is exactly the
+    /// silence described above. A server that was down for the whole fortnight is the only case where a record
+    /// still ages out unreported, and that is bounded by design rather than accidental: the alternative is
+    /// re-examining every settlement ever recorded on every pass.
+    /// </para>
+    /// </remarks>
+    public static readonly TimeSpan AbandonedReportingGrace = TimeSpan.FromDays(7);
+
+    private readonly IInvoiceCreditGateway _gateway;
+    private readonly IInvoiceRecordStore _invoiceStore;
+    private readonly ILogger<SparkInvoiceCreditor> _logger;
+
+    public SparkInvoiceCreditor(
+        IInvoiceCreditGateway gateway,
+        IInvoiceRecordStore invoiceStore,
+        ILogger<SparkInvoiceCreditor> logger)
+    {
+        _gateway = gateway;
+        _invoiceStore = invoiceStore;
+        _logger = logger;
+    }
+
+    /// <summary>The oldest settlement a credit is still <em>attempted</em> for, given the horizon.</summary>
+    public static DateTimeOffset CreditableFrom(DateTimeOffset now) => now - CreditRetryHorizon;
+
+    /// <summary>
+    /// The oldest settlement the credit walk still <em>lists</em>, which is deliberately older than
+    /// <see cref="CreditableFrom"/>.
+    /// </summary>
+    /// <remarks>
+    /// The two must not be the same value. A record that is only listed while it is still creditable can never
+    /// be seen by the pass on the far side of the horizon, so it is never classified, never reported, and never
+    /// stamped — see <see cref="AbandonedReportingGrace"/>, which is the difference between them.
+    /// </remarks>
+    public static DateTimeOffset ListableFrom(DateTimeOffset now) =>
+        now - CreditRetryHorizon - AbandonedReportingGrace;
+
+    /// <summary>
+    /// Routes one settled invoice's payment to the BTCPay invoice its BOLT11 was minted for. Never throws.
+    /// </summary>
+    /// <remarks>
+    /// Never throws because both callers are paths that must not be derailed by it: the settlement path has
+    /// already committed the settlement and published the notification by the time it gets here, and the
+    /// reconciliation pass is walking other stores' invoices behind it.
+    /// </remarks>
+    public async Task<SparkInvoiceCreditResult> CreditAsync(
+        InvoiceRecord record,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        if (record.Status is not InvoiceRecordStatus.Paid)
+        {
+            // Not a settlement, so there is nothing to credit. A caller that reached here with an unpaid row
+            // has a bug, but refusing loudly and doing nothing is the safe answer: marking anything would
+            // suppress the credit of the payment that may still arrive.
+            throw new ArgumentException(
+                "Only a settled invoice can be credited to a BTCPay invoice.", nameof(record));
+        }
+
+        if (record.CreditedAt is not null)
+            return SparkInvoiceCreditResult.AlreadyCredited;
+
+        // Terminal in the other direction, and silent on purpose: a previous pass concluded this settlement can
+        // never reach a BTCPay invoice and said so, with the amount and the hash, at operator level. Repeating
+        // that on every pass for the life of the server would bury it.
+        if (record.CreditAbandonedAt is not null)
+            return SparkInvoiceCreditResult.AlreadyAbandoned;
+
+        try
+        {
+            return await AttemptAsync(record, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Left uncredited on purpose: null is the retry queue, and the next pass tries again.
+            _logger.LogWarning(ex,
+                "Store {StoreId}: could not route the settled Lightning payment {PaymentHash} to its BTCPay "
+                + "invoice ({Reason}). The settlement is recorded and the credit will be retried",
+                record.StoreId, record.PaymentHash, SparkErrors.Describe(ex));
+            return SparkInvoiceCreditResult.Failed;
+        }
+    }
+
+    private async Task<SparkInvoiceCreditResult> AttemptAsync(
+        InvoiceRecord record,
+        CancellationToken cancellationToken)
+    {
+        var match = await _gateway
+            .FindByPaymentHashAsync(record.PaymentHash, cancellationToken)
+            .ConfigureAwait(false);
+        if (match is null)
+        {
+            return await NotAttributableAsync(
+                    record, "BTCPay has no invoice indexed against it", cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        // The cross-store refusal. BTCPay's index is keyed on the payment hash alone, and this plugin's own
+        // records are keyed the same way, so a hash that resolved to another store's invoice would credit that
+        // store for money that arrived in this one's wallet. Nothing in the normal flow can produce it — the
+        // hash came from a BOLT11 this store's wallet minted — which is exactly why it is checked rather than
+        // assumed: the check costs a comparison, and the failure it prevents is money credited to the wrong
+        // merchant. Nothing is marked, so if the mismatch is ever explained the credit is still owed.
+        if (!string.Equals(match.StoreId, record.StoreId, StringComparison.Ordinal))
+        {
+            _logger.LogWarning(
+                "Store {StoreId}: the Lightning payment {PaymentHash} resolves to BTCPay invoice "
+                + "{InvoiceId}, which belongs to store {OtherStoreId}. Refusing to credit it — the money "
+                + "arrived in this store's wallet and crediting another store's invoice would be a "
+                + "misattribution. This should be impossible; investigate before settling it by hand",
+                record.StoreId, record.PaymentHash, match.InvoiceId, match.StoreId);
+            return SparkInvoiceCreditResult.RefusedCrossStore;
+        }
+
+        if (match.AlreadyHasPayment)
+        {
+            // The ordinary case: BTCPay's own listener was watching and credited it. Marking it here is what
+            // stops every later pass asking again.
+            await MarkCreditedAsync(record, cancellationToken).ConfigureAwait(false);
+            return SparkInvoiceCreditResult.AlreadyRecorded;
+        }
+
+        var outcome = await _gateway
+            .AddSettledPaymentAsync(
+                new SparkInvoiceCreditRequest(
+                    match.InvoiceId,
+                    match.PaymentMethodId,
+                    record.PaymentHash,
+                    record.Bolt11,
+                    // What arrived, never what was invoiced. The received amount is the only honest figure —
+                    // crediting the invoiced one is a defect the prior-art plugin shipped.
+                    record.AmountReceivedMsat ?? 0,
+                    record.Preimage,
+                    record.SettledAt ?? DateTimeOffset.UtcNow),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        switch (outcome)
+        {
+            case SparkInvoiceCreditOutcome.CreditedNow:
+                _logger.LogInformation(
+                    "Store {StoreId}: the Lightning payment {PaymentHash} was credited to BTCPay invoice "
+                    + "{InvoiceId}, which was no longer being watched for it",
+                    record.StoreId, record.PaymentHash, match.InvoiceId);
+                await MarkCreditedAsync(record, cancellationToken).ConfigureAwait(false);
+                return SparkInvoiceCreditResult.Credited;
+
+            case SparkInvoiceCreditOutcome.AlreadyRecorded:
+                // BTCPay's listener, or a concurrent pass, won the race on the payments primary key. The
+                // merchant is credited exactly once and this is the caller that was not it.
+                _logger.LogDebug(
+                    "Store {StoreId}: BTCPay invoice {InvoiceId} already held the Lightning payment "
+                    + "{PaymentHash}",
+                    record.StoreId, match.InvoiceId, record.PaymentHash);
+                await MarkCreditedAsync(record, cancellationToken).ConfigureAwait(false);
+                return SparkInvoiceCreditResult.AlreadyRecorded;
+
+            case SparkInvoiceCreditOutcome.PromptMissing:
+                // A prompt is never removed from an invoice's blob, so a retry would fail identically. Stamped
+                // terminal to stop an endless retry — as abandoned, not as credited, because the money is not on
+                // the invoice and the row must not claim it is — and logged loudly, because only a human can
+                // reconcile this one.
+                _logger.LogWarning(
+                    "Store {StoreId}: BTCPay invoice {InvoiceId} has no payment prompt that can hold the "
+                    + "Lightning payment {PaymentHash} ({AmountSats} sat). The money is in the Spark wallet "
+                    + "and recorded here, but the BTCPay invoice cannot be credited automatically and will "
+                    + "not be retried",
+                    record.StoreId, match.InvoiceId, record.PaymentHash,
+                    (record.AmountReceivedMsat ?? 0) / 1000);
+                await MarkAbandonedAsync(record, cancellationToken).ConfigureAwait(false);
+                return SparkInvoiceCreditResult.Unrecordable;
+
+            default:
+                // InvoiceGone: the invoice disappeared between the lookup and the insert, which puts us back
+                // in the same position as never having found it.
+                return await NotAttributableAsync(
+                        record, "its BTCPay invoice was gone by the time it was credited", cancellationToken)
+                    .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Reports a settlement that has no BTCPay invoice to attach to, at the volume its age deserves, and gives
+    /// up on it once it is past the horizon.
+    /// </summary>
+    /// <remarks>
+    /// The report and the stamp are one step deliberately: the warning is emitted only when
+    /// <see cref="IInvoiceRecordStore.MarkCreditAbandonedAsync"/> says <em>this</em> caller is the one that
+    /// stamped the row, so a settlement that can never be credited is reported to the operator exactly once —
+    /// with its amount and its payment hash, which is what a human needs to find the money by hand — rather than
+    /// on every pass forever or, as an earlier revision managed, never at all.
+    /// </remarks>
+    private async Task<SparkInvoiceCreditResult> NotAttributableAsync(
+        InvoiceRecord record,
+        string reason,
+        CancellationToken cancellationToken)
+    {
+        var settledAt = record.SettledAt ?? record.CreatedAt;
+        if (DateTimeOffset.UtcNow - settledAt <= CreditRetryHorizon)
+        {
+            // Expected in the window between CreateInvoice returning and BTCPay indexing the hash, so debug:
+            // an operator-level line here would fire on ordinary checkouts.
+            _logger.LogDebug(
+                "Store {StoreId}: the settled Lightning payment {PaymentHash} cannot be credited yet because "
+                + "{Reason}; the next reconciliation pass will try again",
+                record.StoreId, record.PaymentHash, reason);
+            return SparkInvoiceCreditResult.Deferred;
+        }
+
+        if (await MarkAbandonedAsync(record, cancellationToken).ConfigureAwait(false))
+        {
+            _logger.LogWarning(
+                "Store {StoreId}: the settled Lightning payment {PaymentHash} ({AmountSats} sat) has had no "
+                + "BTCPay invoice to credit for {Horizon}, so it will no longer be retried and is recorded as "
+                + "abandoned. This is expected for a BOLT11 that was never issued for a BTCPay invoice; "
+                + "otherwise the money is in the Spark wallet and no BTCPay invoice records it",
+                record.StoreId, record.PaymentHash,
+                (record.AmountReceivedMsat ?? 0) / 1000, CreditRetryHorizon);
+        }
+
+        return SparkInvoiceCreditResult.Abandoned;
+    }
+
+    /// <summary>
+    /// Stamps the record as credited, tolerating the loser of a race.
+    /// </summary>
+    /// <remarks>
+    /// A false return is not a failure: it means the other caller of this compare-and-set stamped it first,
+    /// and "credited" is what both of them concluded.
+    /// </remarks>
+    private async Task MarkCreditedAsync(InvoiceRecord record, CancellationToken cancellationToken)
+    {
+        var creditedAt = DateTimeOffset.UtcNow;
+        if (await _invoiceStore
+                .MarkCreditedAsync(record.StoreId, record.PaymentHash, creditedAt, cancellationToken)
+                .ConfigureAwait(false))
+        {
+            // Kept in step so a caller holding this instance — the settlement path does — does not re-attempt
+            // the credit it just completed. The same value that was persisted, not a second reading of the
+            // clock, so an in-hand record cannot disagree with the row about when the credit landed.
+            record.CreditedAt ??= creditedAt;
+        }
+    }
+
+    /// <summary>
+    /// Stamps the record as never creditable, and reports whether this call is what stamped it.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="MarkCreditedAsync"/> the return value is used, because it is what makes the operator
+    /// warning exactly-once: only the caller that won the compare-and-set logs. The store refuses to stamp a row
+    /// that has since been credited, so the loser of that race is a pass that was about to report money as
+    /// unaccounted-for when it had in fact just been accounted for.
+    /// </remarks>
+    private async Task<bool> MarkAbandonedAsync(InvoiceRecord record, CancellationToken cancellationToken)
+    {
+        var abandonedAt = DateTimeOffset.UtcNow;
+        if (!await _invoiceStore
+                .MarkCreditAbandonedAsync(record.StoreId, record.PaymentHash, abandonedAt, cancellationToken)
+                .ConfigureAwait(false))
+        {
+            return false;
+        }
+
+        // Kept in step for the same reason the credit stamp is: a caller holding this instance must not attempt
+        // the credit again, and must see the value that was actually persisted.
+        record.CreditAbandonedAt ??= abandonedAt;
+        return true;
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkReconciliationTask.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkReconciliationTask.cs
@@ -29,6 +29,14 @@ namespace BTCPayServer.Plugins.Flint.Services;
 /// merchant's wallet — which is exactly the class of silent loss this plugin exists to avoid.
 /// </para>
 /// <para>
+/// <b>Each pass does two things, and the second is not a subset of the first.</b> It re-checks unpaid
+/// invoices against the service provider, and it retries the routing of already-settled payments onto their
+/// BTCPay invoices (<see cref="SparkSettlementReconciler.CreditStoreAsync"/>). The second is what covers a
+/// notification nobody received: BTCPay's listener watches only each invoice's current payment prompt, so a
+/// superseded BOLT11 paid after a restart settles with nothing listening for it, and no amount of re-checking
+/// unpaid invoices would find it — the row is already paid.
+/// </para>
+/// <para>
 /// Registered through BTCPay's <c>AddScheduledTask</c>, which runs <see cref="Do"/> on a fixed interval and
 /// logs rather than rethrows. <see cref="SparkService"/> additionally runs one pass at startup, to cover
 /// events missed while the process was down.

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -923,8 +923,18 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
     /// Re-checks every running store's unpaid invoices against the Spark service. Returns the number settled.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Driven by <see cref="SparkReconciliationTask"/> on a timer and once from <see cref="StartAsync"/>. See
     /// that class for why this is the plugin's settlement guarantee rather than a fallback.
+    /// </para>
+    /// <para>
+    /// The running instances are the stores that can be <em>settled</em>, and they are all this can supply. They
+    /// are not the whole set of stores the pass covers: crediting an already-recorded settlement onto its BTCPay
+    /// invoice needs no wallet connection, so the reconciler widens this list with the stores its own record
+    /// store says are awaiting a credit — otherwise a store whose Spark connection is broken would never retry
+    /// money it had already received. That widening lives in the reconciler because the record store is what
+    /// answers the question.
+    /// </para>
     /// </remarks>
     public async Task<int> ReconcileAllStoresAsync(CancellationToken cancellationToken = default)
     {

--- a/BTCPayServer.Plugins.Flint/Services/SparkSettlementBroadcaster.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSettlementBroadcaster.cs
@@ -53,9 +53,16 @@ public interface ISparkSettlementSubscriber
 /// <para>
 /// Queues are bounded and refuse when full; a refused push is held back and re-delivered on a short
 /// timer, so a transiently-stalled consumer catches up instead of losing the notification. The
-/// allowance is bounded per subscription and by a delivery deadline, after which the operator is told
-/// the truth — BTCPay does not re-poll listened invoices, and <c>SparkReconciliationTask</c> only scans
-/// unpaid rows, so an already-paid row's push reaches BTCPay only when it next reads the invoice.
+/// allowance is bounded per subscription and by a delivery deadline, after which the push is given up on
+/// and logged.
+/// </para>
+/// <para>
+/// <b>Nothing here is the settlement guarantee, and it must not be mistaken for one.</b> A push that is
+/// never delivered — no listener attached, a listener wedged past its deadline, or a restart between the
+/// settlement and the notification — costs the merchant nothing, because the settlement is separately
+/// routed onto the BTCPay invoice its BOLT11 was minted for by
+/// <see cref="SparkInvoiceCreditor"/> and retried until it lands. This class is the fast path: it wakes a
+/// listening session in milliseconds instead of within a reconciliation pass.
 /// </para>
 /// </remarks>
 public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
@@ -142,11 +149,12 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
 
         if (!_subscriptions.TryGetValue(settlement.StoreId, out var forStore) || forStore.IsEmpty)
         {
-            // No listener attached (BTCPay only listens while it has invoices to watch). The settlement is
-            // already persisted, so the next GetInvoice lookup or reconciliation pass reports it.
+            // No listener attached (BTCPay only listens while it has invoices to watch, and after a restart it
+            // watches only each invoice's current prompt). The settlement is already persisted and is credited
+            // to its BTCPay invoice by the credit path, which does not need a listener.
             _logger.LogDebug(
-                "No Spark settlement listener for store {StoreId}; {PaymentHash} is already recorded and will be "
-                + "reported when BTCPay next asks",
+                "No Spark settlement listener for store {StoreId}; {PaymentHash} is already recorded and its "
+                + "BTCPay invoice is credited directly",
                 settlement.StoreId, settlement.PaymentHash);
             return;
         }
@@ -167,14 +175,14 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
                     continue;
 
                 default:
-                    // The listener's bounded queue is full. Nothing can bank on a quiet recovery: BTCPay
-                    // does not re-poll listened invoices (its one-minute timer only expires stale sessions),
-                    // and the reconciliation task only scans unpaid rows — this row is already paid, the
-                    // push was minted on that very transition. So hold the push back and re-deliver it on a
-                    // short timer; a transiently-stalled consumer catches up instead of losing the push. If
-                    // the consumer stays wedged past the delivery deadline, the retry gives up and logs
-                    // what actually remains: the paid row reaches BTCPay when it next reads the invoice,
-                    // typically after a restart of the plugin or the server.
+                    // The listener's bounded queue is full. BTCPay does not re-poll listened invoices (its
+                    // one-minute timer only expires stale sessions), and the reconciliation task's settlement
+                    // walk only scans unpaid rows — this row is already paid, the push was minted on that very
+                    // transition. So hold the push back and re-deliver it on a short timer; a transiently
+                    // stalled consumer catches up instead of losing the push. If it stays wedged past the
+                    // delivery deadline the retry gives up, and that is survivable rather than a lost payment:
+                    // the settlement is credited to its BTCPay invoice by the credit path, which needs no
+                    // listener at all.
                     if (subscription.EnqueueRetry(settlement))
                     {
                         EnsureRetryTimerRunning();
@@ -188,10 +196,10 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
                     {
                         _logger.LogError(
                             "A Spark settlement listener for store {StoreId} is not keeping up and has "
-                            + "exceeded the retry allowance; giving up on {PaymentHash}. The payment is "
-                            + "recorded and will reach BTCPay when it next reads this invoice — typically "
-                            + "after a restart of the plugin or the server; the BTCPay invoice may otherwise "
-                            + "show unpaid.",
+                            + "exceeded the retry allowance; giving up on the notification for "
+                            + "{PaymentHash}. The payment is recorded and is credited to its BTCPay invoice "
+                            + "by the reconciliation pass instead, so the invoice is paid without this "
+                            + "notification — but a listener this far behind is a fault worth investigating.",
                             settlement.StoreId, settlement.PaymentHash);
                     }
                     continue;
@@ -333,8 +341,8 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
                             + "listener caught up", settlement.PaymentHash);
                         break;
                     case SubscriptionWriteResult.Disposed:
-                        // The session is gone; there is nothing left to deliver to, and the paid row reaches
-                        // BTCPay when it next reads the invoice.
+                        // The session is gone; there is nothing left to deliver to, and the settlement's credit
+                        // to the BTCPay invoice does not depend on this notification.
                         lock (_pendingLock) { _pending.Remove(hash); }
                         break;
                     case SubscriptionWriteResult.Saturated:
@@ -349,9 +357,9 @@ public class SparkSettlementBroadcaster : ISparkSettlementSubscriber
                 logger.LogError(
                     "Gave up delivering the Spark settlement notification for {PaymentHash} to store "
                     + "{StoreId} after {RetryLifetime}: the listening session has not consumed. The payment "
-                    + "is recorded; BTCPay does not re-poll listened invoices, so the invoice will show paid "
-                    + "only when it next reads this one — typically after a restart of the plugin or the "
-                    + "server.",
+                    + "is recorded and its BTCPay invoice is credited by the reconciliation pass instead, so "
+                    + "no money is lost — but a listening session this far behind is a fault worth "
+                    + "investigating.",
                     settlement.PaymentHash, settlement.StoreId, _owner._pushRetryLifetime);
             }
         }

--- a/BTCPayServer.Plugins.Flint/Services/SparkSettlementReconciler.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSettlementReconciler.cs
@@ -34,6 +34,14 @@ public sealed record SparkReconciliationTarget(string StoreId, ISparkSdkClient S
 /// faults, the session never dies and never re-polls. Without this task, a dropped completion event means an
 /// invoice that expires unpaid while the sats sit in the merchant's wallet.
 /// </para>
+/// <para>
+/// <b>Settling is not the same as crediting, and both happen here.</b> Notifying BTCPay's listener only works
+/// while that listener is watching the BOLT11 in question, and it watches only each invoice's <em>current</em>
+/// payment prompt — so a superseded BOLT11 paid after a restart settles here and reaches no BTCPay invoice.
+/// Every settlement is therefore also routed to the invoice its BOLT11 was minted for, through
+/// <see cref="SparkInvoiceCreditor"/>, and retried by <see cref="CreditStoreAsync"/> until it lands. The two
+/// paths cannot double-credit: they collide on BTCPay's own payments primary key.
+/// </para>
 /// </remarks>
 public class SparkSettlementReconciler
 {
@@ -73,8 +81,31 @@ public class SparkSettlementReconciler
     /// </remarks>
     private static readonly TimeSpan ExpiredReconciliationGrace = TimeSpan.FromHours(1);
 
+    /// <summary>
+    /// Settled-but-uncredited invoices whose credit is retried per store per pass.
+    /// </summary>
+    /// <remarks>
+    /// Far smaller than <see cref="MaxInvoicesPerPass"/> because the set is normally empty: the credit is
+    /// attempted the moment a settlement is recorded, and only lands here when BTCPay's own row was not
+    /// written yet, when the process died in between, or when the settlement predates the column. A backlog
+    /// larger than this on one store is drained over consecutive passes, oldest first, which is the right
+    /// order — the oldest is the closest to its retry horizon.
+    /// </remarks>
+    private const int MaxCreditsPerPass = 200;
+
+    /// <summary>
+    /// Stores the credit walk will pick up per pass from the record store rather than from a live wallet.
+    /// </summary>
+    /// <remarks>
+    /// Reaching this cap is pathological: it would mean hundreds of stores each holding money that has not
+    /// reached a BTCPay invoice. It exists so the query cannot become unbounded, and the pass says so in the log
+    /// rather than pretending it walked them all.
+    /// </remarks>
+    private const int MaxCreditStoresPerPass = 500;
+
     private readonly IInvoiceRecordStore _invoiceStore;
     private readonly SparkSettlementBroadcaster _broadcaster;
+    private readonly SparkInvoiceCreditor _creditor;
     private readonly ILogger<SparkSettlementReconciler> _logger;
 
     /// <summary>
@@ -86,10 +117,12 @@ public class SparkSettlementReconciler
     public SparkSettlementReconciler(
         IInvoiceRecordStore invoiceStore,
         SparkSettlementBroadcaster broadcaster,
+        SparkInvoiceCreditor creditor,
         ILogger<SparkSettlementReconciler> logger)
     {
         _invoiceStore = invoiceStore;
         _broadcaster = broadcaster;
+        _creditor = creditor;
         _logger = logger;
     }
 
@@ -150,12 +183,25 @@ public class SparkSettlementReconciler
                 // Published only on the transition, so a duplicate event or a poll racing the event does not
                 // wake every listening session twice.
                 _broadcaster.Publish(ToSettlement(result.Record));
+
+                // And routed to the BTCPay invoice the BOLT11 was minted for, which the publish above cannot
+                // be relied on to achieve: BTCPay's listener only watches each invoice's current prompt, so a
+                // superseded BOLT11 paid after a restart has nothing listening for it. Independent of the
+                // publish rather than an alternative to it — the two collide on BTCPay's payments primary key
+                // and exactly one of them records the money. Ordered after, and unable to throw, so a BTCPay
+                // database that is briefly unreachable cannot unwind a settlement that is already committed.
+                await CreditAsync(result.Record, cancellationToken).ConfigureAwait(false);
                 break;
 
             case InvoiceSettlementOutcome.AlreadySettled:
                 _logger.LogDebug(
                     "Store {StoreId}: Lightning invoice {PaymentHash} was already settled",
                     storeId, paymentHash);
+
+                // A duplicate event is the cheapest retry there is: if the credit for this settlement has not
+                // landed yet, attempt it again here rather than waiting for the next pass.
+                if (result.Record is { CreditedAt: null, CreditAbandonedAt: null })
+                    await CreditAsync(result.Record, cancellationToken).ConfigureAwait(false);
                 break;
 
             default:
@@ -308,6 +354,16 @@ public class SparkSettlementReconciler
     /// position has to outlive a pass, and because the reconciliation task and the startup catch-up are the same
     /// walk over the same stores and should share one position rather than each starting from the top.
     /// </para>
+    /// <para>
+    /// <b>The set of stores is wider than the set of live wallets, and has to be.</b> Settling needs an SDK
+    /// handle; crediting does not — it touches only BTCPay's tables and this plugin's rows. A store whose Spark
+    /// connection is broken (a rotated key, a service-provider outage, a wallet reconfigured away) has no live
+    /// handle and so appears in no target, and while the credit walk was reachable only through a target's visit
+    /// such a store never retried the settlements it had already received: real money, already in the merchant's
+    /// wallet, that no BTCPay invoice recorded. So the pass walks the union of the supplied targets and the
+    /// stores the record store says are still awaiting a credit, and a store in the second set but not the first
+    /// gets the credit walk alone.
+    /// </para>
     /// </remarks>
     public async Task<int> ReconcileStoresAsync(
         IEnumerable<SparkReconciliationTarget> targets,
@@ -325,16 +381,26 @@ public class SparkSettlementReconciler
         foreach (var target in targets)
             byStore[target.StoreId] = target.Sdk;
 
+        var allStores = new HashSet<string>(byStore.Keys, StringComparer.Ordinal);
+        allStores.UnionWith(await ListStoresAwaitingCreditAsync(cancellationToken).ConfigureAwait(false));
+
         // Interlocked rather than a plain increment: a store whose visit outlived its deadline is still running
         // when this method returns, and it must not race the read below or corrupt a later pass's count. Its
         // settlements are simply not counted here, which is honest — nothing waited to find out.
         var settled = 0;
 
         await pass.RunAsync(
-                byStore.Keys,
+                allStores,
                 async (storeId, token) =>
                 {
-                    var count = await ReconcileStoreAsync(storeId, byStore[storeId], token).ConfigureAwait(false);
+                    if (!byStore.TryGetValue(storeId, out var sdk))
+                    {
+                        // No live wallet, so nothing to settle against — but the credit walk needs none.
+                        await CreditStoreSafelyAsync(storeId, token).ConfigureAwait(false);
+                        return;
+                    }
+
+                    var count = await ReconcileStoreAsync(storeId, sdk, token).ConfigureAwait(false);
                     Interlocked.Add(ref settled, count);
                 },
                 (storeId, ex) =>
@@ -360,9 +426,21 @@ public class SparkSettlementReconciler
     /// number settled by this pass.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Pages by keyset to the end of the set rather than taking one page, so no invoice starves behind a
     /// sustained backlog. Bounded overall by <see cref="MaxInvoicesPerPass"/>, and the log says so honestly when
     /// the bound is what stopped the walk.
+    /// </para>
+    /// <para>
+    /// <b>The credit walk runs first, and independently.</b> It used to run last and inside the settlement
+    /// walk's control flow, which gave it two ways to be skipped entirely: a failure loading the settlement page
+    /// returned before reaching it, and a store with a sustained settlement backlog could burn the whole
+    /// per-store deadline before reaching it — every pass, forever, on exactly the store most likely to have
+    /// uncredited money. It is now ordered first (it is bounded, cheap, and makes no SDK call, so it cannot
+    /// starve the settlement walk in return) and wrapped in its own error boundary, so neither walk's failure
+    /// can cost the other its turn. Ordering it first loses nothing: a settlement recorded later in this same
+    /// pass has its credit attempted inline on the settlement path.
+    /// </para>
     /// </remarks>
     public async Task<int> ReconcileStoreAsync(
         string storeId,
@@ -371,6 +449,11 @@ public class SparkSettlementReconciler
     {
         ArgumentException.ThrowIfNullOrEmpty(storeId);
         ArgumentNullException.ThrowIfNull(sdk);
+
+        // Settling is only half of it: a settlement whose credit never reached the merchant's BTCPay invoice has
+        // to be retried, and this is the pass that does it. First, so a backlogged settlement walk cannot starve
+        // it out of the store's deadline slice.
+        await CreditStoreSafelyAsync(storeId, cancellationToken).ConfigureAwait(false);
 
         // Recently expired invoices are included on purpose. The service provider accepts a late payment and
         // Spark has no way to withdraw an invoice from it, so an invoice that expired moments ago can still
@@ -462,6 +545,198 @@ public class SparkSettlementReconciler
         }
 
         return settled;
+    }
+
+    /// <summary>
+    /// Runs a store's credit walk without letting its failure reach the settlement walk that follows.
+    /// </summary>
+    /// <remarks>
+    /// An error boundary of its own rather than a shared <c>try</c>, because the two walks answer different
+    /// questions and neither is a precondition of the other: a store whose invoice listing is failing must still
+    /// have the money it already received routed onto BTCPay's invoices, and a store whose BTCPay database is
+    /// briefly unreachable must still have its unpaid invoices re-checked against the service provider.
+    /// </remarks>
+    private async Task CreditStoreSafelyAsync(string storeId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await CreditStoreAsync(storeId, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Store {StoreId}: the Spark credit pass failed; the settlements it covers stay recorded and "
+                + "uncredited, and the next pass retries them",
+                storeId);
+        }
+    }
+
+    /// <summary>
+    /// The stores the record store says are still awaiting a credit, or none if it cannot be asked.
+    /// </summary>
+    /// <remarks>
+    /// A failure here must not abort the pass: the targets are still walkable, and losing the credit-only stores
+    /// for one pass costs a retry rather than a settlement.
+    /// </remarks>
+    private async Task<IReadOnlyList<string>> ListStoresAwaitingCreditAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var storeIds = await _invoiceStore
+                .ListStoreIdsAwaitingCreditAsync(
+                    SparkInvoiceCreditor.ListableFrom(DateTimeOffset.UtcNow),
+                    MaxCreditStoresPerPass,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (storeIds.Count >= MaxCreditStoresPerPass)
+            {
+                _logger.LogWarning(
+                    "{Count} store(s) hold settled Lightning payments awaiting a BTCPay credit, which is this "
+                    + "pass's limit; the rest are not walked until these are resolved. Something is wrong with "
+                    + "this server's invoices — this set is normally empty",
+                    storeIds.Count);
+            }
+
+            return storeIds;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Could not list the stores awaiting a BTCPay credit; this pass covers only the stores with a "
+                + "running Spark wallet");
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Retries the BTCPay credit for every settlement of a store that has not been credited yet. Returns the
+    /// number credited by this pass.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what makes the routing survive a restart. Four situations put a row here, and one walk covers
+    /// all of them: a payment that arrived while the process was down and was settled from the SDK's replay
+    /// at reconnect; a listening session that was saturated past its retry allowance; a crash between the
+    /// settlement's compare-and-set and BTCPay's own insert; and rows settled before this column existed,
+    /// which resolve on the first pass as already recorded and are then never looked at again.
+    /// </para>
+    /// <para>
+    /// Paged by keyset, oldest first, and bounded by <see cref="MaxCreditsPerPass"/>. No resume cursor, unlike
+    /// the settlement walk: a record leaves this set permanently once it is resolved — credited, or given up on
+    /// and reported — so restarting at the oldest each pass drains a backlog rather than starving behind it. The
+    /// exception is a record that keeps failing, which stays at the front, and that is the right thing to keep
+    /// retrying, because it is the one closest to its horizon.
+    /// </para>
+    /// <para>
+    /// Every record examined here either leaves the set or is left deliberately: nothing ages out of it
+    /// unresolved and unreported, which was the defect this walk shipped with. The bound the listing is given is
+    /// <see cref="SparkInvoiceCreditor.ListableFrom"/> and not the retry horizon precisely so that a record past
+    /// the horizon is still handed to the creditor once — to be reported and stamped — rather than vanishing.
+    /// </para>
+    /// </remarks>
+    public async Task<int> CreditStoreAsync(string storeId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(storeId);
+
+        // The *listable* bound, not the creditable one. They used to be the same value, and that is precisely
+        // what made a settlement past its retry horizon invisible: it left this listing at the instant it became
+        // eligible to be reported as abandoned, so nothing ever reported it and its row stayed indistinguishable
+        // from one still in flight. See SparkInvoiceCreditor.AbandonedReportingGrace.
+        var settledFrom = SparkInvoiceCreditor.ListableFrom(DateTimeOffset.UtcNow);
+        var credited = 0;
+        var examined = 0;
+        InvoiceReconciliationCursor? cursor = null;
+
+        while (examined < MaxCreditsPerPass)
+        {
+            var pageSize = Math.Min(InvoicePageSize, MaxCreditsPerPass - examined);
+
+            IReadOnlyList<InvoiceRecord> page;
+            try
+            {
+                page = await _invoiceStore
+                    .ListUncreditedAsync(storeId, settledFrom, cursor, pageSize, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Store {StoreId}: could not load settled Spark invoices awaiting a BTCPay credit", storeId);
+                return credited;
+            }
+
+            if (page.Count == 0)
+                break;
+
+            foreach (var record in page)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                examined++;
+                // Advanced before the attempt, so a record that keeps failing cannot stall this page's walk on
+                // itself; the next pass starts from the top and reaches it again.
+                cursor = new InvoiceReconciliationCursor(record.CreatedAt, record.PaymentHash);
+
+                if (await CreditAsync(record, cancellationToken).ConfigureAwait(false)
+                    is SparkInvoiceCreditResult.Credited)
+                {
+                    credited++;
+                }
+            }
+
+            if (page.Count < pageSize)
+                break;
+        }
+
+        if (credited > 0)
+        {
+            _logger.LogInformation(
+                "Store {StoreId}: reconciliation credited {Credited} settled Lightning payment(s) to BTCPay "
+                + "invoices that were no longer being watched for them",
+                storeId, credited);
+        }
+
+        return credited;
+    }
+
+    /// <summary>
+    /// Attempts one credit, absorbing anything it throws.
+    /// </summary>
+    /// <remarks>
+    /// The creditor already promises not to throw; this is the belt to that braces, and it exists because of
+    /// where the call sits. On the settlement path the settlement is already committed and the notification
+    /// already published by the time it runs, so an exception escaping here would turn a completed settlement
+    /// into a logged failure — and, on the SDK's event loop, into a store-wide error line for a payment that
+    /// was in fact recorded correctly.
+    /// </remarks>
+    private async Task<SparkInvoiceCreditResult> CreditAsync(
+        InvoiceRecord record,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _creditor.CreditAsync(record, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Store {StoreId}: crediting the settled Lightning payment {PaymentHash} to its BTCPay invoice "
+                + "failed unexpectedly; the settlement is recorded and the credit will be retried",
+                record.StoreId, record.PaymentHash);
+            return SparkInvoiceCreditResult.Failed;
+        }
     }
 
     private static SparkSettlement ToSettlement(InvoiceRecord record) => new(

--- a/BTCPayServer.Plugins.Flint/SparkPlugin.cs
+++ b/BTCPayServer.Plugins.Flint/SparkPlugin.cs
@@ -69,6 +69,15 @@ public class SparkPlugin : BaseBTCPayServerPlugin
         // session (subscribers).
         services.AddSingleton<SparkSettlementBroadcaster>();
 
+        // Routing a settlement to the BTCPay invoice its BOLT11 was minted for, which the settlement
+        // notification above cannot be relied on to achieve: BTCPay's Lightning listener watches only each
+        // invoice's current payment prompt, so a superseded BOLT11 that is paid after a restart settles here
+        // and reaches no invoice. The gateway is the thin part that talks to BTCPay; the creditor holds every
+        // decision, including the refusal to credit another store's invoice, and is unit-tested against a fake
+        // of the gateway.
+        services.AddSingleton<IInvoiceCreditGateway, BTCPayInvoiceCreditGateway>();
+        services.AddSingleton<SparkInvoiceCreditor>();
+
         // The single path from "a Spark receive happened" to "a BTCPay invoice is paid", shared by the event
         // consumer, BTCPay's GetInvoice lookup and the reconciliation task.
         services.AddSingleton<SparkSettlementReconciler>();
@@ -84,6 +93,12 @@ public class SparkPlugin : BaseBTCPayServerPlugin
             provider.GetRequiredService<ISparkClientResolver>);
         services.TryAddSingleton<Func<PaymentMethodHandlerDictionary>>(provider =>
             provider.GetRequiredService<PaymentMethodHandlerDictionary>);
+        // PaymentService touches the same graph — its own constructor takes PaymentMethodHandlerDictionary — and
+        // is deferred to keep that rule uniform rather than because eager injection is known to hang today: the
+        // cycle above is broken at SparkConnectionStringHandler's Func<ISparkClientResolver>.
+        // BTCPayInvoiceCreditGateway documents the path.
+        services.TryAddSingleton<Func<PaymentService>>(provider =>
+            provider.GetRequiredService<PaymentService>);
 
         // Ownership of the store's BTC-LN payment method config. The wiring class holds every decision about
         // when the plugin may write or clear it and is unit-tested against a fake of the store seam; the store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this plugin are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **A superseded bolt11 paid after a restart now reaches its BTCPay invoice.** Recording the settlement
+  was only half the job. BTCPay's Lightning listener matches a notification against a set built from each
+  invoice's *current* payment prompt, so once bolt11 X has been replaced by Y and the server has
+  restarted, only Y is watched — X stays payable on the service provider, and a payment to it settled in
+  this plugin's records while the merchant's BTCPay invoice stayed unpaid, with the funds already in their
+  Spark wallet. The plugin no longer relies on that listener: every settlement is also written directly
+  onto the BTCPay invoice its bolt11 was minted for, found through BTCPay's own payment-hash index (which
+  keeps the mint-time association permanently), and each settlement now records whether that credit
+  landed so the reconciliation pass can retry it until it does. That retry also closes three smaller
+  holes of the same shape — a payment that arrived while the server was down, a listening session
+  saturated past its retry allowance, and a crash between recording the settlement and notifying BTCPay.
+  The merchant cannot be credited twice: the credit is keyed on the payment hash, the same id BTCPay's own
+  listener uses, so the two collide on BTCPay's payments primary key and exactly one of them records the
+  money. Crediting an invoice that belongs to a different store than the wallet the money arrived in is
+  refused outright and logged. The retry needs no Spark connection — crediting touches only BTCPay's own
+  tables — so a store whose wallet is disconnected, its key rotated or its configuration removed still has
+  money it already received routed onto the right invoice. LNURL proof-of-payment keeps working too: the
+  preimage is written onto the invoice's payment prompt, which is where LUD-21 `verify` reads it from, and
+  is deliberately not written when the prompt has since moved on to a replacement bolt11.
+- **A settlement that can never be credited is now reported, once, instead of going quiet.** A payment
+  whose hash BTCPay has no invoice for — a bolt11 minted through the plugin's own API, say — is retried
+  for seven days. After that the next reconciliation pass logs it once at warning level with its amount
+  and payment hash and marks it abandoned, which is recorded separately from "credited": the plugin's
+  records keep saying that this money never reached a BTCPay invoice, so a merchant's wallet balance can
+  be reconciled against them. The same applies to a BTCPay invoice with no payment prompt able to hold the
+  payment. Nothing is reported twice and nothing is retried forever.
+
 ## [0.1.5.4] — 2026-08-24
 
 ### Security

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -11,7 +11,50 @@
   credits the BTCPay invoice it was minted for. What cancellation actually buys is bookkeeping: the
   invoice is no longer offered to payers, and a late payment is attributed to it, not to its
   replacement. The plugin keeps reporting a cancelled invoice as unpaid (never expired) until it
-  settles, so BTCPay's Lightning listener stays attached and can deliver that credit.
+  settles, so BTCPay's Lightning listener stays attached and can still deliver that credit — a listener
+  drops an invoice whose status reads expired.
+
+  **How that credit actually reaches BTCPay, since its listener cannot be relied on either.** BTCPay's
+  Lightning listener only watches each invoice's *current* payment prompt. Replace BOLT11 X with
+  BOLT11 Y — which BTCPay does whenever an LNURL invoice is re-quoted — and X leaves the watched set;
+  after a restart it is never re-added, because that set is rebuilt from the prompts that exist now.
+  So the plugin does not depend on notifying a listener. Every settlement is also written straight
+  onto the BTCPay invoice the BOLT11 was minted for, found through BTCPay's own payment-hash index
+  (`AddressInvoices`, which is insert-only and keeps the mint-time association forever). The plugin
+  records whether that credit landed and retries it on every reconciliation pass until it does, which
+  also covers a payment that arrived while the server was down, a listening session that fell too far
+  behind, and a crash between recording the settlement and telling BTCPay. The retry does not need the
+  store's Spark wallet to be connected — crediting touches only BTCPay's own tables — so a store whose
+  connection is broken still has its already-received money routed. The credit cannot happen
+  twice: it is keyed on the payment hash, the same id BTCPay's own listener uses, so the two collide on
+  BTCPay's payments primary key and exactly one of them records the money.
+
+  **When the plugin gives up, and what it leaves behind.** Three bounds are worth knowing, and all three
+  end the same way: one warning in BTCPay's log naming the amount and the payment hash, and a row marked
+  as abandoned rather than as credited — so `SELECT` on the plugin's `InvoiceRecords` can always tell
+  money that reached an invoice from money that did not.
+
+  - A settlement whose payment hash BTCPay has **no invoice for** — a BOLT11 minted through this
+    plugin's Greenfield endpoints, say — is retried for **seven days**, then reported once and given up
+    on, because it can never be attributed. It is reported and marked on the first reconciliation pass
+    after that seven days, not silently forgotten; the only settlements that escape the report are ones
+    already older than a fortnight when this version was first installed, which are outside the walk
+    entirely.
+  - A BTCPay invoice with **no payment prompt** that could hold the payment is given up on immediately,
+    since a prompt is never removed from an invoice once written and a retry would fail identically.
+    This is very close to unreachable in practice — nothing in BTCPay deletes a prompt — and is listed
+    because if it ever does happen the money is in the wallet, the invoice cannot be credited
+    automatically, and only a human can reconcile it.
+  - A store whose LNURL prompts have **LUD-21 disabled by hand** loses the LNURL half of the index:
+    BTCPay only records the payment hash of an LNURL prompt when LUD-21 is on, which is why this plugin
+    turns it on when it provisions a store. Such a payment is reported as unattributable rather than
+    guessed at.
+
+  One thing the plugin does *not* keep from BTCPay's own listener is worth naming as a non-limitation:
+  the preimage is written onto the payment prompt as well as onto the payment, so LNURL
+  proof-of-payment (LUD-21 `verify`) works for a Flint checkout exactly as it does for any other
+  Lightning backend. The one case it is deliberately not written is a superseded BOLT11 — the prompt is
+  offering the replacement by then, and its preimage is a different value.
 - **Testnet and signet are unsupported**, because the SDK only offers mainnet and regtest.
 - **The SDK's own log cannot be turned up to `trace`, on purpose.** The plugin installs the Rust SDK's
   logging subscriber, which writes `<DataDir>/Plugins/Flint/logs/sdk.log` *and* forwards every line into

--- a/docs/store-setup.md
+++ b/docs/store-setup.md
@@ -68,6 +68,29 @@ exactly one credit and one notification.
 The task keeps looking for **one hour past an invoice's expiry**, because the service provider accepts a
 late payment and Spark has no way to withdraw an invoice from it — so a just-expired invoice can still
 take real money that has to be recorded. Past that hour it stops, which is a deliberate bound: a payment
-arriving later than that stays in the wallet balance without being attributed to an invoice. Note that
-BTCPay stops listening for an invoice as soon as it expires, so a settlement recorded after expiry keeps
-this plugin's own ledger truthful but will usually not revive the BTCPay invoice.
+arriving later than that stays in the wallet balance without being attributed to an invoice.
+
+### And the notification is not what credits the merchant
+
+Notifying BTCPay's listener only works while that listener is watching the BOLT11 in question — and it
+watches only each invoice's *current* payment prompt. Replace BOLT11 X with BOLT11 Y (BTCPay does this
+whenever an LNURL invoice is re-quoted) and X leaves the watched set; after a restart it is never re-added,
+because the set is rebuilt from the prompts that exist now. X is still payable on the service provider.
+
+So every settlement is **also written directly onto the BTCPay invoice its BOLT11 was minted for**, found
+through BTCPay's own payment-hash index, which keeps the mint-time association permanently. The plugin
+records whether that credit landed and the reconciliation pass retries it until it does — covering a
+payment that arrived while the server was down, a listening session that fell too far behind, and a crash
+between recording the settlement and telling BTCPay. It cannot happen twice: the credit is keyed on the
+payment hash, the same id BTCPay's own listener uses, so the two collide on BTCPay's payments primary key
+and exactly one records the money.
+
+That retry needs no Spark connection — it touches only BTCPay's own tables — so a store whose wallet is
+disconnected, its key rotated, or its configuration removed still has money it already received routed
+onto the right invoice.
+
+A settlement whose payment hash BTCPay has no invoice for is retried for **seven days**. After that, the
+next pass reports it once — with its amount and its payment hash, at warning level — and marks it as
+abandoned, which is a different mark from credited: the plugin's records keep saying that this money never
+reached a BTCPay invoice, so a wallet balance can be reconciled against them. Nothing is reported twice,
+and nothing is retried forever.


### PR DESCRIPTION
Closes the follow-up audit finding on the superseded-invoice fix in v0.1.5.4:

> When BTCPay replaces BOLT11 X with Y and then restarts, it resumes watching only Y. If X is still payable and is later paid, Flint records the payment, but BTCPay drops the notification before associating it with the original invoice.

**Every settlement is now routed directly onto the BTCPay invoice its BOLT11 was minted for**, instead of relying on BTCPay's Lightning listener being attached. The route uses BTCPay's own state: the insert-only `AddressInvoices` payment-hash index (which keeps the mint-time association across supersession and restarts) resolves the invoice, and the payment is written with the same payment id core's listener uses — BTCPay's payments primary key arbitrates between the two paths, so **exactly one credit ever lands** even when both fire.

- A new `CreditedAt` column makes "paid but not yet routed" a persisted state; the reconciliation pass retries it until it lands, needing no Spark connection — covering payments that arrive while the server is down, broadcaster saturation, a crash between settle and notify, and pre-existing orphaned settlements.
- A settlement no BTCPay invoice ever accounts for is warned about once (amount + hash) after a 7-day retry horizon and marked `CreditAbandonedAt` — distinct from credited, so wallet-vs-invoice reconciliation stays possible in SQL.
- Crediting an invoice belonging to a different store than the wallet the money arrived in is refused and logged.
- The winning credit backfills the preimage onto the current payment prompt (hash-guarded), keeping LUD-21 `verify` proofs working; a superseded BOLT11's preimage is never written onto its replacement's prompt.
- Regression tests requested by the audit: X → Y → restart → pay X with exactly-once credit to the original invoice, plus paid-while-down, duplicate-delivery, abandonment, and backfill variants — all mutation-checked. Two `InvoiceRecordTests` that had silently lost their `[Fact]` attributes run again.

Verification: full suite green in-memory (1,274 tests, 0 failures) and against real Postgres 17 (only funded-regtest skipped); both EF migrations validated up/down/up against Postgres 17 with pre-existing rows surviving.

Test targets: after review, build and deploy to the staging/dev BTCPay hosts before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)