### PR TITLE
Keep the mint-time hash→invoice association independent of LUD-21

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -30,8 +30,13 @@ writes it with a single space between hash and filename. GNU `sha256sum -c` acce
 
 ## Installing
 
-**Server settings → Plugins → Upload plugin**, and select `BTCPayServer.Plugins.Flint.btcpay`.
-BTCPay restarts itself to finish. Requires BTCPay Server 2.4.1 or newer, on a non-Alpine host.
+**Server settings → Plugins**, find **Flint** in the plugin store
+([official listing](https://plugin-builder.btcpayserver.org/public/plugins/flint)), and install it.
+BTCPay restarts itself to finish.
+
+Alternatively, **Server settings → Plugins → Upload plugin**, and select
+`BTCPayServer.Plugins.Flint.btcpay`. BTCPay restarts itself to finish. Both routes require BTCPay Server
+2.4.1 or newer, on a non-Alpine host.
 
 Read [CHANGELOG.md](https://github.com/__REPO__/blob/__TAG__/CHANGELOG.md) for what is in this
 release and how far it has actually been proven, and the

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ packages/
 
 # Agent worktrees: transient, and each is its own git repo.
 .claude/worktrees/
+
+# Local-only deploy/test notes (never commit).
+.local/

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeInvoiceCreditGateway.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeInvoiceCreditGateway.cs
@@ -3,19 +3,27 @@ using BTCPayServer.Plugins.Flint.Services;
 namespace BTCPayServer.Plugins.Flint.Tests.Fakes;
 
 /// <summary>
-/// An <see cref="IInvoiceCreditGateway"/> that models the two BTCPay tables the real one talks to.
+/// An <see cref="IInvoiceCreditGateway"/> that models the two indexes the real one talks to.
 /// </summary>
 /// <remarks>
 /// <para>
 /// Not a stub that returns configured answers: the properties the credit path depends on are properties of
-/// BTCPay's schema, and a fake that did not have them would make every assertion here hollow. Two things are
-/// modelled, and both are load-bearing.
+/// BTCPay's schema, and a fake that did not have them would make every assertion here hollow. What is modelled
+/// is what the real gateway consults, in the order it consults it.
 /// </para>
 /// <para>
 /// <b><c>AddressInvoices</c> is insert-only.</b> BTCPay writes the payment hash of every prompt it issues
 /// into that table when the prompt is minted and never removes it, so superseding BOLT11 X with BOLT11 Y
 /// leaves <em>both</em> hashes pointing at the same invoice. That is the entire basis for crediting a payment
 /// to a replaced BOLT11, so <see cref="Mint"/> only ever adds.
+/// </para>
+/// <para>
+/// <b>The plugin's own payment-hash index is written regardless of LUD-21.</b> The real gateway falls back to
+/// <see cref="Services.IInvoicePaymentHashIndex"/> when core's table has no row, which happens for an LNURL
+/// prompt minted while the merchant had LUD-21 disabled by hand (core indexes LNURL prompts only when LUD-21
+/// is on). <see cref="Mint"/> therefore writes the plugin index <em>always</em> and core's
+/// <c>AddressInvoices</c> only when told to, so a test can reproduce the LUD-21-off shape by minting with
+/// <c>indexInCore: false</c>.
 /// </para>
 /// <para>
 /// <b><c>Payments</c> has primary key <c>(Id, PaymentMethodId)</c>.</b> That collision — not any ordering or
@@ -41,6 +49,7 @@ public sealed class FakeInvoiceCreditGateway : IInvoiceCreditGateway
     public const string LnurlPaymentMethodId = "BTC-LNURL";
 
     private readonly Dictionary<string, Row> _addressInvoices = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Row> _pluginIndex = new(StringComparer.Ordinal);
     private readonly HashSet<(string Id, string PaymentMethodId)> _payments = [];
     private readonly Dictionary<string, Prompt> _prompts = new(StringComparer.Ordinal);
 
@@ -71,16 +80,24 @@ public sealed class FakeInvoiceCreditGateway : IInvoiceCreditGateway
     public Exception? FailWith { get; set; }
 
     /// <summary>
-    /// Records that BTCPay issued this payment hash for an invoice, as it does when a prompt is minted.
+    /// Records that this BOLT11's payment hash was minted for an invoice, as happens when a prompt is minted.
     /// </summary>
+    /// <param name="indexInCore">
+    /// Whether core also recorded the hash in its <c>AddressInvoices</c> table. False models an LNURL prompt
+    /// minted while LUD-21 was disabled by hand: core does not index it, but the plugin's own index — written
+    /// from the mint event regardless of LUD-21 — does.
+    /// </param>
     public FakeInvoiceCreditGateway Mint(
         string paymentHash,
         string invoiceId,
         string storeId,
-        string paymentMethodId = LightningPaymentMethodId)
+        string paymentMethodId = LightningPaymentMethodId,
+        bool indexInCore = true)
     {
-        // Insert-only, like the real table: superseding a BOLT11 does not remove the old hash's row.
-        _addressInvoices.TryAdd(paymentHash, new Row(invoiceId, storeId, paymentMethodId));
+        // Insert-only, like the real tables: superseding a BOLT11 does not remove the old hash's row.
+        if (indexInCore)
+            _addressInvoices.TryAdd(paymentHash, new Row(invoiceId, storeId, paymentMethodId));
+        _pluginIndex.TryAdd(paymentHash, new Row(invoiceId, storeId, paymentMethodId));
         // The prompt, by contrast, is replaced — this invoice now offers this BOLT11 and no longer the previous
         // one. Minting X then Y is exactly the supersession the credit path exists for.
         _prompts[invoiceId] = new Prompt { PaymentHash = paymentHash };
@@ -126,9 +143,15 @@ public sealed class FakeInvoiceCreditGateway : IInvoiceCreditGateway
             throw FailWith;
 
         Lookups++;
-        if (!_addressInvoices.TryGetValue(paymentHash, out var row))
+        // The real gateway consults core's table first and the plugin's own index only when that has no row —
+        // the LUD-21-off LNURL case modelled by Mint(..., indexInCore: false). Either index can resolve the
+        // hash; core's index just takes precedence, exactly as in the production gateway.
+        var row = _addressInvoices.GetValueOrDefault(paymentHash)
+                  ?? _pluginIndex.GetValueOrDefault(paymentHash);
+        if (row is null)
+        {
             return Task.FromResult<SparkInvoiceCreditMatch?>(null);
-
+        }
         return Task.FromResult<SparkInvoiceCreditMatch?>(new SparkInvoiceCreditMatch(
             row.InvoiceId,
             row.StoreId,
@@ -145,8 +168,13 @@ public sealed class FakeInvoiceCreditGateway : IInvoiceCreditGateway
 
         Attempts.Add(request);
 
-        if (!_addressInvoices.ContainsKey(request.PaymentHash))
+        // "Which invoice was this minted for" is the question, and either index can answer it — the same
+        // existence test as the real gateway's re-read of the invoice by id.
+        if (!_addressInvoices.ContainsKey(request.PaymentHash)
+            && !_pluginIndex.ContainsKey(request.PaymentHash))
+        {
             return Task.FromResult(SparkInvoiceCreditOutcome.InvoiceGone);
+        }
 
         if (PromptMissingFor.Contains(request.PaymentHash))
             return Task.FromResult(SparkInvoiceCreditOutcome.PromptMissing);

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemoryInvoicePaymentHashIndex.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemoryInvoicePaymentHashIndex.cs
@@ -1,0 +1,42 @@
+using BTCPayServer.Plugins.Flint.Data;
+
+namespace BTCPayServer.Plugins.Flint.Tests.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IInvoicePaymentHashIndex"/> with the same semantics as the EF implementation, so the
+/// indexer and the contract tests can run without Postgres.
+/// </summary>
+public sealed class InMemoryInvoicePaymentHashIndex : IInvoicePaymentHashIndex
+{
+    private readonly Dictionary<string, InvoicePaymentHash> _entries = new(StringComparer.Ordinal);
+
+    /// <summary>Thrown by <see cref="RecordAsync"/> when set, to exercise the failure path.</summary>
+    public Exception? FailRecordWith { get; set; }
+
+    public IReadOnlyDictionary<string, InvoicePaymentHash> Entries => _entries;
+
+    public Task RecordAsync(InvoicePaymentHash entry, CancellationToken cancellationToken = default)
+    {
+        if (FailRecordWith is not null)
+            throw FailRecordWith;
+
+        // Write-once, like core's AddressInvoices and like the EF store's ON CONFLICT DO NOTHING: the first
+        // writer of a hash wins, and a duplicate is not an error.
+        _entries.TryAdd(entry.PaymentHash.ToLowerInvariant(), new InvoicePaymentHash
+        {
+            PaymentHash = entry.PaymentHash.ToLowerInvariant(),
+            InvoiceId = entry.InvoiceId,
+            PaymentMethodId = entry.PaymentMethodId,
+            FirstSeenAt = entry.FirstSeenAt == default ? DateTimeOffset.UtcNow : entry.FirstSeenAt
+        });
+        return Task.CompletedTask;
+    }
+
+    public Task<InvoicePaymentHash?> FindByPaymentHashAsync(
+        string paymentHash,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(_entries.GetValueOrDefault(paymentHash.ToLowerInvariant()));
+
+    /// <summary>Seeds an association directly, standing in for a row written before this instance existed.</summary>
+    public void Seed(InvoicePaymentHash entry) => _entries[entry.PaymentHash.ToLowerInvariant()] = entry;
+}

--- a/BTCPayServer.Plugins.Flint.Tests/InvoicePaymentHashIndexContractTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/InvoicePaymentHashIndexContractTests.cs
@@ -1,0 +1,108 @@
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using BTCPayServer.Plugins.Flint.Tests.Postgres;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The <see cref="IInvoicePaymentHashIndex"/> contract, asserted against every implementation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Written as a contract rather than as tests of one class for the same reason the invoice-record store is:
+/// the in-memory implementation is what the rest of the suite runs against, and those tests only mean
+/// something if the production EF store behaves identically — notably that a recorded association is
+/// write-once (first writer wins) and that lookups are case-insensitive on the hex.
+/// </para>
+/// <para>
+/// The Postgres subclass is skipped unless <c>SPARK_POSTGRES_TESTS</c> holds a connection string.
+/// </para>
+/// </remarks>
+public abstract class InvoicePaymentHashIndexContractTests
+{
+    private const string InvoiceId = "btcpay-invoice-1";
+    private const string PaymentMethodId = "BTC-LNURL";
+
+    protected abstract Task<IInvoicePaymentHashIndex> CreateIndexAsync();
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static InvoicePaymentHash Entry(string? hash = null, string? invoiceId = null) => new()
+    {
+        PaymentHash = hash ?? PaymentFixture.PaymentHash,
+        InvoiceId = invoiceId ?? InvoiceId,
+        PaymentMethodId = PaymentMethodId
+    };
+
+    [Fact]
+    public async Task A_recorded_hash_is_found_with_the_invoice_it_was_minted_for()
+    {
+        var index = await CreateIndexAsync();
+        await index.RecordAsync(Entry(), Ct);
+
+        var found = await index.FindByPaymentHashAsync(PaymentFixture.PaymentHash, Ct);
+        Assert.NotNull(found);
+        Assert.Equal(InvoiceId, found.InvoiceId);
+        Assert.Equal(PaymentMethodId, found.PaymentMethodId);
+        Assert.NotEqual(default, found.FirstSeenAt);
+
+        // A hash that was never minted for a BTCPay invoice is the "no association" answer.
+        Assert.Null(await index.FindByPaymentHashAsync(PaymentFixture.OtherPaymentHash, Ct));
+    }
+
+    [Fact]
+    public async Task A_hash_is_found_regardless_of_hex_case()
+    {
+        // BTCPay is not consistent about the case of a payment hash, and the association must not care.
+        // (The contract pins the normalisation both implementations perform on the way in.)
+        var index = await CreateIndexAsync();
+        await index.RecordAsync(Entry(hash: PaymentFixture.PaymentHash.ToUpperInvariant()), Ct);
+
+        Assert.NotNull(await index.FindByPaymentHashAsync(PaymentFixture.PaymentHash, Ct));
+        Assert.NotNull(
+            await index.FindByPaymentHashAsync(PaymentFixture.PaymentHash.ToUpperInvariant(), Ct));
+    }
+
+    [Fact]
+    public async Task The_first_writer_of_a_hash_wins()
+    {
+        // A payment hash is unique to the BOLT11 minted for one invoice, so a second association for the
+        // same hash cannot be legitimate — including one minted for the same invoice, which is what a plain
+        // retry of a mint event looks like. The first row must survive, not be overwritten, mirroring core's
+        // insert-only AddressInvoices.
+        var index = await CreateIndexAsync();
+        await index.RecordAsync(Entry(invoiceId: InvoiceId), Ct);
+        var original = await index.FindByPaymentHashAsync(PaymentFixture.PaymentHash, Ct);
+        Assert.NotNull(original);
+
+        await index.RecordAsync(Entry(invoiceId: "a-different-invoice"), Ct);
+
+        var after = await index.FindByPaymentHashAsync(PaymentFixture.PaymentHash, Ct);
+        Assert.NotNull(after);
+        Assert.Equal(InvoiceId, after.InvoiceId);
+        Assert.Equal(original.FirstSeenAt, after.FirstSeenAt);
+    }
+}
+
+/// <summary>The contract against the in-memory implementation used by the rest of the suite.</summary>
+public class InMemoryInvoicePaymentHashIndexTests : InvoicePaymentHashIndexContractTests
+{
+    protected override Task<IInvoicePaymentHashIndex> CreateIndexAsync() =>
+        Task.FromResult<IInvoicePaymentHashIndex>(new InMemoryInvoicePaymentHashIndex());
+}
+
+/// <summary>
+/// The same contract against the production EF store and a real Postgres database.
+/// </summary>
+[Trait("Category", "Postgres")]
+[Collection(PostgresTestDatabase.CollectionName)]
+public class PostgresInvoicePaymentHashIndexTests : InvoicePaymentHashIndexContractTests
+{
+    private readonly PostgresTestDatabase _database;
+
+    public PostgresInvoicePaymentHashIndexTests(PostgresTestDatabase database) => _database = database;
+
+    protected override async Task<IInvoicePaymentHashIndex> CreateIndexAsync() =>
+        new EfInvoicePaymentHashIndex(await _database.CreateFactoryAsync());
+}

--- a/BTCPayServer.Plugins.Flint.Tests/SparkInvoicePaymentHashIndexerTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkInvoicePaymentHashIndexerTests.cs
@@ -1,0 +1,168 @@
+using BTCPayServer.Events;
+using BTCPayServer.Logging;
+using BTCPayServer.Payments;
+using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using NBitcoin;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The decision in <see cref="SparkInvoicePaymentHashIndexer"/>: which prompt-mint events become the plugin's
+/// own payment-hash → invoice association.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class is what makes a late payment to a superseded LNURL BOLT11 creditable when the merchant disabled
+/// LUD-21 by hand — the case BTCPay's own <c>AddressInvoices</c> index does not cover, because core writes an
+/// LNURL prompt's hash there only while LUD-21 is on, while <c>InvoiceNewPaymentDetailsEvent</c> fires on
+/// every mint. Driving <see cref="SparkInvoicePaymentHashIndexer.RecordAssociationAsync"/> directly pins the
+/// decision; the wiring from the event aggregator to it is covered by
+/// <see cref="SparkPluginStartupTests"/>, which resolves the hosted service from BTCPay's own container.
+/// </para>
+/// </remarks>
+public class SparkInvoicePaymentHashIndexerTests
+{
+    private const string InvoiceId = "btcpay-invoice-1";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static SparkInvoicePaymentHashIndexer Create(out InMemoryInvoicePaymentHashIndex index)
+    {
+        var logs = new Logs();
+        logs.Configure(NullLoggerFactory.Instance);
+        index = new InMemoryInvoicePaymentHashIndex();
+        return new SparkInvoicePaymentHashIndexer(
+            new BTCPayServer.EventAggregator(logs),
+            index,
+            NullLogger<SparkInvoicePaymentHashIndexer>.Instance);
+    }
+
+    private static PaymentMethodId Pmi(string cryptoCode, PaymentType type) => type.GetPaymentMethodId(cryptoCode);
+
+    private static uint256 Hash() => uint256.Parse(PaymentFixture.PaymentHash);
+
+    [Fact]
+    public async Task An_LNURL_prompt_mint_records_the_association()
+    {
+        // The case this exists for: an LNURL prompt, which BTCPay's own index only covers while LUD-21 is on.
+        var indexer = Create(out var index);
+        await indexer.RecordAssociationAsync(
+            new InvoiceNewPaymentDetailsEvent(
+                InvoiceId,
+                new LNURLPayPaymentMethodDetails { PaymentHash = Hash() },
+                Pmi("BTC", PaymentTypes.LNURL)),
+            Ct);
+
+        var entry = await index.FindByPaymentHashAsync(PaymentFixture.PaymentHash, Ct);
+        Assert.NotNull(entry);
+        Assert.Equal(InvoiceId, entry.InvoiceId);
+        Assert.Equal("BTC-LNURL", entry.PaymentMethodId);
+        Assert.NotEqual(default, entry.FirstSeenAt);
+    }
+
+    [Fact]
+    public async Task A_plain_lightning_prompt_mint_records_the_association()
+    {
+        // A plain checkout prompt: core always indexes this hash itself, so this row is redundant — but the
+        // event carries it too, and recording both rails keeps the index uniform.
+        var indexer = Create(out var index);
+        await indexer.RecordAssociationAsync(
+            new InvoiceNewPaymentDetailsEvent(
+                InvoiceId,
+                new LigthningPaymentPromptDetails { PaymentHash = Hash() },
+                Pmi("BTC", PaymentTypes.LN)),
+            Ct);
+
+        var entry = await index.FindByPaymentHashAsync(PaymentFixture.PaymentHash, Ct);
+        Assert.NotNull(entry);
+        Assert.Equal("BTC-LN", entry.PaymentMethodId);
+    }
+
+    [Fact]
+    public async Task A_prompt_for_another_crypto_is_not_recorded()
+    {
+        // The plugin credits only Bitcoin Lightning payments, so another crypto's prompts are not its business
+        // — and a same-named hash could in principle be minted on two networks without meaning the same thing.
+        var indexer = Create(out var index);
+        await indexer.RecordAssociationAsync(
+            new InvoiceNewPaymentDetailsEvent(
+                InvoiceId,
+                new LigthningPaymentPromptDetails { PaymentHash = Hash() },
+                Pmi("LTC", PaymentTypes.LN)),
+            Ct);
+
+        Assert.Null(await index.FindByPaymentHashAsync(PaymentFixture.PaymentHash, Ct));
+    }
+
+    [Fact]
+    public async Task A_prompt_without_a_payment_hash_yet_is_not_recorded()
+    {
+        // The LNURL request event precedes the mint that gives a prompt its hash; there is nothing to index
+        // until the mint event follows.
+        var indexer = Create(out var index);
+        await indexer.RecordAssociationAsync(
+            new InvoiceNewPaymentDetailsEvent(
+                InvoiceId,
+                new LNURLPayPaymentMethodDetails { PaymentHash = null! },
+                Pmi("BTC", PaymentTypes.LNURL)),
+            Ct);
+
+        Assert.Empty(index.Entries);
+    }
+
+    [Fact]
+    public async Task A_prompt_of_an_unrelated_payment_type_is_not_recorded()
+    {
+        // The details of an on-chain prompt, say, derive from a different base and carry no payment hash.
+        var indexer = Create(out var index);
+        await indexer.RecordAssociationAsync(
+            new InvoiceNewPaymentDetailsEvent(
+                InvoiceId,
+                new object(),
+                Pmi("BTC", PaymentTypes.LNURL)),
+            Ct);
+
+        Assert.Empty(index.Entries);
+    }
+
+    [Fact]
+    public async Task A_failed_index_write_is_swallowed_and_logged_not_thrown()
+    {
+        // A prompt association is not worth unwinding the event-aggregator loop over: for a store with LUD-21
+        // on, core's own index covers the hash anyway, and the next mint of the same invoice re-fires the
+        // event. The base class's loop logs unhandled exceptions and continues, but this method must not even
+        // get to that — it is called from ProcessEvent deliberately.
+        var indexer = Create(out var index);
+        index.FailRecordWith = new InvalidOperationException("db down");
+
+        await indexer.RecordAssociationAsync(
+            new InvoiceNewPaymentDetailsEvent(
+                InvoiceId,
+                new LNURLPayPaymentMethodDetails { PaymentHash = Hash() },
+                Pmi("BTC", PaymentTypes.LNURL)),
+            Ct);
+
+        Assert.Empty(index.Entries);
+    }
+
+    [Fact]
+    public async Task The_stored_hash_is_lower_case()
+    {
+        // The primary key is case-sensitive, and the caller's event could carry the hash in either case.
+        var indexer = Create(out var index);
+        await indexer.RecordAssociationAsync(
+            new InvoiceNewPaymentDetailsEvent(
+                InvoiceId,
+                new LNURLPayPaymentMethodDetails { PaymentHash = uint256.Parse(PaymentFixture.PaymentHash.ToUpperInvariant()) },
+                Pmi("BTC", PaymentTypes.LNURL)),
+            Ct);
+
+        var stored = Assert.Single(index.Entries.Values);
+        Assert.Equal(PaymentFixture.PaymentHash, stored.PaymentHash);
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/SparkPluginStartupTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkPluginStartupTests.cs
@@ -100,6 +100,7 @@ public class SparkPluginStartupTests
             provider => provider.GetServices<IHostedService>().ToList());
 
         Assert.Contains(hostedServices, service => service is SparkService);
+        Assert.Contains(hostedServices, service => service is SparkInvoicePaymentHashIndexer);
     }
 
     /// <summary>
@@ -194,7 +195,9 @@ public class SparkPluginStartupTests
                      typeof(IInvoiceRecordStore),
                      typeof(IOutgoingPaymentStore),
                      typeof(ISweepRecordStore),
-                     typeof(SparkPluginDbContextFactory)
+                     typeof(SparkPluginDbContextFactory),
+                     typeof(IInvoicePaymentHashIndex),
+                     typeof(SparkInvoicePaymentHashIndexer)
                  })
         {
             var resolved = host.Resolve(type.Name, provider => provider.GetRequiredService(type));

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSupersededInvoiceCreditTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSupersededInvoiceCreditTests.cs
@@ -32,6 +32,13 @@ namespace BTCPayServer.Plugins.Flint.Tests;
 /// <see cref="SparkLightningClient"/>, and restarts by actually discarding the service and its in-memory
 /// broadcaster while keeping the database and BTCPay's payment-hash index — the split a real restart makes.
 /// </para>
+/// <para>
+/// <b>The LUD-21-off variant.</b> The same scenario, with one extra twist in the middle: BTCPay writes an
+/// LNURL prompt's payment hash into its own <c>AddressInvoices</c> index only when LUD-21 is enabled, so a
+/// merchant who disables it by hand (the plugin forces it on at setup, but nothing stops them) removes the
+/// LNURL half of the association from core's tables entirely. The plugin's own payment-hash index — written
+/// from every prompt-mint event, LUD-21 or not — is what keeps the superseded BOLT11 attributable after that.
+/// </para>
 /// </remarks>
 public class SparkSupersededInvoiceCreditTests
 {
@@ -123,10 +130,18 @@ public class SparkSupersededInvoiceCreditTests
     }
 
     /// <summary>Mints one invoice through the real client and indexes it the way BTCPay does.</summary>
+    /// <param name="paymentMethodId">The payment method the prompt is minted under.</param>
+    /// <param name="indexInCore">
+    /// Whether core also writes the hash into its own <c>AddressInvoices</c> table — true for a plain
+    /// Lightning prompt, and for an LNURL prompt with LUD-21 on; false for an LNURL prompt minted while the
+    /// merchant disabled LUD-21, which core does not index and the plugin's own index still covers.
+    /// </param>
     private static async Task<LightningInvoice> MintAsync(
         SparkServiceHarness h,
         ILightningClient client,
-        string bolt11)
+        string bolt11,
+        string paymentMethodId = FakeInvoiceCreditGateway.LightningPaymentMethodId,
+        bool indexInCore = true)
     {
         h.Sdk.Clients[StoreId].NextPaymentRequest = bolt11;
         var invoice = await client.CreateInvoice(
@@ -134,8 +149,10 @@ public class SparkSupersededInvoiceCreditTests
 
         // What core's LightningLikePaymentHandler.ConfigurePrompt does immediately after this returns: it
         // writes the payment hash into AddressInvoices against the invoice it is prompting for. Insert-only,
-        // so superseding this BOLT11 later does not remove the row.
-        h.Credits.Mint(invoice.Id, InvoiceId, StoreId);
+        // so superseding this BOLT11 later does not remove the row — except that an LNURL prompt with LUD-21
+        // off is never indexed by core at all, which indexInCore: false models (the plugin's own index is
+        // written regardless, as the real mint event is).
+        h.Credits.Mint(invoice.Id, InvoiceId, StoreId, paymentMethodId, indexInCore);
         return invoice;
     }
 
@@ -212,6 +229,55 @@ public class SparkSupersededInvoiceCreditTests
             // Y *is* the current prompt, so crediting it does fill the prompt's preimage — the ordinary
             // proof-of-payment path, which the superseded case above must not disturb and does not.
             Assert.Equal(PaymentFixture.Preimage, h.Credits.PromptPreimageFor(InvoiceId));
+        }
+        finally
+        {
+            (h ?? first).Dispose();
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task A_superseded_bolt11_minted_while_LUD21_was_off_is_credited_after_a_restart()
+    {
+        // The review finding this pins. BTCPay indexes an LNURL prompt's payment hash into its own
+        // AddressInvoices table only when LUD-21 is enabled; a merchant who disables it by hand (the plugin
+        // forces it on at setup, but nothing stops them) leaves that half of the association unrecorded in
+        // core. The plugin's own payment-hash index, written from the mint event regardless of LUD-21, is what
+        // keeps a superseded BOLT11 attributable after a restart when core's table has no row for it.
+        var (first, paymentKey) = await StartedAsync();
+        SparkServiceHarness? h = null;
+        try
+        {
+            var client = ClientFor(first, paymentKey);
+
+            // X is minted as an LNURL prompt while LUD-21 is off — so core never indexes it — then superseded
+            // by Y under the same setting, and the server restarts with only Y being watched.
+            var x = await MintAsync(
+                first, client, Bolt11X, FakeInvoiceCreditGateway.LnurlPaymentMethodId, indexInCore: false);
+            await client.CancelInvoice(x.Id, Ct);
+            await MintAsync(
+                first, client, Bolt11Y, FakeInvoiceCreditGateway.LnurlPaymentMethodId, indexInCore: false);
+
+            h = first.Restart();
+            await h.Service.StartAsync(CancellationToken.None);
+
+            // And X is paid, after the restart, with nobody watching it.
+            Pay(h, HashX, "recv-x");
+
+            await WaitFor(
+                () => h.Invoices.Records[HashX] is { Status: InvoiceRecordStatus.Paid, CreditedAt: not null },
+                "the payment to the LUD-21-off superseded invoice never reached its BTCPay invoice");
+
+            // Exactly one payment, on the right invoice, with X's own hash and its preimage.
+            var credit = Assert.Single(h.Credits.CreditsFor(InvoiceId));
+            Assert.Equal(HashX, credit.PaymentHash);
+            Assert.Equal(100_000, credit.AmountReceivedMsat);
+            Assert.Equal(PaymentFixture.Preimage, credit.Preimage);
+
+            // The replacement's prompt is untouched, exactly as in the LUD-21-on case: no proof-of-payment for
+            // an invoice the payer never paid.
+            Assert.Equal(HashY, h.Credits.PromptPaymentHashFor(InvoiceId));
+            Assert.Null(h.Credits.PromptPreimageFor(InvoiceId));
         }
         finally
         {

--- a/BTCPayServer.Plugins.Flint/Data/EfInvoicePaymentHashIndex.cs
+++ b/BTCPayServer.Plugins.Flint/Data/EfInvoicePaymentHashIndex.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace BTCPayServer.Plugins.Flint.Data;
+
+/// <summary>
+/// <see cref="IInvoicePaymentHashIndex"/> over the plugin's own Postgres schema.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One short-lived <see cref="SparkPluginDbContext"/> per operation, created from
+/// <see cref="SparkPluginDbContextFactory"/> — the same convention and the same reason as
+/// <see cref="EfInvoiceRecordStore"/>: the writer is called from the event-aggregator loop and the reader
+/// from BTCPay's invoice credit path, neither of which is inside an HTTP request scope.
+/// </para>
+/// <para>
+/// The write is a single <c>INSERT ... ON CONFLICT DO NOTHING</c> statement, for the two reasons every other
+/// statement in this schema is single and unconditional: this context's retrying execution strategy refuses
+/// user-initiated transactions (see <see cref="EfInvoiceRecordStore"/> for the reproduced failure), and the
+/// association is write-once — a hash can never legitimately change invoice — so the database deciding on
+/// conflict is the whole semantics. It mirrors core's <c>UpsertAddressInvoice</c>, which keeps the same table
+/// this one mirrors for the same reason.
+/// </para>
+/// </remarks>
+public class EfInvoicePaymentHashIndex : IInvoicePaymentHashIndex
+{
+    private readonly SparkPluginDbContextFactory _contextFactory;
+
+    public EfInvoicePaymentHashIndex(SparkPluginDbContextFactory contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+
+    public async Task RecordAsync(InvoicePaymentHash entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentException.ThrowIfNullOrEmpty(entry.PaymentHash);
+        ArgumentException.ThrowIfNullOrEmpty(entry.InvoiceId);
+        ArgumentException.ThrowIfNullOrEmpty(entry.PaymentMethodId);
+
+        await using var context = _contextFactory.CreateContext();
+
+        // Normalised here rather than trusted from the caller: the event carries the hash in whatever case
+        // core produced it, and this table's primary key is case-sensitive.
+        var paymentHash = entry.PaymentHash.ToLowerInvariant();
+        var firstSeenAt = entry.FirstSeenAt == default ? DateTimeOffset.UtcNow : entry.FirstSeenAt;
+
+        await context.Database.ExecuteSqlInterpolatedAsync(
+            $"""
+             INSERT INTO "{Constants.DatabaseSchema}"."InvoicePaymentHashes"
+                 ("PaymentHash", "InvoiceId", "PaymentMethodId", "FirstSeenAt")
+             VALUES ({paymentHash}, {entry.InvoiceId}, {entry.PaymentMethodId}, {firstSeenAt})
+             ON CONFLICT ("PaymentHash") DO NOTHING
+             """,
+            cancellationToken);
+    }
+
+    public async Task<InvoicePaymentHash?> FindByPaymentHashAsync(
+        string paymentHash,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(paymentHash);
+
+        await using var context = _contextFactory.CreateContext();
+        return await context.InvoicePaymentHashes
+            .AsNoTracking()
+            .FirstOrDefaultAsync(h => h.PaymentHash == paymentHash.ToLowerInvariant(), cancellationToken);
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Data/EfInvoicePaymentHashIndex.cs
+++ b/BTCPayServer.Plugins.Flint/Data/EfInvoicePaymentHashIndex.cs
@@ -47,13 +47,20 @@ public class EfInvoicePaymentHashIndex : IInvoicePaymentHashIndex
         var paymentHash = entry.PaymentHash.ToLowerInvariant();
         var firstSeenAt = entry.FirstSeenAt == default ? DateTimeOffset.UtcNow : entry.FirstSeenAt;
 
-        await context.Database.ExecuteSqlInterpolatedAsync(
-            $"""
-             INSERT INTO "{Constants.DatabaseSchema}"."InvoicePaymentHashes"
-                 ("PaymentHash", "InvoiceId", "PaymentMethodId", "FirstSeenAt")
-             VALUES ({paymentHash}, {entry.InvoiceId}, {entry.PaymentMethodId}, {firstSeenAt})
-             ON CONFLICT ("PaymentHash") DO NOTHING
-             """,
+        // ExecuteSqlRawAsync, deliberately, not the interpolated overload: a FormattableString turns every
+        // {hole} into a bind parameter, and an identifier cannot be bound — the generated INSERT would read
+        // relation "@p0"."InvoicePaymentHashes" where Postgres expects the schema name as a literal (the
+        // Postgres contract suite caught exactly that). The identifier is therefore concatenated as text and
+        // only the values ride as parameters.
+        var table = "\"" + Constants.DatabaseSchema + "\".\"InvoicePaymentHashes\"";
+        var sql =
+            "INSERT INTO " + table + " (\"PaymentHash\", \"InvoiceId\", \"PaymentMethodId\", \"FirstSeenAt\") "
+            + "VALUES ({0}, {1}, {2}, {3}) ON CONFLICT (\"PaymentHash\") DO NOTHING";
+        // The IEnumerable<object> overload, not the params one, so the trailing cancellation token is taken
+        // as the token rather than as a fifth parameter value.
+        await context.Database.ExecuteSqlRawAsync(
+            sql,
+            new object[] { paymentHash, entry.InvoiceId, entry.PaymentMethodId, firstSeenAt },
             cancellationToken);
     }
 

--- a/BTCPayServer.Plugins.Flint/Data/IInvoicePaymentHashIndex.cs
+++ b/BTCPayServer.Plugins.Flint/Data/IInvoicePaymentHashIndex.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BTCPayServer.Plugins.Flint.Data;
+
+/// <summary>
+/// The plugin's own payment-hash → BTCPay invoice association, written from core's
+/// <c>InvoiceNewPaymentDetailsEvent</c> and read as the credit gate­way's fallback.
+/// </summary>
+/// <remarks>
+/// <para>
+/// BTCPay's own <c>AddressInvoices</c> table is the authority for the association, and
+/// <c>IInvoiceCreditGateway.FindByPaymentHashAsync</c> checks it first. This index exists because that table
+/// misses the case this plugin has to handle: core records an LNURL prompt's payment hash there only when
+/// LUD-21 is enabled, so a store whose merchant disabled LUD-21 by hand leaves the LNURL half of the
+/// association unrecorded in core, and a late payment to a superseded LNURL BOLT11 after a restart would
+/// settle in this plugin's records with nothing to tie it to its BTCPay invoice. The event that feeds this
+/// index fires on every prompt mint regardless of LUD-21.
+/// </para>
+/// <para>
+/// Write-once per hash, read by payment hash only — a payment hash is unique to the BOLT11 minted for one
+/// invoice, so there is no update path and no store-scoped key, exactly as in core's insert-only
+/// <c>AddressInvoices</c>.
+/// </para>
+/// </remarks>
+public interface IInvoicePaymentHashIndex
+{
+    /// <summary>
+    /// Records that a BOLT11 with this payment hash was minted for a BTCPay invoice. Idempotent: the first
+    /// write for a hash wins, exactly like the core table this mirrors.
+    /// </summary>
+    /// <param name="entry">
+    /// With <see cref="InvoicePaymentHash.PaymentHash"/> lower-case hex, which the implementation enforces by
+    /// normalising it before storing.
+    /// </param>
+    Task RecordAsync(InvoicePaymentHash entry, CancellationToken cancellationToken = default);
+
+    /// <summary>Finds the invoice a payment hash was minted for, or null when it was never observed.</summary>
+    /// <param name="paymentHash">Lower-case hex, as <see cref="InvoicePaymentHash.PaymentHash"/> is stored.</param>
+    Task<InvoicePaymentHash?> FindByPaymentHashAsync(
+        string paymentHash,
+        CancellationToken cancellationToken = default);
+}

--- a/BTCPayServer.Plugins.Flint/Data/InvoicePaymentHash.cs
+++ b/BTCPayServer.Plugins.Flint/Data/InvoicePaymentHash.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace BTCPayServer.Plugins.Flint.Data;
+
+/// <summary>
+/// The plugin's own record of which BTCPay invoice a Lightning payment hash was minted for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the same association BTCPay keeps in its <c>AddressInvoices</c> table — insert-only, keyed on the
+/// payment hash of the prompt as it was minted, so a superseded BOLT11 keeps pointing at the invoice it was
+/// issued for. This table is a <em>second copy</em> of the half of that association this plugin credits
+/// against, kept for one reason: BTCPay writes an <c>AddressInvoices</c> row for an LNURL prompt only when
+/// LUD-21 is enabled, so a merchant who disables LUD-21 by hand removes the LNURL half of the association
+/// from core's tables. The plugin still observes every prompt mint through core's
+/// <c>InvoiceNewPaymentDetailsEvent</c> — which fires whether or not LUD-21 is on — and records it here, so
+/// a late payment to a superseded LNURL BOLT11 remains attributable after a restart even when the merchant
+/// turned LUD-21 off. See <see cref="Services.SparkInvoicePaymentHashIndexer"/> for the writer and
+/// <c>BTCPayInvoiceCreditGateway.FindByPaymentHashAsync</c> for the reader.
+/// </para>
+/// <para>
+/// The row is written once per prompt and never updated: a payment hash is unique to the BOLT11 minted for
+/// one invoice, so the same hash can never map to a different invoice. Re-quoting an LNURL invoice replaces
+/// the prompt but mints a <em>new</em> hash, which is a new row.
+/// </para>
+/// <para>
+/// All hex values are stored lower-cased and must be normalised on the way in; BTCPay is not consistent
+/// about case and the primary-key comparison is case-sensitive.
+/// </para>
+/// </remarks>
+public class InvoicePaymentHash
+{
+    /// <summary>The payment hash of the BOLT11 a prompt offered, lower-case hex. Primary key.</summary>
+    public string PaymentHash { get; set; } = null!;
+
+    /// <summary>The BTCPay invoice the BOLT11 was minted for.</summary>
+    public string InvoiceId { get; set; } = null!;
+
+    /// <summary>
+    /// The payment method the prompt was minted under, as its string form (<c>BTC-LN</c> or
+    /// <c>BTC-LNURL</c>) — the form BTCPay's credit gateway parses back on the way in.
+    /// </summary>
+    public string PaymentMethodId { get; set; } = null!;
+
+    /// <summary>When this association was first observed.</summary>
+    public DateTimeOffset FirstSeenAt { get; set; }
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        $"{PaymentMethodId}: {PaymentHash} was minted for BTCPay invoice {InvoiceId}";
+}

--- a/BTCPayServer.Plugins.Flint/Data/SparkPluginDbContext.cs
+++ b/BTCPayServer.Plugins.Flint/Data/SparkPluginDbContext.cs
@@ -13,6 +13,7 @@ public class SparkPluginDbContext : DbContext
     public DbSet<InvoiceRecord> InvoiceRecords { get; set; } = null!;
     public DbSet<OutgoingPaymentRecord> OutgoingPayments { get; set; } = null!;
     public DbSet<SweepRecord> SweepRecords { get; set; } = null!;
+    public DbSet<InvoicePaymentHash> InvoicePaymentHashes { get; set; } = null!;
 
     public SparkPluginDbContext(DbContextOptions<SparkPluginDbContext> options) : base(options)
     {
@@ -56,6 +57,17 @@ public class SparkPluginDbContext : DbContext
             entity.HasIndex(record => new { record.StoreId, record.CreatedAt });
             // Every pass of the sweep engine opens by looking for this store's in-flight rows.
             entity.HasIndex(record => new { record.StoreId, record.Status });
+        });
+
+        modelBuilder.Entity<InvoicePaymentHash>(entity =>
+        {
+            // The payment hash is the primary key — the read path is a point read on it, exactly as in core's
+            // AddressInvoices. No store-scoped key: a hash is unique to one invoice, and the reader never
+            // filters by store.
+            entity.HasKey(record => record.PaymentHash);
+            // The table name is pinned so the raw SQL in EfInvoicePaymentHashIndex.RecordAsync names the same
+            // table EF creates, rather than relying on both ending up at EF's default pluralisation.
+            entity.ToTable("InvoicePaymentHashes");
         });
     }
 }

--- a/BTCPayServer.Plugins.Flint/Migrations/20260826151813_InvoicePaymentHashes.Designer.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260826151813_InvoicePaymentHashes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BTCPayServer.Plugins.Flint.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BTCPayServer.Plugins.Flint.Migrations
 {
     [DbContext(typeof(SparkPluginDbContext))]
-    partial class SparkPluginDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260826151813_InvoicePaymentHashes")]
+    partial class InvoicePaymentHashes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BTCPayServer.Plugins.Flint/Migrations/20260826151813_InvoicePaymentHashes.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260826151813_InvoicePaymentHashes.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Plugins.Flint.Migrations
+{
+    /// <inheritdoc />
+    public partial class InvoicePaymentHashes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InvoicePaymentHashes",
+                schema: "BTCPayServer.Plugins.Flint",
+                columns: table => new
+                {
+                    PaymentHash = table.Column<string>(type: "text", nullable: false),
+                    InvoiceId = table.Column<string>(type: "text", nullable: false),
+                    PaymentMethodId = table.Column<string>(type: "text", nullable: false),
+                    FirstSeenAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InvoicePaymentHashes", x => x.PaymentHash);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "InvoicePaymentHashes",
+                schema: "BTCPayServer.Plugins.Flint");
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/BTCPayInvoiceCreditGateway.cs
+++ b/BTCPayServer.Plugins.Flint/Services/BTCPayInvoiceCreditGateway.cs
@@ -7,6 +7,7 @@ using BTCPayServer.Events;
 using BTCPayServer.Lightning;
 using BTCPayServer.Payments;
 using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Plugins.Flint.Data;
 using BTCPayServer.Services.Invoices;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
@@ -81,8 +82,10 @@ public sealed class BTCPayInvoiceCreditGateway : IInvoiceCreditGateway
     /// <c>BTC-LN</c> first because a plain Lightning checkout always indexes the hash there. <c>BTC-LNURL</c>
     /// second because LNURL prompts index it only when LUD-21 is enabled — which this plugin forces on when it
     /// provisions a store (<see cref="BTCPayStoreLightningConfigStore.SetAsync"/>), so for a Flint store both
-    /// rails are covered. A merchant who turned LUD-21 off by hand loses the LNURL half of this, and the
-    /// credit for such a payment is reported as unresolvable rather than guessed at.
+    /// rails are covered. There is no third entry: an LNURL prompt minted while LUD-21 was off by hand is
+    /// indexed by neither core table at all — the plugin's own copy of the mint-time association
+    /// (<see cref="IInvoicePaymentHashIndex"/>) is what <see cref="FindByPaymentHashAsync"/> falls back to
+    /// for it.
     /// </remarks>
     internal static readonly PaymentMethodId[] CreditablePaymentMethods =
     [
@@ -95,23 +98,30 @@ public sealed class BTCPayInvoiceCreditGateway : IInvoiceCreditGateway
     private readonly Func<PaymentMethodHandlerDictionary> _handlers;
     private readonly EventAggregator _eventAggregator;
     private readonly ILogger<BTCPayInvoiceCreditGateway> _logger;
+    private readonly IInvoicePaymentHashIndex _index;
 
     /// <param name="paymentService">
     /// Resolved on first use rather than injected, and that is load-bearing: see the remarks on this class.
     /// </param>
     /// <param name="handlers">Deferred for the same reason, and shared with the rest of the plugin.</param>
+    /// <param name="index">
+    /// The plugin's own payment-hash → invoice association, consulted when core's <c>AddressInvoices</c> has
+    /// no row for the hash — the LUD-21-off LNURL case. See <see cref="FindByPaymentHashAsync"/>.
+    /// </param>
     public BTCPayInvoiceCreditGateway(
         InvoiceRepository invoiceRepository,
         Func<PaymentService> paymentService,
         Func<PaymentMethodHandlerDictionary> handlers,
         EventAggregator eventAggregator,
-        ILogger<BTCPayInvoiceCreditGateway> logger)
+        ILogger<BTCPayInvoiceCreditGateway> logger,
+        IInvoicePaymentHashIndex index)
     {
         _invoiceRepository = invoiceRepository;
         _paymentService = paymentService;
         _handlers = handlers;
         _eventAggregator = eventAggregator;
         _logger = logger;
+        _index = index;
     }
 
     /// <inheritdoc />
@@ -145,7 +155,35 @@ public sealed class BTCPayInvoiceCreditGateway : IInvoiceCreditGateway
                 invoice.Id, invoice.StoreId, paymentMethodId.ToString(), alreadyHasPayment);
         }
 
-        return null;
+        // Core's own table has no row for this hash. That is the ordinary answer for a BOLT11 that was never
+        // minted for a BTCPay invoice — but it is also exactly what an LNURL prompt minted while LUD-21 was
+        // disabled looks like, because core writes an LNURL prompt's payment hash into AddressInvoices only
+        // when LUD-21 is enabled. The plugin's own index (<see cref="IInvoicePaymentHashIndex"/>), kept from
+        // the mint-time event and independent of that setting, is the fallback that restores the
+        // association. It resolves the same way the primary path does — a point read on the invoice gets the
+        // authoritative store and the payment rows — so the two paths disagree only about the source of the
+        // invoice id. The store is re-read from core rather than trusted from the index, which is what the
+        // creditor's cross-store refusal compares.
+        var entry = await _index
+            .FindByPaymentHashAsync(paymentHash, cancellationToken)
+            .ConfigureAwait(false);
+        if (entry is null)
+            return null;
+
+        var indexedInvoice = await _invoiceRepository.GetInvoice(entry.InvoiceId).ConfigureAwait(false);
+        if (indexedInvoice is null)
+            return null;
+
+        // The hash has no AddressInvoices row, so a payment for it can only exist here if core's own listener
+        // recorded one against the invoice's prompt while it was watching — the ordinary (non-superseded)
+        // LUD-21-off case. Same "primary key already taken" question as the loop above.
+        var indexedPaymentMethodId = PaymentMethodId.Parse(entry.PaymentMethodId);
+        var alreadyRecorded = indexedInvoice
+            .GetPayments(false)
+            .Any(p => p.Id == paymentHash && p.PaymentMethodId == indexedPaymentMethodId);
+
+        return new SparkInvoiceCreditMatch(
+            indexedInvoice.Id, indexedInvoice.StoreId, entry.PaymentMethodId, alreadyRecorded);
     }
 
     /// <inheritdoc />

--- a/BTCPayServer.Plugins.Flint/Services/SparkInvoicePaymentHashIndexer.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkInvoicePaymentHashIndexer.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Events;
+using BTCPayServer.HostedServices;
+using BTCPayServer.Payments.Lightning;
+using BTCPayServer.Plugins.Flint.Data;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>
+/// Keeps the plugin's own payment-hash → BTCPay invoice association, from core's prompt-mint event.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this exists alongside BTCPay's own index.</b> The credit gateway
+/// (<c>BTCPayInvoiceCreditGateway.FindByPaymentHashAsync</c>) resolves which invoice a settled payment
+/// belongs to through BTCPay's <c>AddressInvoices</c> table — the authority, and insert-only, so a
+/// superseded BOLT11 keeps pointing at the invoice it was minted for. But core writes an LNURL prompt's
+/// payment hash into that table only when LUD-21 is enabled (<c>UILNURLController</c>), so a store whose
+/// merchant disabled LUD-21 by hand has the LNURL half of the association unrecorded in core, and a late
+/// payment to a superseded LNURL BOLT11 after a restart would reach the Spark wallet with nothing left
+/// tying it to its BTCPay invoice. The event this class subscribes to —
+/// <see cref="InvoiceNewPaymentDetailsEvent"/> — is published by core on every prompt mint regardless of
+/// LUD-21, so it is the observation point that restores the association independently of that setting.
+/// </para>
+/// <para>
+/// <b>Scope.</b> Only Bitcoin Lightning prompts are recorded (<c>BTC-LN</c> and <c>BTC-LNURL</c>): those
+/// are the only payment methods this plugin can credit, and the only ones whose hash the gateway asks
+/// about. Prompts without a payment hash yet (the LNURL <em>request</em> event, which precedes the mint
+/// that gives a prompt its hash) are skipped; the mint event that follows carries the hash.
+/// </para>
+/// <para>
+/// <b>Best-effort, and why that is the right bound.</b> A failed write is logged and swallowed — it must
+/// not unwind the event-aggregator loop. This index is a fallback over core's own table, not the primary
+/// authority: for a store with LUD-21 on (which this plugin forces when it provisions a store), core's
+/// <c>AddressInvoices</c> row covers the same hashes and this index is redundant. It exists for the
+/// LUD-21-off store, and for that store a row can only be written if this plugin was running when the
+/// prompt was minted — a prompt minted during a plugin outage leaves no observer, and is reported as
+/// unattributable exactly as before.
+/// </para>
+/// </remarks>
+public class SparkInvoicePaymentHashIndexer : EventHostedServiceBase
+{
+    private readonly IInvoicePaymentHashIndex _index;
+    private readonly ILogger<SparkInvoicePaymentHashIndexer> _logger;
+
+    public SparkInvoicePaymentHashIndexer(
+        EventAggregator eventAggregator,
+        IInvoicePaymentHashIndex index,
+        ILogger<SparkInvoicePaymentHashIndexer> logger) : base(eventAggregator, logger)
+    {
+        _index = index;
+        _logger = logger;
+    }
+
+    protected override void SubscribeToEvents()
+    {
+        // The mint-time association, published by core whether or not LUD-21 is enabled — which is the whole
+        // point, see the class remarks.
+        Subscribe<InvoiceNewPaymentDetailsEvent>();
+        base.SubscribeToEvents();
+    }
+
+    protected override Task ProcessEvent(object evt, CancellationToken cancellationToken)
+    {
+        if (evt is InvoiceNewPaymentDetailsEvent prompt)
+            return RecordAssociationAsync(prompt, cancellationToken);
+        return base.ProcessEvent(evt, cancellationToken);
+    }
+
+    /// <summary>
+    /// Records the payment hash → invoice association carried by one prompt-mint event. Never throws.
+    /// </summary>
+    /// <remarks>
+    /// Public so the decision — which events are recorded, and that a database failure cannot unwind the
+    /// caller — is unit-testable without driving the whole hosted service. Never throws for the reason the
+    /// base class's loop logs-and-continues: a prompt association is not worth derailing the event
+    /// aggregator over, and the gateway falls back to this index only when core's own table has nothing.
+    /// </remarks>
+    public async Task RecordAssociationAsync(
+        InvoiceNewPaymentDetailsEvent prompt,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(prompt);
+
+        try
+        {
+            // Only the payment methods this plugin can credit, and only prompts that carry a hash yet. The
+            // LNURL request event (UILNURLController, before the first mint) has no hash; the mint event
+            // that follows does.
+            if (!BTCPayInvoiceCreditGateway.CreditablePaymentMethods.Contains(prompt.PaymentMethodId)
+                || prompt.Details is not LigthningPaymentPromptDetails { PaymentHash: not null } details)
+            {
+                return;
+            }
+
+            await _index.RecordAsync(
+                new InvoicePaymentHash
+                {
+                    PaymentHash = details.PaymentHash.ToString().ToLowerInvariant(),
+                    InvoiceId = prompt.InvoiceId,
+                    PaymentMethodId = prompt.PaymentMethodId.ToString()
+                },
+                cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Best-effort by design — see the class remarks for why this bound is correct. The hash's
+            // invoice remains resolvable through core's own table whenever LUD-21 is on, which is why the
+            // store provisioning forces it on.
+            _logger.LogWarning(ex,
+                "Could not record which BTCPay invoice minted the prompt for an event on invoice "
+                + "{InvoiceId}; a late payment to its BOLT11 will be attributable through this plugin's own "
+                + "index only if LUD-21 is enabled",
+                prompt.InvoiceId);
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/SparkPlugin.cs
+++ b/BTCPayServer.Plugins.Flint/SparkPlugin.cs
@@ -78,6 +78,16 @@ public class SparkPlugin : BaseBTCPayServerPlugin
         services.AddSingleton<IInvoiceCreditGateway, BTCPayInvoiceCreditGateway>();
         services.AddSingleton<SparkInvoiceCreditor>();
 
+        // The plugin's own payment-hash → invoice association, kept from every prompt-mint event regardless
+        // of LUD-21. BTCPay indexes an LNURL prompt's hash into its AddressInvoices table only while LUD-21
+        // is enabled, so a store whose merchant disabled it by hand would otherwise leave a late payment to a
+        // superseded LNURL BOLT11 unattributable after a restart; this index is the fallback the gateway
+        // consults when core's own table has nothing (see SparkInvoicePaymentHashIndexer for the writer).
+        services.AddSingleton<IInvoicePaymentHashIndex, EfInvoicePaymentHashIndex>();
+        services.AddSingleton<SparkInvoicePaymentHashIndexer>();
+        services.AddSingleton<IHostedService>(provider =>
+            provider.GetRequiredService<SparkInvoicePaymentHashIndexer>());
+
         // The single path from "a Spark receive happened" to "a BTCPay invoice is paid", shared by the event
         // consumer, BTCPay's GetInvoice lookup and the reconciliation task.
         services.AddSingleton<SparkSettlementReconciler>();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ All notable changes to this plugin are recorded here. The format follows
   be reconciled against them. The same applies to a BTCPay invoice with no payment prompt able to hold the
   payment. Nothing is reported twice and nothing is retried forever.
 
+- **The payment-hash → invoice association no longer depends on LUD-21.** The routing described above
+  found the invoice through BTCPay's own payment-hash index (`AddressInvoices`), and BTCPay writes an
+  LNURL prompt's hash into that index only while LUD-21 is enabled — so a merchant who disabled LUD-21
+  by hand (the plugin forces it on at store setup, but nothing stops them) was back to the original
+  gap: a late payment to a superseded LNURL bolt11 after a restart reached the Spark wallet with no
+  BTCPay invoice credited. The plugin now keeps its own copy of the mint-time association from every
+  prompt-mint event, which BTCPay publishes whether or not LUD-21 is on, and the credit gateway falls
+  back to it whenever core's own index has no row. The one case left unattributable is a prompt minted
+  while the plugin itself was not running.
+
 ## [0.1.5.4] — 2026-08-24
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -50,12 +50,11 @@ What a server needs to *run* this plugin:
 
 Requires **BTCPay Server 2.4.1 or newer** on a host the Breez SDK has native libraries for — see
 [Requirements](#requirements) before you start, because Alpine-based images are not among them.
+**From the [official BTCPay plugin store](https://plugin-builder.btcpayserver.org/public/plugins/flint)**:
+in your BTCPay Server, go to **Server settings → Plugins**, find **Flint**, and install it. BTCPay
+restarts itself to complete the install.
 
-**From the BTCPay plugin registry** *(once this plugin is listed there — it is not yet)*: in your BTCPay
-Server, go to **Server settings → Plugins**, find **Flint**, and install it. BTCPay restarts itself to
-complete the install.
-
-**From a release artifact**, which is the route available today: download
+**From a release artifact**, for servers without access to the plugin store: download
 `BTCPayServer.Plugins.Flint.btcpay` from the [releases page](https://github.com/sethforprivacy/flint/releases),
 then **Server settings → Plugins → Upload plugin** and select the file. BTCPay restarts to complete the
 install. Every release artifact is signed; the releases page carries `SHA256SUMS` and the commands to

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -20,8 +20,10 @@
   after a restart it is never re-added, because that set is rebuilt from the prompts that exist now.
   So the plugin does not depend on notifying a listener. Every settlement is also written straight
   onto the BTCPay invoice the BOLT11 was minted for, found through BTCPay's own payment-hash index
-  (`AddressInvoices`, which is insert-only and keeps the mint-time association forever). The plugin
-  records whether that credit landed and retries it on every reconciliation pass until it does, which
+  (`AddressInvoices`, which is insert-only and keeps the mint-time association forever) — and, for the
+  hashes that index misses, through the plugin's own copy of the mint-time association kept from every
+  prompt-mint event (LUD-21 off). The plugin records whether that credit landed and retries it on
+  every reconciliation pass until it does, which
   also covers a payment that arrived while the server was down, a listening session that fell too far
   behind, and a crash between recording the settlement and telling BTCPay. The retry does not need the
   store's Spark wallet to be connected — crediting touches only BTCPay's own tables — so a store whose
@@ -45,10 +47,14 @@
     This is very close to unreachable in practice — nothing in BTCPay deletes a prompt — and is listed
     because if it ever does happen the money is in the wallet, the invoice cannot be credited
     automatically, and only a human can reconcile it.
-  - A store whose LNURL prompts have **LUD-21 disabled by hand** loses the LNURL half of the index:
-    BTCPay only records the payment hash of an LNURL prompt when LUD-21 is on, which is why this plugin
-    turns it on when it provisions a store. Such a payment is reported as unattributable rather than
-    guessed at.
+  - An LNURL prompt whose mint happened while this plugin was **not running**. The plugin keeps its own
+    copy of the mint-time association (payment hash → BTCPay invoice) from every prompt-mint event, which
+    BTCPay publishes whether or not LUD-21 is enabled — so a merchant who disables LUD-21 by hand does not
+    lose the LNURL half of the index any more. The remaining gap is narrower and is about outages rather
+    than settings: a prompt minted while the plugin itself was not running has no observer, and a late
+    payment to it is reported as unattributable rather than guessed at. (The plugin forces LUD-21 on when
+    it provisions a store; while that setting is on, core's own index covers the hash even through an
+    outage.)
 
   One thing the plugin does *not* keep from BTCPay's own listener is worth naming as a non-limitation:
   the preimage is written onto the payment prompt as well as onto the payment, so LNURL


### PR DESCRIPTION
## Summary
Closes the review finding that a late payment to a superseded LNURL BOLT11 could still evade the BTCPay invoice when the merchant disabled LUD-21 by hand.

BTCPay writes an LNURL prompt's payment hash into its `AddressInvoices` index only while LUD-21 is enabled. The plugin now keeps its own copy of the mint-time association from every prompt-mint event (`InvoiceNewPaymentDetailsEvent` — published regardless of LUD-21) and the credit gateway falls back to it when core's index has no row.

## Changes
- New write-once `InvoicePaymentHashes` table (plugin's own Postgres schema) + migration.
- `SparkInvoicePaymentHashIndexer` — hosted service observing prompt-mint events.
- `BTCPayInvoiceCreditGateway.FindByPaymentHashAsync` — plugin-index fallback after core's `AddressInvoices` misses.
- End-to-end test: superseded BOLT11 minted with LUD-21 off, restart, late payment → credited exactly once.
- Also: install docs now use the official BTCPay plugin-store listing (live at plugin-builder.btcpayserver.org).

## Verification
- Full suite: 1288 tests, 0 failures (including 106 opt-in skips).
- `dotnet ef migrations script` generates valid SQL.
- Migration chain clean; `EfMigrations` opt-in build output cleaned.

## Not covered by the suite (unchanged convention)
The real gateway's core-DB path still lacks unit coverage (needs Postgres); composition is covered via the service harness.

## Pre-publish validation
Artifact will be deployed to the btcpay-dev and btcpay-stg instances and checked against a real BTCPay host plus a real Postgres migration before release.
