### PR TITLE
chore(deps): Bump Breez.Sdk.Spark from 0.22.3 to 0.23.0

### DIFF
--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -109,7 +109,7 @@
       The package carries ~200 MB of native libraries for linux-x64/arm64, osx-x64/arm64,
       win-x64/x86. There is no linux-musl (Alpine) or win-arm64 payload.
     -->
-    <PackageReference Include="Breez.Sdk.Spark" Version="0.22.3" />
+    <PackageReference Include="Breez.Sdk.Spark" Version="0.23.0" />
   </ItemGroup>
 
   <!--

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkSdkClient.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkSdkClient.cs
@@ -115,6 +115,12 @@ public sealed class SparkSdkClient : ISparkSdkClient
             expirySecs,
             // paymentHash: null lets the SSP pick, which means it owns the preimage and claims the
             // HTLC for us. Supplying our own would make this a hold invoice we must claim manually.
+            null,
+            // receiverIdentityPublicKey: null since the SDK 0.23.0 binding change. The new field routes a
+            // minted BOLT11 to another Spark identity; passing null (the documented "absent" encoding)
+            // preserves the pre-0.23.0 behaviour of crediting the connected wallet, which is what every
+            // LNURL prompt here needs. A connected-wallet invoice whose key we set would be a hold invoice
+            // nobody can claim.
             null);
 
         var response = await _sdk.ReceivePayment(new ReceivePaymentRequest(method)).ConfigureAwait(false);


### PR DESCRIPTION
Stacked on #40 (base: `flint-lud21-independent-hash-index`) so the release can carry both the LUD-21 fixes and this SDK bump.

## What changed
- `Breez.Sdk.Spark` 0.22.3 → 0.23.0
- `ReceivePaymentMethod.Bolt11Invoice` gained a **required** `receiverIdentityPublicKey` constructor parameter (breez/spark-sdk#1032 — "support BOLT11 invoices for external Spark recipients"). It is a binding-level breaking change: existing callers must pass an absent key. The plugin now passes `null`, which upstream documents as preserving the pre-0.23.0 behaviour of crediting the **connected wallet** — exactly what every LNURL receive here needs. A connected-wallet invoice with a key set would be a hold invoice nobody could claim.

## Everything else in 0.23.0 is additive for this plugin
- Instant (0-conf) deposit claims (`ClaimDepositRequest.maxInstantFeeBps`, `Config.maxInstantDepositClaimFeeBps`): default off, plugin's claims behave as before.
- `DepositInfo` gains `refundTx`/`instantClaimStatus`; existing fields (incl. `refundTxId`, `claimError`) unchanged.
- `Payment`, `PaymentStatus`, send/quote/config shapes the plugin maps compile unchanged.
- New `SdkEvent` variants fall into the adapter's existing `SparkEventKind.Other` arm.
- #1057's new "requested amount must equal invoice amount" send validation cannot trip: the plugin only supplies an explicit amount for amountless invoices.

## Verification
- Full solution build clean (plugin + tests).
- Test suite: 1288 total, 0 failed, 1182 passed, 106 opt-in skips (Postgres/funded-regtest/integration, same as base).
- Note: local SDK 10.0.302's Razor compiler rejects the existing `LNPaymentMethodSetupTabhead.cshtml` `<script>`+`@Safe.Json` pattern; 10.0.400 (what CI resolves for `10.0.x`) compiles it. Pre-existing upstream regression in the 302 patch, not caused by this bump.