### PR TITLE
Release 1.0.1

### DIFF
--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -45,7 +45,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this plugin are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] — 2026-08-26
+
+### Changed
+
+- **The setup page now tells a tenant whose store is not on their own server who holds their seed.**
+  On a shared or public-registration instance, the store's Spark recovery phrase is stored encrypted
+  on the server, and whoever operates the server can decrypt it and spend the store's Lightning
+  funds. The setup page previously framed the stored copy as a recovery fact ("unreadable without
+  this server's data-protection keys") — the wrong side of the truth about an operator — and now says
+  plainly, before a seed is created or imported, that the server operator is a custodian, with a
+  stronger warning for a store manager who is not a server admin. The same disclosure is on the
+  Greenfield provisioning endpoint and in SECURITY.md, the README trust model and the trust-model
+  document.
+
 ## [1.0.0] — 2026-08-26
 
 ### Security
@@ -594,3 +608,4 @@ signet), the unrotated `sdk.log`, and the one SDK error classification with no a
 
 [0.1.0]: https://github.com/sethforprivacy/flint/releases/tag/v0.1.0
 [1.0.0]: https://github.com/sethforprivacy/flint/releases/tag/v1.0.0
+[1.0.1]: https://github.com/sethforprivacy/flint/releases/tag/v1.0.1


### PR DESCRIPTION
Cutting **v1.0.1** (patch): ships the multi-tenant seed-custody warning from #43/#45.

- Version bump \`1.0.0\` → \`1.0.1\`, CHANGELOG head \`[1.0.1] — 2026-08-26\`.
- \`PluginVersionTests\` green.
- package.yml will build + upload the artifact and publish the GitHub Release from the \`v1.0.1\` tag after merge.