### PR TITLE
Fix line breaks in release notes template

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -30,15 +30,8 @@ writes it with a single space between hash and filename. GNU `sha256sum -c` acce
 
 ## Installing
 
-**Server settings → Plugins**, find **Flint** in the plugin store
-([official listing](https://plugin-builder.btcpayserver.org/public/plugins/flint)), and install it.
-BTCPay restarts itself to finish.
+**Server settings → Plugins**, find **Flint** in the plugin store ([official listing](https://plugin-builder.btcpayserver.org/public/plugins/flint)), and install it. BTCPay restarts itself to finish.
 
-Alternatively, **Server settings → Plugins → Upload plugin**, and select
-`BTCPayServer.Plugins.Flint.btcpay`. BTCPay restarts itself to finish. Both routes require BTCPay Server
-2.4.1 or newer, on a non-Alpine host.
+Alternatively, **Server settings → Plugins → Upload plugin**, and select `BTCPayServer.Plugins.Flint.btcpay`. BTCPay restarts itself to finish. Both routes require BTCPay Server 2.4.1 or newer, on a non-Alpine host.
 
-Read [CHANGELOG.md](https://github.com/__REPO__/blob/__TAG__/CHANGELOG.md) for what is in this
-release and how far it has actually been proven, and the
-[trust model](https://github.com/__REPO__/blob/__TAG__/docs/trust-model.md), before you put money
-through it.
+Read the [CHANGELOG](https://github.com/__REPO__/blob/__TAG__/CHANGELOG.md) for what is in this release and how far it has actually been proven, and the [trust model](https://github.com/__REPO__/blob/__TAG__/docs/trust-model.md), before you put money through it.


### PR DESCRIPTION
The release page's Installing/trust paragraphs rendered mid-sentence line breaks (v1.0.0 and v1.0.1 both shipped them). Each paragraph is now a single flowing line; both published releases were repaired with `gh release edit`.