### PR TITLE
Strip packaged native payload; share reconciliation scans; cache status probe

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -123,6 +123,22 @@ jobs:
           fi
           echo "path=$target_dir" >> "$GITHUB_OUTPUT"
 
+
+      # Strip the DWARF debug info and symbol tables Breez ships inside its linux .so files
+      # (and the fat symbol tables in the osx dylibs, though those ship as-is from a linux runner:
+      # GNU strip cannot rewrite Mach-O). ~100 MB of the 196 MB runtimes payload is never-mapped
+      # debug data; see the header of the script for the full trade, the measured numbers, and the
+      # toolchain fallbacks. Idempotent, and it fails the build loudly if an ELF cannot be stripped.
+      - name: Strip debug info from native payloads
+        run: |
+          set -euo pipefail
+          # The runner is x86-64, so host strip covers linux-x64; the aarch64 cross-tool covers
+          # linux-arm64. Without it the script's docker fallback works too, but pays an apt-get
+          # per file inside a container.
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq binutils-aarch64-linux-gnu
+          ./scripts/strip-native-payloads.sh "${{ steps.build-dir.outputs.path }}"
+
       - name: Run PluginPacker
         env:
           PLUGIN_DIR: ${{ steps.build-dir.outputs.path }}

--- a/BTCPayServer.Plugins.Flint.Tests/SparkLogBridgeTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkLogBridgeTests.cs
@@ -2,6 +2,7 @@ using Breez.Sdk.Spark;
 using BTCPayServer.Plugins.Flint.Sdk;
 using BTCPayServer.Plugins.Flint.Tests.Fakes;
 using NBitcoin;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using BitcoinNetwork = NBitcoin.Network;
 
@@ -336,5 +337,56 @@ public class SparkLogBridgeTests
         var entry = Assert.Single(log.Lines);
         var marker = "spark: ";
         return entry[(entry.IndexOf(marker, StringComparison.Ordinal) + marker.Length)..];
+    }
+
+    /// <summary>
+    /// The cost check, and its redaction corollary: a line the logger would discard must not be paid for
+    /// (five scrub regexes on an SDK callback thread), and the lines that ARE emitted must still scrub —
+    /// the gate must not become a way to skip redaction for anything that actually reaches the log.
+    /// </summary>
+    [Fact]
+    public void Lines_below_the_effective_level_are_dropped_before_the_scrub()
+    {
+        var log = new ThresholdLogger(LogLevel.Warning);
+        var bridge = new SparkLogBridge(log);
+
+        // SDK "info" → Information, "debug" → Debug, "trace" → Trace: all below the threshold.
+        bridge.Log(new LogEntry("sync completed", "info"));
+        bridge.Log(new LogEntry("dumping payment row with preimage abc", "debug"));
+        bridge.Log(new LogEntry("graphql session_token: deadbeef", "trace"));
+        Assert.Empty(log.Lines);
+
+        // "warn" stays Warning, and "error" maps DOWN to Warning — both at or above the threshold, so
+        // both are forwarded, and the secret among them is scrubbed on the way.
+        bridge.Log(new LogEntry("retrying connect", "warn"));
+        bridge.Log(new LogEntry("session_token: deadbeef", "error"));
+        Assert.Equal(2, log.Lines.Count);
+        Assert.Contains("retrying connect", log.AllText);
+        Assert.DoesNotContain("deadbeef", log.AllText);
+        Assert.Contains(SparkLogScrubber.Redacted, log.AllText);
+    }
+
+    private sealed class ThresholdLogger(LogLevel minimum) : ILogger
+    {
+        private readonly List<string> _lines = [];
+
+        public IReadOnlyList<string> Lines => _lines;
+        public string AllText => string.Join('\n', _lines);
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= minimum;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) => _lines.Add(formatter(state, exception));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkNetworkStatusProbeTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkNetworkStatusProbeTests.cs
@@ -1,19 +1,29 @@
 using BTCPayServer.Plugins.Flint.Sdk;
 using BTCPayServer.Plugins.Flint.Tests.Fakes;
 using Xunit;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace BTCPayServer.Plugins.Flint.Tests;
 
 /// <summary>
-/// The probe's contract: it renders a status page, so it must never throw and never hang.
+/// Two contracts on one class: the probe must never throw and never hang (a status page depends on it),
+/// and its third-party round trip must be shared across stores, not multiplied per store.
 /// </summary>
 /// <remarks>
-/// The live call is covered by the regtest integration suite. What is worth pinning here is the behaviour the
-/// status page depends on — that an unreachable or slow third-party status endpoint degrades to "unknown" rather
-/// than 500ing the page — plus the classification, which decides whether the page shows green or amber.
+/// <para>
+/// The never-throw tests run against the real static SDK call. Where the native library loads it performs a
+/// network call and returns something; where it does not, it returns null. Either is a pass — what must not
+/// happen is an exception reaching the status action.
+/// </para>
+/// <para>
+/// The cache tests drive the probe seam with a fake clock, because the behaviour worth pinning is the cache
+/// policy — call counts and TTL boundaries — not the SDK call itself, which the plugin cannot fake.
+/// </para>
 /// </remarks>
 public class SparkNetworkStatusProbeTests
 {
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
     [Fact]
     public async Task A_failing_probe_reports_unknown_rather_than_throwing()
     {
@@ -53,5 +63,144 @@ public class SparkNetworkStatusProbeTests
         var reported = new SparkNetworkStatus(status, DateTimeOffset.UnixEpoch);
 
         Assert.Equal(expected, reported.IsOperational);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Cache semantics (probe seam + fake clock).
+    // ---------------------------------------------------------------------------------------------
+
+    private static SparkNetworkStatus Operational() =>
+        new("Operational", new DateTimeOffset(2026, 8, 26, 0, 0, 0, TimeSpan.Zero));
+
+    private static SparkNetworkStatus Degraded() =>
+        new("Degraded", new DateTimeOffset(2026, 8, 25, 0, 0, 0, TimeSpan.Zero));
+
+    private static SparkNetworkStatusProbe Create(
+        Func<CancellationToken, Task<SparkNetworkStatus?>> probe,
+        Func<DateTimeOffset> clock) =>
+        new(NullLogger<SparkNetworkStatusProbe>.Instance, (_, ct) => probe(ct), clock);
+
+    private sealed class FakeClock
+    {
+        public DateTimeOffset Now = new(2026, 8, 26, 12, 0, 0, TimeSpan.Zero);
+        public DateTimeOffset UtcNow() => Now;
+        public void Advance(TimeSpan by) => Now = Now.Add(by);
+    }
+
+    [Fact]
+    public async Task A_success_is_reused_within_its_ttl_without_re_probing()
+    {
+        var clock = new FakeClock();
+        var calls = 0;
+        var probe = Create(async _ => { calls++; return Operational(); }, clock.UtcNow);
+
+        var first = await probe.TryGetAsync(Ct);
+        clock.Advance(TimeSpan.FromSeconds(30));
+        var second = await probe.TryGetAsync(Ct);
+
+        Assert.NotNull(first);
+        Assert.Equal(first, second);
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public async Task A_success_is_re_probed_once_its_ttl_expires()
+    {
+        var clock = new FakeClock();
+        var calls = 0;
+        var probe = Create(async _ => { calls++; return calls == 1 ? Operational() : Degraded(); }, clock.UtcNow);
+
+        Assert.Equal("Operational", (await probe.TryGetAsync(Ct))!.Status);
+        clock.Advance(SparkNetworkStatusProbe.SuccessTtl + TimeSpan.FromSeconds(1));
+
+        var second = await probe.TryGetAsync(Ct);
+        Assert.Equal(2, calls);
+        Assert.Equal("Degraded", second!.Status);
+    }
+
+    [Fact]
+    public async Task A_failure_is_backed_off_shorter_than_a_success_is_cached()
+    {
+        var clock = new FakeClock();
+        var calls = 0;
+        var probe = Create(async _ =>
+        {
+            calls++;
+            return calls == 1 ? null : Operational();
+        }, clock.UtcNow);
+
+        Assert.Null(await probe.TryGetAsync(Ct));          // failure caches a null for RetryTtl
+
+        clock.Advance(TimeSpan.FromSeconds(5));
+        Assert.Null(await probe.TryGetAsync(Ct));          // still within the retry backoff
+        Assert.Equal(1, calls);
+
+        clock.Advance(SparkNetworkStatusProbe.RetryTtl);   // past it — and NOT yet past SuccessTtl,
+                                                           // so a retry does not have to wait out the
+                                                           // success window
+        var recovered = await probe.TryGetAsync(Ct);
+        Assert.Equal(2, calls);
+        Assert.Equal("Operational", recovered!.Status);
+    }
+
+    [Fact]
+    public async Task Concurrent_callers_share_one_probe_round_trip()
+    {
+        var clock = new FakeClock();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var probe = Create(async _ =>
+        {
+            calls++;
+            await gate.Task;
+            return Operational();
+        }, clock.UtcNow);
+
+        var first = probe.TryGetAsync(Ct);
+        while (Volatile.Read(ref calls) == 0)
+            await Task.Yield();
+        var second = probe.TryGetAsync(Ct);               // arrives mid-probe; waits at the gate
+
+        gate.SetResult();
+        var results = await Task.WhenAll(first, second);
+
+        Assert.Equal(1, calls);
+        Assert.Equal(results[0], results[1]);
+        Assert.Equal("Operational", results[0]!.Status);
+    }
+
+    [Fact]
+    public async Task A_stale_success_is_served_while_a_refresh_is_in_flight()
+    {
+        // The documented degrade: a caller that cannot get through the gate — here because its request
+        // is cancelled while queueing — leaves with the previous cache rather than hanging or throwing.
+        // (The bounded real-time timeout takes the same `return _cached` branch; testing that would just
+        // spend the full 5 s deadline.)
+        var clock = new FakeClock();
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = 0;
+        var probe = Create(async _ =>
+        {
+            calls++;
+            if (calls == 1)
+                return Operational();
+            await gate.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            return Degraded();
+        }, clock.UtcNow);
+
+        var cached = await probe.TryGetAsync(Ct);
+        clock.Advance(SparkNetworkStatusProbe.SuccessTtl + TimeSpan.FromSeconds(1));
+
+        var refresh = probe.TryGetAsync(Ct);              // first caller: probes, blocks here
+        while (Volatile.Read(ref calls) < 2)
+            await Task.Yield();
+
+        using var queuer = new CancellationTokenSource(200);
+        var served = await probe.TryGetAsync(queuer.Token);   // cancelled at the gate → previous cache
+        Assert.Equal(cached, served);
+
+        gate.SetResult();
+        var refreshed = await refresh;
+        Assert.Equal("Degraded", refreshed!.Status);      // the blocked probe still completes and refreshes
     }
 }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkSettlementReconcilerTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkSettlementReconcilerTests.cs
@@ -492,6 +492,116 @@ public class SparkSettlementReconcilerTests
     }
 
     [Fact]
+    public async Task Reconciling_a_store_scans_shared_history_once_for_many_unpaid_invoices()
+    {
+        // The cost the shared sweep exists to remove: five unpaid invoices with no recorded id used to mean
+        // five full history scans per pass, every minute, on a store with no incoming traffic whatsoever.
+        // One drained shared scan now answers all five with a single query.
+        var (reconciler, store, _) = Create();
+        for (var i = 0; i < 5; i++)
+            Seed(store, hash: i.ToString("x64"));
+
+        var sdk = new FakeSparkSdkClient();
+        var settled = await reconciler.ReconcileStoreAsync(StoreId, sdk, Ct);
+
+        Assert.Equal(0, settled);
+        Assert.Single(sdk.ListQueries);
+    }
+
+    [Fact]
+    public async Task Reconciling_a_store_settles_from_the_shared_history_page_without_another_scan()
+    {
+        // The payment arrived inside the one page the shared sweep fetched. Neither the hit nor the two
+        // drained misses may spend a further query — the whole batching win, pinned.
+        var (reconciler, store, _) = Create();
+        var first = new string('a', 64);
+        var second = new string('b', 64);
+        var third = new string('c', 64);
+        Seed(store, first);
+        Seed(store, second);
+        Seed(store, third);
+        var sdk = new FakeSparkSdkClient().Seed(Receive(hash: second));
+
+        var settled = await reconciler.ReconcileStoreAsync(StoreId, sdk, Ct);
+
+        Assert.Equal(1, settled);
+        Assert.Equal(InvoiceRecordStatus.Paid, store.Records[second].Status);
+        Assert.Equal(InvoiceRecordStatus.Unpaid, store.Records[first].Status);
+        Assert.Equal(InvoiceRecordStatus.Unpaid, store.Records[third].Status);
+        Assert.Single(sdk.ListQueries);
+        // The shared query must keep the exact filter shape the per-record scan used, or the sweep could
+        // quietly start settling on rows the old path would have ignored.
+        Assert.True(sdk.ListQueries.All(q =>
+            q.CompletedOnly && q.Direction == SparkPaymentDirection.Receive));
+    }
+
+    [Fact]
+    public async Task Reconciling_a_store_falls_back_to_a_per_invoice_scan_when_the_shared_scan_caps_out()
+    {
+        // A capped shared scan is not evidence of absence. The page holds an old invoice (which anchors the
+        // shared window) and a newer one whose payment the shared window buries: the fake orders history by
+        // insertion, so seeding the target FIRST under 500 receives that live inside the shared window but
+        // before the target invoice's own, plus 60 inside both windows, puts the target at position 560 of
+        // the newest-first shared scan — past the 500-payment cap, so the sweep returns undrained and the
+        // target must not be judged by its miss. The target's own scan, anchored to its own creation time,
+        // cuts those 500 out of its window entirely and finds the payment on its second page.
+        var (reconciler, store, _) = Create();
+        var olderHash = new string('a', 64);
+        var targetHash = new string('b', 64);
+        Seed(store, olderHash, createdAt: DateTimeOffset.UtcNow.AddHours(-3));
+        Seed(store, targetHash, createdAt: DateTimeOffset.UtcNow.AddMinutes(-30));
+
+        var sdk = new FakeSparkSdkClient();
+        sdk.Seed(Receive(hash: targetHash, sdkPaymentId: "target",
+            timestamp: DateTimeOffset.UtcNow.AddMinutes(-25)));
+        for (var i = 0; i < 500; i++)
+        {
+            sdk.Seed(Receive(
+                hash: i.ToString("x64"),
+                sdkPaymentId: $"filler-old-{i}",
+                timestamp: DateTimeOffset.UtcNow.AddMinutes(-180)));
+        }
+        for (var i = 0; i < 60; i++)
+        {
+            sdk.Seed(Receive(
+                hash: (1000 + i).ToString("x64"),
+                sdkPaymentId: $"filler-new-{i}",
+                timestamp: DateTimeOffset.UtcNow.AddMinutes(-35 - i / 10.0)));
+        }
+
+        var settled = await reconciler.ReconcileStoreAsync(StoreId, sdk, Ct);
+
+        Assert.Equal(1, settled);
+        Assert.Equal(InvoiceRecordStatus.Paid, store.Records[targetHash].Status);
+        Assert.Equal(InvoiceRecordStatus.Unpaid, store.Records[olderHash].Status);
+        // The sweep's ten capped pages alone already fill MaxPaymentPages; anything more is proof the
+        // undrained miss was not taken as absence and the per-invoice fallback ran.
+        Assert.True(sdk.ListQueries.Count > 10,
+            $"the capped sweep must not silence the per-invoice fallback (got {sdk.ListQueries.Count})");
+    }
+
+    [Fact]
+    public async Task Reconciling_a_store_skips_the_shared_scan_when_every_invoice_has_an_SDK_payment_id()
+    {
+        // The shared scan exists only for records the point lookup cannot serve. Running it anyway would be
+        // the batching spending money it saves nobody.
+        var (reconciler, store, _) = Create();
+        var first = new string('a', 64);
+        var second = new string('b', 64);
+        Seed(store, first, sdkPaymentId: "sdk-a");
+        Seed(store, second, sdkPaymentId: "sdk-b");
+        var sdk = new FakeSparkSdkClient();
+        sdk.Seed(Receive(hash: first, sdkPaymentId: "sdk-a"));
+        sdk.Seed(Receive(hash: second, sdkPaymentId: "sdk-b"));
+
+        var settled = await reconciler.ReconcileStoreAsync(StoreId, sdk, Ct);
+
+        Assert.Equal(2, settled);
+        Assert.Empty(sdk.ListQueries);
+        Assert.Equal(2, sdk.GetPaymentCalls.Count);
+    }
+
+    [Fact]
     public async Task Finding_a_receive_falls_back_to_a_scan_when_the_recorded_id_resolves_to_nothing()
     {
         // The recorded id came from a PaymentPending event. If the SDK has since replaced or re-keyed that row,

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkLogBridge.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkLogBridge.cs
@@ -45,10 +45,14 @@ public sealed class SparkLogBridge : Logger
             };
             // Downgraded by one step relative to the Rust level: the SDK is chatty at "info" and its
             // notion of severity is about the SDK, not about the merchant's BTCPay server.
-            _logger.Log(
-                level == LogLevel.Error ? LogLevel.Warning : level,
-                "spark: {Line}",
-                SparkLogScrubber.Scrub(l.line));
+            var effective = level == LogLevel.Error ? LogLevel.Warning : level;
+            // Checked before the scrub, not inside ILogger: SparkLogScrubber.Scrub runs five full-line
+            // regex passes, and at Warning-and-above that work would be thrown away per discarded line
+            // on an SDK-owned callback thread. A skipped line is never emitted, so redaction coverage
+            // is exactly the set of lines that reach the log.
+            if (!_logger.IsEnabled(effective))
+                return;
+            _logger.Log(effective, "spark: {Line}", SparkLogScrubber.Scrub(l.line));
         }
         catch
         {

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkNetworkStatusProbe.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkNetworkStatusProbe.cs
@@ -16,6 +16,20 @@ namespace BTCPayServer.Plugins.Flint.Sdk;
 /// slow or unreachable status endpoint must degrade to "unknown" rather than hang the page or 500 it.
 /// </para>
 /// <para>
+/// The result is served from a process-wide cache (<see cref="SuccessTtl"/> for a status, shorter
+/// <see cref="RetryTtl"/> after a failure). <c>GetSparkStatus</c> describes the Spark network as a whole —
+/// it is a process-global static carrying the provider's own <c>lastUpdated</c> — so re-running it per store
+/// per request multiplies an identical third-party round trip across every polled store and every concurrent
+/// viewer, which is request amplification against a provider this plugin does not own. The single-flight gate
+/// additionally folds concurrent first calls into one round trip. The cached value is diagnostic, never
+/// financial: no settlement, sweep or credit decision reads it.
+/// </para>
+/// <para>
+/// The 5-second page budget is per caller, not per probe: a caller that arrives while another is mid-probe
+/// spends at most the same total wait, and leaves with the previous cache (possibly null, possibly stale) if
+/// even that expires. The in-flight probe itself keeps running under its own deadline and refreshes the cache.
+/// </para>
+/// <para>
 /// Loading the native library is a side effect of the first SDK call in the process (~450 ms). In practice
 /// <c>SparkService.StartAsync</c> has already paid that cost by initialising logging, so this is not the
 /// first call; the deadline covers the case where it is.
@@ -29,23 +43,103 @@ public sealed class SparkNetworkStatusProbe : ISparkNetworkStatusProbe
     /// </summary>
     private static readonly TimeSpan Deadline = TimeSpan.FromSeconds(5);
 
+    /// <summary>
+    /// How long a successful read is reused across stores and callers. Well below the cadence at which a
+    /// network-status outage becomes operationally interesting, and above any plausible page-poll rate.
+    /// </summary>
+    internal static readonly TimeSpan SuccessTtl = TimeSpan.FromSeconds(45);
+
+    /// <summary>
+    /// How long a failed read is held before trying again. Short enough that a status page opened after an
+    /// outage ends shows recovery promptly; long enough that a dead endpoint is not re-struck per request.
+    /// </summary>
+    internal static readonly TimeSpan RetryTtl = TimeSpan.FromSeconds(10);
+
     private readonly ILogger<SparkNetworkStatusProbe> _logger;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly Func<ILogger, CancellationToken, Task<SparkNetworkStatus?>> _probe;
+    private readonly Func<DateTimeOffset> _utcNow;
+
+    // Cache fields are touched from many request threads without a lock around the read. Reference and
+    // 64-bit-tick access is atomic on the runtimes BTCPay ships; tearing would at worst serve one probe's
+    // status with another's expiry tick, which degrades to an early re-probe or a brief stale read — both
+    // benign for a diagnostic. The gate serialises writes.
+    private SparkNetworkStatus? _cached;
+    private long _expiresUtcTicks;
 
     public SparkNetworkStatusProbe(ILogger<SparkNetworkStatusProbe> logger)
+        : this(logger, static (lg, ct) => ProbeCoreAsync(lg, ct), static () => DateTimeOffset.UtcNow)
+    {
+    }
+
+    /// <summary>
+    /// Test seam: the SDK call and the clock, so cache semantics are testable without a network.
+    /// </summary>
+    internal SparkNetworkStatusProbe(
+        ILogger<SparkNetworkStatusProbe> logger,
+        Func<ILogger, CancellationToken, Task<SparkNetworkStatus?>> probe,
+        Func<DateTimeOffset> utcNow)
     {
         _logger = logger;
+        _probe = probe;
+        _utcNow = utcNow;
     }
 
     /// <inheritdoc />
     public async Task<SparkNetworkStatus?> TryGetAsync(CancellationToken cancellationToken = default)
     {
+        if (_utcNow() < FromTicks(Volatile.Read(ref _expiresUtcTicks)))
+            return _cached;
+
+        // Bounded wait, own-budget: never more than Deadline for the whole call, and never a throw on
+        // timeout — the previous cache (or null) is the honest answer for a caller that could not get in.
+        var entered = false;
+        try
+        {
+            entered = await _gate.WaitAsync(Deadline, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return _cached;
+        }
+
+        if (!entered)
+            return _cached;
+
+        try
+        {
+            // Double-check under the gate: a probe launched between the fast-path read and the gate is
+            // exactly what single-flight means — reuse its result, do not re-probe.
+            if (_utcNow() < FromTicks(Volatile.Read(ref _expiresUtcTicks)))
+                return _cached;
+
+            var status = await _probe(_logger, cancellationToken).ConfigureAwait(false);
+            _cached = status;
+            // Volatile.Write after the value write: a reader that sees the new expiry also sees the new
+            // status (release ordering), never the reverse.
+            Volatile.Write(ref _expiresUtcTicks, _utcNow().Add(status is null ? RetryTtl : SuccessTtl).UtcTicks);
+            return status;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private static DateTimeOffset FromTicks(long ticks) => new(ticks, TimeSpan.Zero);
+
+    private static async Task<SparkNetworkStatus?> ProbeCoreAsync(
+        ILogger logger, CancellationToken cancellationToken)
+    {
+        // Kept static and exception-free by the same rules as before: the deadline degrades a slow
+        // endpoint to null, and the catch is the last line of defence against a throw from the FFI boundary.
         try
         {
             var status = await SparkDeadline
                 .OrNullAsync(
                     BreezSdkSparkMethods.GetSparkStatus(),
                     Deadline,
-                    () => _logger.LogDebug(
+                    () => logger.LogDebug(
                         "Reading the Spark network status exceeded {Seconds}s", Deadline.TotalSeconds),
                     cancellationToken)
                 .ConfigureAwait(false);
@@ -61,10 +155,11 @@ public sealed class SparkNetworkStatusProbe : ISparkNetworkStatusProbe
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Could not read the Spark network status");
+            logger.LogDebug(ex, "Could not read the Spark network status");
             return null;
         }
     }
+
 
     private static DateTimeOffset ToTimestamp(ulong unixSeconds)
     {

--- a/BTCPayServer.Plugins.Flint/Services/SparkSettlementReconciler.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkSettlementReconciler.cs
@@ -35,6 +35,17 @@ public sealed record SparkReconciliationTarget(string StoreId, ISparkSdkClient S
 /// invoice that expires unpaid while the sats sit in the merchant's wallet.
 /// </para>
 /// <para>
+/// <b>A quiet store would pay for its own scan, so a pass shares one across an invoice page.</b> Each
+/// invoice with no recorded SDK payment id costs up to ten pages of payment history per pass, every
+/// minute, and a store with five waiting invoices and no incoming traffic pays that five times over to
+/// find nothing. So the pass runs one scan for the whole page — anchored to its oldest unpaid invoice and
+/// indexed by payment hash — and settles records straight out of the index. What the index does not name
+/// counts as unpaid <em>only</em> when the scan saw a short page: ten full pages prove only that more
+/// history was there to read, not that the payment is absent, so on a capped or failed sweep every miss
+/// falls back to the per-invoice scan that ran before the batching existed. Coverage is unchanged; only
+/// the cost is shared.
+/// </para>
+/// <para>
 /// <b>Settling is not the same as crediting, and both happen here.</b> Notifying BTCPay's listener only works
 /// while that listener is watching the BOLT11 in question, and it watches only each invoice's <em>current</em>
 /// payment prompt — so a superseded BOLT11 paid after a restart settles here and reaches no BTCPay invoice.
@@ -319,10 +330,27 @@ public class SparkSettlementReconciler
     /// <summary>
     /// Resolves one invoice against the SDK and settles it if it has been paid. Returns the current record.
     /// </summary>
-    public async Task<InvoiceRecord> ResolveAsync(
+    public Task<InvoiceRecord> ResolveAsync(
         ISparkSdkClient sdk,
         InvoiceRecord record,
         CancellationToken cancellationToken = default)
+        => ResolveAsync(sdk, record, sweep: null, cancellationToken);
+
+    /// <summary>
+    /// The batched form of <see cref="ResolveAsync(ISparkSdkClient,InvoiceRecord,CancellationToken)"/>: one
+    /// invoice resolved against a payment sweep already run for its page.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="sweep"/> is the only difference, and it only ever spends less: a record the index
+    /// names settles exactly as one a scan would have found, and a record it does not name is passed over
+    /// only when the sweep drained. A null sweep — every caller outside the store walk, and every batch the
+    /// sweep declined or failed to run — is the pre-batching path, unchanged.
+    /// </remarks>
+    internal async Task<InvoiceRecord> ResolveAsync(
+        ISparkSdkClient sdk,
+        InvoiceRecord record,
+        ReceiveSweep? sweep,
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(record);
         // Paid is terminal. A cancelled invoice is still scanned: on Spark it remains payable, so a late
@@ -330,12 +358,155 @@ public class SparkSettlementReconciler
         if (record.Status is InvoiceRecordStatus.Paid)
             return record;
 
-        var payment = await FindReceiveAsync(sdk, record, cancellationToken).ConfigureAwait(false);
+        SparkPayment? payment;
+        if (record.SdkPaymentId is null && sweep is { } shared)
+        {
+            if (shared.Index.TryGetValue(record.PaymentHash, out var swept))
+            {
+                payment = swept;
+            }
+            else if (shared.Drained)
+            {
+                // The shared scan walked its window to the end without naming this hash — the same evidence
+                // a per-invoice scan stopping at a short page used to produce, bought with one query for the
+                // whole page instead of one per invoice. Absent Drained this would be the only way batching
+                // can lose a settlement, which is why Drained exists.
+                return record;
+            }
+            else
+            {
+                payment = await FindReceiveAsync(sdk, record, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            // A recorded id still needs its point lookup — the shared scan neither covers GetPayment nor is
+            // run for a page of such records — and a record without a sweep gets exactly the scan it always
+            // got.
+            payment = await FindReceiveAsync(sdk, record, cancellationToken).ConfigureAwait(false);
+        }
+
         if (payment is not { Status: SparkPaymentStatus.Completed, PaymentHash: not null })
             return record;
 
         var result = await ApplyAsync(record.StoreId, payment, cancellationToken).ConfigureAwait(false);
         return result.Record ?? record;
+    }
+
+    /// <summary>
+    /// The result of one shared history scan for a page of invoices: every completed receive it saw, keyed
+    /// by payment hash, and whether it reached the end of the window.
+    /// </summary>
+    /// <remarks>
+    /// <c>Drained</c> carries the whole epistemic weight. "Not in the index" means "not paid" only if the
+    /// scan drained its window; a run of full pages stopped by the cap proves only that more history was
+    /// there. Settling from <see cref="Index"/> is safe either way — the hash matched — but treating a miss
+    /// as absence is not, and that miss is the only thing a non-drained sweep could otherwise be used for.
+    /// </remarks>
+    internal sealed record ReceiveSweep(Dictionary<string, SparkPayment> Index, bool Drained);
+
+    /// <summary>
+    /// Scans the payment history once for a whole page of invoices, or returns null when there is nothing
+    /// for the scan to serve or the scan itself failed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Anchored to the oldest invoice on the page still needing a scan, so the shared window contains every
+    /// per-invoice window it replaces; the paging, the deadline and the cap are the ones
+    /// <see cref="FindReceiveAsync"/> would have paid per record, paid once instead.
+    /// </para>
+    /// <para>
+    /// A failure is a null, not a throw: the sweep is a cost optimisation layered over the old path, and
+    /// losing it must cost the pass its batching and not its invoices. A null sweep sends every record down
+    /// exactly the route it took before the sweep existed.
+    /// </para>
+    /// </remarks>
+    private async Task<ReceiveSweep?> BuildReceiveSweepAsync(
+        string storeId,
+        ISparkSdkClient sdk,
+        IReadOnlyList<InvoiceRecord> page,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Only a record with no id to look up by needs the scan; running one for a page where every
+            // record has an id would spend the shared query to serve nobody.
+            DateTimeOffset? anchor = null;
+            var awaiting = 0;
+            foreach (var record in page)
+            {
+                if (record.SdkPaymentId is not null)
+                    continue;
+                awaiting++;
+                if (anchor is null || record.CreatedAt < anchor)
+                    anchor = record.CreatedAt;
+            }
+
+            if (anchor is null)
+                return null;
+
+            var index = new Dictionary<string, SparkPayment>(StringComparer.Ordinal);
+            for (var pageIndex = 0; pageIndex < MaxPaymentPages; pageIndex++)
+            {
+                var payments = await SparkDeadline.OrNullAsync(
+                        sdk.ListPaymentsAsync(
+                            new SparkListPaymentsQuery(
+                                SparkPaymentDirection.Receive,
+                                CompletedOnly: true,
+                                // Anchored to the oldest invoice still waiting, so the shared window holds
+                                // every window the per-invoice scans would each have walked.
+                                From: anchor.Value - ReconciliationSlack,
+                                Offset: pageIndex * PaymentPageSize,
+                                Limit: PaymentPageSize),
+                            cancellationToken),
+                        Constants.SdkCallDeadline,
+                        () => _logger.LogWarning(
+                            "Store {StoreId}: the shared Spark payment scan for {Invoices} invoice(s) "
+                            + "exceeded {Seconds}s",
+                            storeId, awaiting, Constants.SdkCallDeadline.TotalSeconds),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                // Null means the deadline passed. Whatever this index holds, what it omits now proves
+                // nothing, so no invoice may be concluded unpaid from it.
+                if (payments is null)
+                    return new ReceiveSweep(index, Drained: false);
+
+                foreach (var payment in payments)
+                {
+                    // The same shape the per-invoice scan matched on: a hashless row or a send leg settles
+                    // nothing. First writer under a hash wins, because paging walks newest-first and that is
+                    // the row a per-invoice scan's FirstOrDefault would have returned.
+                    if (payment.PaymentHash is not { } hash
+                        || payment.Direction is not SparkPaymentDirection.Receive)
+                    {
+                        continue;
+                    }
+
+                    index.TryAdd(hash, payment);
+                }
+
+                // A short page is the end of the window, and the only thing that lets a miss in this index
+                // stand for "not paid".
+                if (payments.Count < PaymentPageSize)
+                    return new ReceiveSweep(index, Drained: true);
+            }
+
+            _logger.LogWarning(
+                "Store {StoreId}: the shared scan of Spark payments for {Invoices} invoice(s) hit the "
+                + "{Count}-payment cap without draining the window; anything it did not name falls back to "
+                + "its own scan. If this repeats, the wallet's history has outgrown the scan window",
+                storeId, awaiting, MaxPaymentPages * PaymentPageSize);
+            return new ReceiveSweep(index, Drained: false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Store {StoreId}: the shared Spark payment scan failed ({Reason}); this pass reconciles "
+                + "invoice by invoice, as it did before the scan was shared",
+                storeId, SparkErrors.Describe(ex));
+            return null;
+        }
     }
 
     /// <summary>
@@ -490,6 +661,13 @@ public class SparkSettlementReconciler
             if (page.Count == 0)
                 break;
 
+            // One history scan for the whole page rather than one per unpaid invoice: this walk used to
+            // spend up to ten pages of SDK paging per record lacking an id, every minute, mostly to prove
+            // nobody had paid. A null sweep — nothing to share, or the sweep itself failed — leaves every
+            // record on the pre-batching path.
+            var sweep = await BuildReceiveSweepAsync(storeId, sdk, page, cancellationToken)
+                .ConfigureAwait(false);
+
             foreach (var record in page)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -499,7 +677,7 @@ public class SparkSettlementReconciler
 
                 try
                 {
-                    var resolved = await ResolveAsync(sdk, record, cancellationToken).ConfigureAwait(false);
+                    var resolved = await ResolveAsync(sdk, record, sweep, cancellationToken).ConfigureAwait(false);
                     if (resolved.Status is InvoiceRecordStatus.Paid)
                         settled++;
                 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to this plugin are recorded here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Changed
+
+- **The packaged plugin is ~23% smaller: linux native libraries are stripped at packaging time.**
+  Breez ships its Rust `.so` files with ~28 MB of DWARF debug info apiece — sections that are never
+  mapped at run time, but that nonetheless travel inside every `.btcpay`. Packaging now runs
+  `scripts/strip-native-payloads.sh` between the build and PluginPacker: 196 MB of runtimes become
+  ~100 MB, and the artifact from 67.4 MB to 51.7 MB. The osx dylibs are additionally stripped when
+  packaging happens on a macOS host (GNU strip cannot rewrite Mach-O; the step warns and ships them
+  as-is on linux runners), and the Windows DLLs are untouched — they carry no strippable debug
+  data. The costs are stated where the fix lives: symbolised native backtraces on linux are lost
+  (Rust panic *messages* survive), and the shipped hashes no longer match Breez's upstream
+  byte-for-byte — the script prints each pre-strip upstream sha256, MIT permits the modification,
+  and the Sigstore attestation still binds the artifact to this repository and commit.
+- **A store's reconciliation pass shares one Spark payment-history scan across an invoice page.**
+  Each invoice with no recorded SDK payment id previously ran its own paged history scan — up to
+  ten pages — every pass. A quiet store with five waiting invoices and no traffic paid five full
+  scans per minute to find nothing. The pass now runs one scan per page anchored to its oldest
+  unpaid invoice and settles records from a payment-hash index; a miss counts as unpaid only when
+  the shared scan reached the end of its window, and anything else (a capped or failed scan, a
+  record with a recorded id) keeps its own scan, bit-for-bit the path it took before. Settlement
+  coverage is unchanged; the number of SDK calls per idle store per minute drops from one per
+  unpaid invoice to one.
+- **The Spark network status is read once per process, not once per store per request.** It is a
+  process-global provider status; every configured store's status page and every Greenfield status
+  call re-struck the identical third-party request. Successful reads are now reused for 45 seconds
+  and failed reads back off for 10, with concurrent first callers folded into one round trip. The
+  cached value is diagnostic only — no settlement, sweep or credit decision reads it.
+- **SDK log lines below the operator's effective log level no longer pay for redaction.** The
+  scrubber's five regex passes run only on lines that will actually be emitted. Lines that are
+  emitted scrub exactly as before.
+
 ## [1.0.1] — 2026-08-26
 
 ### Changed

--- a/docs/ci-and-releases.md
+++ b/docs/ci-and-releases.md
@@ -25,6 +25,17 @@
   and `SHA256SUMS`) as a workflow artifact, and attaches it to the corresponding GitHub Release when
   triggered by a tag. On a tag it also refuses to build if the tag disagrees with the version in the
   csproj, so a `v0.2.0` tag on a 0.1.0 tree fails rather than producing a mislabelled release.
+  - **The linux native payload is stripped at packaging time** by
+    [`scripts/strip-native-payloads.sh`](../scripts/strip-native-payloads.sh): Breez ships its Rust
+    `.so` files with ~28 MB of DWARF debug info apiece — never-mapped data that nonetheless travels
+    inside every `.btcpay` — and stripping takes the packaged runtimes from ~196 MB to ~100 MB
+    uncompressed. The trade (symbolised native backtraces on linux, and hashes that no longer match
+    Breez's upstream byte-for-byte — hence the upstream sha256 each strip prints) is argued in the
+    script's header, which is also the local pre-release recipe: run `dotnet build -c Release`, run
+    the script against the output directory, then `PluginPacker` by hand. The step is idempotent and
+    fails the package loudly if an ELF cannot be stripped; the osx dylibs are stripped on macOS
+    hosts only (GNU strip cannot rewrite Mach-O) and the Windows DLLs are not touched at all,
+    because they carry no strippable debug data.
   - **Artifacts are signed with keyless Sigstore build provenance**
     (`actions/attest-build-provenance`), not a maintainer GPG key: there is no long-lived key for
     anyone to generate, store, lose or leak, and the attestation binds the artifact's digest to this

--- a/scripts/strip-native-payloads.sh
+++ b/scripts/strip-native-payloads.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Strip debug information from the Breez Spark native payload in a build output
+# directory, in place. Run against a plugin TargetDir *before* PluginPacker zips
+# it; package.yml runs it there, and the same command is what a local pre-release
+# check uses.
+#
+# Why: Breez.Sdk.Spark ships its Rust libraries unstripped. Each linux .so carries
+# ~28 MB of .debug_* DWARF (~48% of the file) plus the .symtab that goes with it;
+# the osx dylibs carry ~9-11 MB of symbol/linkedit. None of it is loaded at run
+# time — stripping removes only never-mapped sections, .text/.rodata/.data/
+# .eh_frame/.dynsym are untouched — yet it is what makes the packaged runtimes
+# ~200 MB instead of ~100 MB. Measured on Breez.Sdk.Spark 0.23.0:
+#
+#   linux-x64   60 MB -> 21 MB     linux-arm64  59 MB -> 18 MB
+#   osx-x64     25 MB -> 16 MB     osx-arm64    24 MB -> 13 MB
+#
+# What stripping costs, stated plainly:
+#   - Native crash triage: Rust panic *messages* (with file:line) survive, they
+#     live in .rodata. Symbolised RUST_BACKTRACE/gdb/coredumps on linux do not:
+#     frames show bare addresses instead of function names.
+#   - Shipped hashes no longer match Breez's upstream artifacts. Provenance is
+#     this plugin's build attestation (package.yml), and the sha256 before each
+#     strip is printed so an upstream mapping always exists. MIT permits the
+#     modification; NOTICE still travels (enforced in package.yml).
+#
+# What it deliberately does not touch:
+#   - Windows DLLs. Checked on 0.23.0: the PE debug directory is a CodeView
+#     pointer of tens of bytes on win-x64; the payload is all real code.
+#   - Mach-O on a non-macOS host: GNU/LLVM strip cannot rewrite Mach-O. Warn and
+#     skip rather than fail — CI packaging runs on linux and the osx payload is
+#     dev-only there; a mac host strips it for free.
+#   - A Mach-O carrying a real (non-ad-hoc, non-linker-signed) signature: strip
+#     would invalidate the signing identity. Today the dylibs are ad-hoc and
+#     macOS strip re-establishes an ad-hoc signature (verified with codesign -v
+#     after each strip); if Breez ever ships Developer ID-signed binaries,
+#     skipping them is the correct behaviour, not a size loss.
+#
+# Toolchain resolution per ELF file (first that can handle the file's arch):
+# llvm-strip (any ELF arch) -> <arch>-linux-gnu-strip -> host strip (probed) ->
+# docker (ubuntu:24.04 + cross binutils). Idempotent: an already-stripped file
+# is a no-op, so re-running after an incremental build is always safe.
+#
+# Usage: scripts/strip-native-payloads.sh <target-dir>   (expects <target-dir>/runtimes/)
+
+set -euo pipefail
+
+TARGET_DIR="${1:?usage: $0 <plugin TargetDir containing runtimes/>}"
+RUNTIMES="$TARGET_DIR/runtimes"
+[ -d "$RUNTIMES" ] || { echo "error: $RUNTIMES does not exist; pass the plugin build output directory" >&2; exit 1; }
+
+DOCKER_IMAGE="ubuntu:24.04"
+
+sha() { sha256sum "$1" 2>/dev/null | cut -d' ' -f1 || shasum -a 256 "$1" | cut -d' ' -f1; }
+fsize() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1"; }
+mb() { awk -v n="$1" 'BEGIN{printf "%.0f", n/1048576}'; }
+
+# ELF e_machine (bytes 18-19, little-endian) decides which cross-tool to reach for.
+elf_arch() {
+  case "$(od -An -j18 -N2 -t x1 "$1" | tr -d ' \n')" in
+    3e00) echo x86_64 ;;
+    b700) echo aarch64 ;;
+    *) echo unknown ;;
+  esac
+}
+
+docker_strip() { # $1 = directory, $2 = file name — strips in place via bind mount
+  local dir; dir="$(cd "$1" && pwd)"   # docker -v needs an absolute host path
+  docker run --rm -v "$dir:/work" "$DOCKER_IMAGE" bash -c '
+    set -e
+    apt-get update -qq >/dev/null && apt-get install -y -qq binutils-aarch64-linux-gnu binutils-x86-64-linux-gnu >/dev/null
+    aarch64-linux-gnu-strip -s "/work/$1" || x86_64-linux-gnu-strip -s "/work/$1"
+  ' strip "$2"
+}
+
+strip_elf() { # $1 = path to .so
+  local f="$1" arch tool=""
+  arch="$(elf_arch "$f")"
+  [ "$arch" != unknown ] || { echo "error: $f has an unrecognised ELF machine id" >&2; return 1; }
+
+  if command -v llvm-strip >/dev/null 2>&1; then
+    tool="llvm-strip"
+  elif command -v "${arch}-linux-gnu-strip" >/dev/null 2>&1; then
+    tool="${arch}-linux-gnu-strip"
+  elif command -v strip >/dev/null 2>&1; then
+    # Host GNU strip is single-arch on Debian/Ubuntu images and macOS has no ELF
+    # support at all; probe with a copy so a miss never touches the real file.
+    if cp "$f" "$f.probe" && strip -s "$f.probe" 2>/dev/null; then
+      tool="strip"
+    fi
+    rm -f "$f.probe"
+  fi
+
+  if [ -n "$tool" ]; then
+    "$tool" -s "$f"
+    return 0
+  fi
+
+  command -v docker >/dev/null 2>&1 || {
+    echo "error: no ELF stripper for $f (install llvm or binutils-${arch}-linux-gnu, or run with docker)" >&2
+    return 1
+  }
+  docker_strip "$(dirname "$f")" "$(basename "$f")"
+}
+
+strip_macho() { # $1 = path to .dylib
+  local f="$1" sig
+  if [ "$(uname -s)" != "Darwin" ]; then
+    echo "warn: $f not stripped (Mach-O stripping needs a macOS host; linux CI ships the osx payload as-is)" >&2
+    return 2
+  fi
+  # Safe to strip when unsigned (x86_64 payloads ship that way; x86_64 macOS
+  # does not require signatures at load) or ad-hoc/linker-signed (strip
+  # re-establishes an equivalent ad-hoc signature). A real signing identity
+  # must survive untouched: invalidating it is worse than the bytes saved.
+  sig="$(codesign -dv "$f" 2>&1 || true)"
+  if ! printf '%s' "$sig" | grep -q 'adhoc\|linker-signed\|not signed at all'; then
+    echo "warn: $f carries a real code signature; not stripping (identity would be invalidated)" >&2
+    return 2
+  fi
+  # || rc=$? in the caller suspends errexit here, so a failed strip must be explicit
+  strip -x "$f" || { echo "error: strip -x failed on $f" >&2; return 1; }
+  # before: the pre-strip size, set by the caller
+  # There is no cheap "already stripped" test for Mach-O (unlike `file` on
+  # ELF), but strip -x is idempotent: a second pass on a stripped dylib frees
+  # nothing. No shrink therefore means no-op, not failure.
+  if [ "$(fsize "$f")" = "$before" ]; then
+    printf 'no-op  %-12s %3s MB — already stripped\n' "$(basename "$(dirname "$(dirname "$f")")")" "$(mb "$before")"
+    return 3
+  fi
+  if printf '%s' "$sig" | grep -q 'adhoc\|linker-signed'; then codesign -v "$f"; fi   # verify the re-sign
+  return 0
+}
+
+total_before=0; total_after=0
+
+while read -r f; do
+  plat="$(basename "$(dirname "$(dirname "$f")")")"
+  before="$(fsize "$f")"
+  total_before=$((total_before + before))
+
+  case "$f" in
+    *.dll)
+      printf 'skip   %-12s %3s MB — PE payload has no strippable debug data\n' "$plat" "$(mb "$before")"
+      total_after=$((total_after + before))
+      continue
+      ;;
+    *.so)
+      if ! file "$f" | grep -q 'not stripped\|with debug_info'; then
+        printf 'no-op  %-12s %3s MB — already stripped\n' "$plat" "$(mb "$before")"
+        total_after=$((total_after + before))
+        continue
+      fi
+      hash_before="$(sha "$f")"
+      strip_elf "$f"
+      ;;
+    *.dylib)
+      hash_before="$(sha "$f")"
+      rc=0; strip_macho "$f" || rc=$?
+      if [ "$rc" = 2 ] || [ "$rc" = 3 ]; then   # 2 = skipped (warn printed), 3 = no-op (printed)
+        total_after=$((total_after + before))
+        continue
+      fi
+      [ "$rc" = 0 ] || exit 1
+      ;;
+    *)
+      echo "error: unexpected native file $f" >&2; exit 1
+      ;;
+  esac
+
+  after="$(fsize "$f")"
+  total_after=$((total_after + after))
+  printf 'strip  %-12s %3s MB -> %2s MB   upstream sha256 %s\n' \
+    "$plat" "$(mb "$before")" "$(mb "$after")" "$hash_before"
+  [ "$after" -lt "$before" ] || { echo "error: $f did not shrink after strip" >&2; exit 1; }
+done < <(find "$RUNTIMES" -path '*/native/*' \( -name '*.so' -o -name '*.dylib' -o -name '*.dll' \) | sort)
+
+printf 'runtimes total: %s MB -> %s MB\n' "$(mb "$total_before")" "$(mb "$total_after")"

--- a/scripts/strip-native-payloads.sh
+++ b/scripts/strip-native-payloads.sh
@@ -49,7 +49,15 @@ TARGET_DIR="${1:?usage: $0 <plugin TargetDir containing runtimes/>}"
 RUNTIMES="$TARGET_DIR/runtimes"
 [ -d "$RUNTIMES" ] || { echo "error: $RUNTIMES does not exist; pass the plugin build output directory" >&2; exit 1; }
 
-DOCKER_IMAGE="ubuntu:24.04"
+# Pinned by manifest digest, not the mutable tag: the binary this container
+# produces rewrites libraries that ship inside the attested artifact, so a
+# repointed ubuntu:24.04 would put unverified bytes on the release path while
+# the Sigstore attestation still vouched for the result. The apt-installed
+# binutils are themselves GPG-verified against the Ubuntu archive key by apt.
+# This digest is what `ubuntu:24.04` resolved to when the first stripped,
+# server-verified artifacts were produced; refresh deliberately (and re-verify
+# the output) when the base image is next needed for anything new.
+DOCKER_IMAGE="ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517"
 
 sha() { sha256sum "$1" 2>/dev/null | cut -d' ' -f1 || shasum -a 256 "$1" | cut -d' ' -f1; }
 fsize() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1"; }


### PR DESCRIPTION
## What

Audit follow-up: shrink the packaged artifact and cut redundant SDK work found in the same pass.

### 1. The `.btcpay` is 23% smaller — linux natives stripped at packaging time

`Breez.Sdk.Spark` ships its Rust libraries **with full DWARF debug info**: each linux `.so` is 60 MB of which ~29 MB is `.debug_*` sections that are *never mapped at run time*. The new `scripts/strip-native-payloads.sh` runs between the build and PluginPacker in `package.yml`:

| payload | before | after |
|---|---|---|
| linux-x64 `.so` | 60 MB | **21 MB** |
| linux-arm64 `.so` | 59 MB | **18 MB** |
| osx-x64 `.dylib` | 26 MB | 16 MB (mac-host only¹) |
| osx-arm64 `.dylib` | 25 MB | 14 MB (mac-host only¹) |
| win-x64 / win-x86 | 17 / 15 MB | untouched — PE debug dir is a CodeView pointer; nothing strippable |
| **packed `.btcpay`** | **67.4 MB** | **51.7 MB** |

¹ GNU strip cannot rewrite Mach-O; on the linux runner the osx libs ship as-is (warned), a macOS packaging host strips them (verified: `strip -x` re-establishes the ad-hoc signature, `codesign -v` + dlopen pass).

The script is idempotent, prints the pre-strip upstream sha256 of each payload it rewrites (upstream mapping survives), refuses to touch a Mach-O carrying a real signing identity, and **fails the package loudly** if an ELF cannot be stripped. Toolchain resolution: `llvm-strip` → `<arch>-linux-gnu-strip` → host strip (probed) → docker.

**Accepted costs, stated here:** symbolised native backtraces on linux are lost (Rust panic *messages* with file:line survive — they live in `.rodata`); shipped hashes no longer match Breez's upstream bytes (MIT permits the modification, NOTICE still travels, the Sigstore attestation binds *this* build).

### 2. One shared payment-history scan per invoice page (reconciler)

Every settleable invoice with no recorded SDK payment id ran its own paged history scan (≤10 pages) **every pass, every minute** — a quiet store with five waiting invoices paid five full scans per minute to find nothing. `ReconcileStoreAsync` now sweeps once per page anchored to its oldest unpaid invoice and settles from a payment-hash index. A miss counts as unpaid **only** when the sweep drained its window; capped/failed sweeps and records with a recorded id keep the pre-batching path bit-for-bit. Settlement coverage is unchanged (`Drained` carries that proof; four new tests pin it, including a divergent-window test that proves fallback settles what the capped sweep cannot see).

### 3. Process-global status probe read once, not per store per request

`GetSparkStatus` is a static third-party round trip describing the whole Spark network — every configured store's status page and every Greenfield status call re-struck it. Now: 45 s success TTL / 10 s failure backoff, single-flight gate, stale-serving degrade. Diagnostic data only; no money decision reads it. Five cache tests on a probe seam + fake clock; the original never-throw tests untouched.

### 4. Scrubbing only pays for lines that get emitted

`SparkLogBridge` ran the scrubber's five regex passes before `ILogger` could reject the line. `IsEnabled` is now checked first; lines that are emitted scrub exactly as before (test asserts both halves).

## Verification

- **Unit suite: 1301 passed / 0 failed** (incl. 10 new); **Postgres suite: 99/99**; **regtest integration: 2/2** (real SSP, minted a live `lnbcrt` invoice).
- **Stripped natives loaded and did real work** — not just `dlopen`: stripped linux `.so` dlopens under real linux; both test servers run the packaged stripped build with full wallet lifecycle (identity signing, deposit sync, balance updates, payment listings).
- **Deployed to btcpay-dev and btcpay-stg** from a *local* build (`dotnet build` → strip script → PluginPacker), byte-identical DLL/`.so` hashes on both, `Running plugin BTCPayServer.Plugins.Flint - 1.0.1.0`, **zero Flint/Spark exceptions in 30 min** of reconciler cycles on live stores (165 + 212 SDK activity lines in a 4-min sample).
- Not covered: a fresh invoice paid end-to-end on the servers — the Greenfield keys there can create invoices but the dev instance's chain config left them `New` (no BOLT11 minted), and the stg key returned `400` on auth. Minting itself is covered by the local integration suite; happy to pair on an E2E once those keys/instances are re-scoped.

No public API changed (`ReceiveSweep` and the 4-arg `ResolveAsync` overload are `internal`; `InternalsVisibleTo` already existed for the tests).
