### PR TITLE
Release 1.0.2

### DIFF
--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -45,7 +45,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this plugin are recorded here. The format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [1.0.2] — 2026-08-27
 
 ### Changed
 
@@ -643,3 +643,4 @@ signet), the unrotated `sdk.log`, and the one SDK error classification with no a
 [0.1.0]: https://github.com/sethforprivacy/flint/releases/tag/v0.1.0
 [1.0.0]: https://github.com/sethforprivacy/flint/releases/tag/v1.0.0
 [1.0.1]: https://github.com/sethforprivacy/flint/releases/tag/v1.0.1
+[1.0.2]: https://github.com/sethforprivacy/flint/releases/tag/v1.0.2


### PR DESCRIPTION
Version bump and changelog roll for v1.0.2. Payload is PR #48 (native-stripped packaging, shared payment-history sweep, process-global status probe, log-level gate), already merged to main and validated on both test servers plus the security-quorum pass. Mirrors the 1.0.1 release commit.