### PR TITLE
Audit follow-up: strip the osx payload everywhere; pin the release path

### DIFF
--- a/.github/workflows/breez-sdk-update.yml
+++ b/.github/workflows/breez-sdk-update.yml
@@ -33,6 +33,10 @@ jobs:
   check:
     name: Check for a newer Breez SDK release
     runs-on: ubuntu-latest
+    # Discovery only reads the csproj and talks to the NuGet/GitHub APIs: the
+    # write powers the bump job needs must not leak into the scheduled check.
+    permissions:
+      contents: read
     outputs:
       changed: ${{ steps.check.outputs.changed }}
       current: ${{ steps.check.outputs.current }}
@@ -42,7 +46,7 @@ jobs:
       # No submodule checkout needed: the discovery script only reads the csproj and queries the
       # GitHub and NuGet APIs, so this stays cheap enough to run unconditionally every week.
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run discovery script
         id: check
@@ -71,7 +75,7 @@ jobs:
       DRY_RUN: ${{ github.event.inputs.dry_run }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Configure git identity
         run: |

--- a/.github/workflows/btcpayserver-update.yml
+++ b/.github/workflows/btcpayserver-update.yml
@@ -37,6 +37,10 @@ jobs:
   check:
     name: Check for a newer stable btcpayserver release
     runs-on: ubuntu-latest
+    # Discovery only reads Constants.cs and runs git ls-remote: the write
+    # powers the bump job needs must not leak into the scheduled check.
+    permissions:
+      contents: read
     outputs:
       changed: ${{ steps.check.outputs.changed }}
       current: ${{ steps.check.outputs.current }}
@@ -47,7 +51,7 @@ jobs:
       # repo and queries the upstream remote's tag list over the network (git ls-remote), so this
       # stays cheap enough to run unconditionally every week.
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Run discovery script
         id: check
@@ -74,7 +78,7 @@ jobs:
       DRY_RUN: ${{ github.event.inputs.dry_run }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,9 @@ jobs:
     # nothing could ever settle, and no in-memory test can catch it.
     services:
       postgres:
-        image: postgres:17-alpine
+        # Digest-pinned like every other image on a gate path: a retagged
+        # postgres:17-alpine must not be able to change what store-test runs on.
+        image: postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
         env:
           POSTGRES_PASSWORD: sparktest
           POSTGRES_DB: sparktests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Depth 1 applies to the btcpayserver submodule too (actions/checkout passes the same
           # fetch-depth through to `git submodule update`), which matters: the submodule is a
@@ -43,14 +43,14 @@ jobs:
           fetch-depth: 1
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"
 
       # setup-dotnet's own `cache: true` input keys on packages.lock.json, which this repo does
       # not use, so NuGet caching is done directly against the global-packages folder instead.
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
@@ -99,18 +99,18 @@ jobs:
           --health-retries 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 1
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
@@ -162,18 +162,18 @@ jobs:
     continue-on-error: true
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 1
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
@@ -237,7 +237,7 @@ jobs:
     continue-on-error: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 1
@@ -261,13 +261,13 @@ jobs:
 
       - name: Set up .NET
         if: steps.gate.outputs.funded == 'true'
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"
 
       - name: Cache NuGet packages
         if: steps.gate.outputs.funded == 'true'
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
@@ -313,7 +313,7 @@ jobs:
       # downloadable by anyone with read access to the repository, and a leak must not also be a publication.
       - name: Upload the SDK log audit
         if: always() && steps.gate.outputs.funded == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: funded-regtest-log-audit
           path: funded-regtest-artifacts/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -87,18 +87,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 1
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
@@ -236,7 +236,7 @@ jobs:
       - name: Attest build provenance
         id: attest
         if: github.event.repository.visibility == 'public'
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             ${{ steps.artifact.outputs.dir }}/*.btcpay
@@ -277,7 +277,7 @@ jobs:
           echo "Attestation: ${{ steps.attest.outputs.attestation-url }}"
 
       - name: Upload workflow artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ env.PLUGIN_NAME }}
           path: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -124,20 +124,32 @@ jobs:
           echo "path=$target_dir" >> "$GITHUB_OUTPUT"
 
 
-      # Strip the DWARF debug info and symbol tables Breez ships inside its linux .so files
-      # (and the fat symbol tables in the osx dylibs, though those ship as-is from a linux runner:
-      # GNU strip cannot rewrite Mach-O). ~100 MB of the 196 MB runtimes payload is never-mapped
-      # debug data; see the header of the script for the full trade, the measured numbers, and the
-      # toolchain fallbacks. Idempotent, and it fails the build loudly if an ELF cannot be stripped.
+      # Strip the DWARF debug info and symbol tables Breez ships inside its native payloads.
+      # ~100 MB of the 196 MB runtimes payload is never-mapped debug data. This runs inside the
+      # digest-pinned container rather than on the mutable runner image so the toolchain that
+      # rewrites the attested bytes is itself pinned (apt-GPG-verified llvm-18 inside an
+      # ubuntu:24.04 pinned by manifest digest — the same policy as the script's own docker
+      # fallback). The container strips all four ELF/Mach-O payloads: llvm-strip rewrites Mach-O
+      # and the script re-verifies every CodeDirectory page hash afterwards, discarding the result
+      # if any hash fails (verified end to end: the stripped arm64 dylib passes `codesign -v
+      # --strict` and dlopens on a real arm64 macOS). See the script header for the full trade,
+      # the measured numbers, and the toolchain fallbacks. Idempotent; fails the build loudly if
+      # an ELF cannot be stripped.
       - name: Strip debug info from native payloads
+        env:
+          TARGET_DIR: ${{ steps.build-dir.outputs.path }}
         run: |
           set -euo pipefail
-          # The runner is x86-64, so host strip covers linux-x64; the aarch64 cross-tool covers
-          # linux-arm64. Without it the script's docker fallback works too, but pays an apt-get
-          # per file inside a container.
-          sudo apt-get update -qq
-          sudo apt-get install -y -qq binutils-aarch64-linux-gnu
-          ./scripts/strip-native-payloads.sh "${{ steps.build-dir.outputs.path }}"
+          docker run --rm \
+            -v "$PWD:$PWD" -w "$PWD" \
+            -e TARGET_DIR \
+            ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517 \
+            bash -c '
+              set -euo pipefail
+              apt-get update -qq >/dev/null
+              apt-get install -y -qq --no-install-recommends llvm-18 python3 file >/dev/null
+              bash scripts/strip-native-payloads.sh "$TARGET_DIR"
+            '
 
       - name: Run PluginPacker
         env:
@@ -184,6 +196,26 @@ jobs:
             fi
           done
           echo "NOTICE and LICENSE are inside the artifact."
+
+      # SHA256SUMS is attested and its contents are what release consumers verify
+      # against, so it must list exactly the shipped files with the hashes they
+      # actually carry — a stale or superset sums file would ship a lie with a
+      # signature on it. PluginPacker writes it; this proves it.
+      - name: SHA256SUMS matches the artifacts it will be trusted for
+        env:
+          ARTIFACT_DIR: ${{ steps.artifact.outputs.dir }}
+        run: |
+          set -euo pipefail
+          cd "$ARTIFACT_DIR"
+          sha256sum -c SHA256SUMS
+          listed="$(sed 's/  .*$//' SHA256SUMS | sort)"
+          present="$(find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%f\n' | sort)"
+          if [ "$listed" != "$present" ]; then
+            echo "error: SHA256SUMS and the artifact directory disagree:" >&2
+            diff <(echo "$listed") <(echo "$present") >&2 || true
+            exit 1
+          fi
+          echo "SHA256SUMS covers exactly: $listed"
 
       # A tag is the one input to this workflow that nothing else validates. Note what is and is not
       # at stake: the plugin registry does *not* key anything off the tag -- it reads the version out

--- a/.github/workflows/spark-regtest-wallet.yml
+++ b/.github/workflows/spark-regtest-wallet.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           fetch-depth: 1
@@ -58,12 +58,12 @@ jobs:
           fi
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v6
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: "10.0.x"
 
       - name: Cache NuGet packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -110,6 +110,16 @@
       win-x64/x86. There is no linux-musl (Alpine) or win-arm64 payload.
     -->
     <PackageReference Include="Breez.Sdk.Spark" Version="0.23.0" />
+    <!--
+      Transitive-vulnerability pin: SSH.NET 2025.1.0 flows in from BTCPayServer.csproj and lands in
+      this plugin's build output via CopyLocalLockFileAssemblies, and 2025.1.0 is the last version
+      affected by CVE-2026-48798 (GHSA-q939-rpr3-3284, high: ScpClient recursive download writes
+      outside the target directory on a malicious server; fixed in 2026.0.0). This plugin never
+      calls SSH.NET itself, but it would redistribute the vulnerable copy; NuGet resolves the
+      direct reference to the higher version, so this ships 2026.0.0. Drop it once the pinned
+      btcpayserver submodule carries a fixed SSH.NET on its own.
+    -->
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 
   <!--

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -45,7 +45,7 @@
   <PropertyGroup>
     <Product>Flint</Product>
     <Description>Accept Lightning payments without running a node. Each store gets its own Spark wallet, wired into Lightning and LNURL automatically, with optional automatic sweeps to on-chain Bitcoin or to a stablecoin on an EVM address. Funds sit on Spark, a non-custodial Bitcoin layer two network, until they are swept.</Description>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
+++ b/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
@@ -111,15 +111,16 @@
     -->
     <PackageReference Include="Breez.Sdk.Spark" Version="0.23.0" />
     <!--
-      Transitive-vulnerability pin: SSH.NET 2025.1.0 flows in from BTCPayServer.csproj and lands in
-      this plugin's build output via CopyLocalLockFileAssemblies, and 2025.1.0 is the last version
-      affected by CVE-2026-48798 (GHSA-q939-rpr3-3284, high: ScpClient recursive download writes
-      outside the target directory on a malicious server; fixed in 2026.0.0). This plugin never
-      calls SSH.NET itself, but it would redistribute the vulnerable copy; NuGet resolves the
-      direct reference to the higher version, so this ships 2026.0.0. Drop it once the pinned
-      btcpayserver submodule carries a fixed SSH.NET on its own.
+      Transitive-vulnerability pin: SSH.NET 2025.1.0 flows in from BTCPayServer.csproj, and 2025.1.0 is
+      the last version affected by CVE-2026-48798 (GHSA-q939-rpr3-3284, high: ScpClient recursive
+      download writes outside the target directory on a malicious server; fixed in 2026.0.0). This
+      plugin never calls SSH.NET, so the reference exists only to force the resolved graph to
+      2026.0.0 (clearing NU1903) — ExcludeAssets keeps its assembly and the BouncyCastle copy it
+      drags along out of the plugin's build output, exactly as BTCPayServer's transitive packages
+      are kept out. Drop the reference once the pinned btcpayserver submodule carries a fixed
+      SSH.NET on its own.
     -->
-    <PackageReference Include="SSH.NET" Version="2026.0.0" />
+    <PackageReference Include="SSH.NET" Version="2026.0.0" ExcludeAssets="runtime;compile" />
   </ItemGroup>
 
   <!--

--- a/BTCPayServer.Plugins.Flint/Data/SparkPluginDbContext.cs
+++ b/BTCPayServer.Plugins.Flint/Data/SparkPluginDbContext.cs
@@ -34,6 +34,14 @@ public class SparkPluginDbContext : DbContext
             entity.HasIndex(record => new { record.StoreId, record.Status });
             // ListInvoices pages newest-first within a store.
             entity.HasIndex(record => new { record.StoreId, record.CreatedAt });
+            // The every-minute cross-store credit walk (ListStoreIdsAwaitingCreditAsync) and the
+            // per-store ListUncreditedAsync both filter on exactly this predicate. Without it the
+            // cross-store DISTINCT scans every InvoiceRecords row each pass; with it both queries are
+            // index-only over a partial index that holds roughly the unsettled tail of the table.
+            // Quoted identifiers: the columns are created mixed-case and Postgres would otherwise
+            // fold the filter's references to lowercase and fail to match.
+            entity.HasIndex(record => new { record.StoreId, record.SettledAt })
+                .HasFilter("\"Status\" = 1 AND \"CreditedAt\" IS NULL AND \"CreditAbandonedAt\" IS NULL AND \"SettledAt\" IS NOT NULL");
         });
 
         modelBuilder.Entity<OutgoingPaymentRecord>(entity =>

--- a/BTCPayServer.Plugins.Flint/Migrations/20260828163549_InvoiceCreditSweepIndex.Designer.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260828163549_InvoiceCreditSweepIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BTCPayServer.Plugins.Flint.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BTCPayServer.Plugins.Flint.Migrations
 {
     [DbContext(typeof(SparkPluginDbContext))]
-    partial class SparkPluginDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260828163549_InvoiceCreditSweepIndex")]
+    partial class InvoiceCreditSweepIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BTCPayServer.Plugins.Flint/Migrations/20260828163549_InvoiceCreditSweepIndex.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260828163549_InvoiceCreditSweepIndex.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Plugins.Flint.Migrations
+{
+    /// <inheritdoc />
+    public partial class InvoiceCreditSweepIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_InvoiceRecords_StoreId_SettledAt",
+                schema: "BTCPayServer.Plugins.Flint",
+                table: "InvoiceRecords",
+                columns: new[] { "StoreId", "SettledAt" },
+                filter: "\"Status\" = 1 AND \"CreditedAt\" IS NULL AND \"CreditAbandonedAt\" IS NULL AND \"SettledAt\" IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InvoiceRecords_StoreId_SettledAt",
+                schema: "BTCPayServer.Plugins.Flint",
+                table: "InvoiceRecords");
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to this plugin are recorded here. The format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Changed
+
+- **The osx native payload is now stripped from CI builds too, and the strip runs in a pinned
+  container.** The 1.0.2 strip covered the linux `.so` files; the osx dylibs shipped as-is from the
+  linux runner because "GNU/LLVM strip cannot rewrite Mach-O" — the LLVM half of that claim was
+  wrong. `llvm-strip` rewrites Mach-O fine, and for these payloads the rewrite preserves the code
+  signature: the stripped arm64 dylib passes `codesign -v --strict` and `dlopen`s on a real arm64
+  macOS, verified on both the runner's llvm-18 and a current brew llvm. Because that validity is an
+  observed property rather than a contract, the script now reads each dylib's CodeDirectory before
+  stripping (only unsigned and ad-hoc/linker-signed payloads are rewritten; a Developer ID-signed
+  one is skipped, as the macOS path already did) and re-verifies every page hash after stripping,
+  discarding the result if any hash fails — a fat artifact is a size regression, an invalid
+  signature is a broken plugin. Net effect: the packed `.btcpay` drops from ~51.7 MB to ~31 MB.
+  The strip step itself moved off the mutable runner image and into the digest-pinned
+  `ubuntu:24.04` container (apt-verified llvm-18), so the toolchain that rewrites the attested
+  bytes is pinned like everything else on the release path.
+- **The strip script no longer risks leaving probe or backup files inside the packaged artifact.**
+  The ELF probe (and the new Mach-O copies) are created outside the build output directory; a
+  leaked 60 MB probe file previously could have been zipped into the `.btcpay` by a crash at the
+  wrong moment.
+
+### Fixed
+
+- **`SSH.NET` is pinned to 2026.0.0 in the plugin**, clearing NU1903 (CVE-2026-48798,
+  GHSA-q939-rpr3-3284, high: `ScpClient` recursive download could write outside the target
+  directory on a malicious server). The plugin never calls SSH.NET, but the vulnerable 2025.1.0
+  copy flowed in transitively from BTCPayServer and travelled inside the artifact; the pin drops
+  once the pinned btcpayserver submodule carries a fixed version itself.
+
+### Security
+
+- **All GitHub Actions are pinned by commit SHA** (`checkout`, `setup-dotnet`, `cache`,
+  `upload-artifact`, `attest-build-provenance`) with Dependabot continuing to move the pins.
+  Mutable major tags on the workflow that mints the release attestation were the same class of
+  supply-chain risk the docker fallback image was already pinned against.
+- **The Postgres service image in CI is digest-pinned**, and **`SHA256SUMS` contents are verified
+  against the packed artifacts before attestation** — the sums file is what release consumers
+  trust, so CI now proves it lists exactly the shipped files with the hashes they carry.
+- **The weekly update workflows' discovery jobs run with read-only permissions** — the write
+  powers the bump jobs need no longer leak into the scheduled checks.
+- **`global.json` pins the .NET SDK** (`10.0.400`, `rollForward: latestFeature`) so local and CI
+  builds resolve the same compiler.
+
+### Performance
+
+- **`InvoiceRecords` gained a partial index for the credit sweep.** The every-minute cross-store
+  query behind `ListStoreIdsAwaitingCreditAsync` (Paid, uncredited, settled in the window,
+  `DISTINCT StoreId`) had no usable index and scanned the whole table each pass; the new partial
+  index on `(StoreId, SettledAt)` filtered to exactly that predicate makes both it and the
+  per-store `ListUncreditedAsync` index-only over roughly the unsettled tail of the table.
+
+
 ## [1.0.2] — 2026-08-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,12 @@ All notable changes to this plugin are recorded here. The format follows
 
 ### Fixed
 
-- **`SSH.NET` is pinned to 2026.0.0 in the plugin**, clearing NU1903 (CVE-2026-48798,
-  GHSA-q939-rpr3-3284, high: `ScpClient` recursive download could write outside the target
-  directory on a malicious server). The plugin never calls SSH.NET, but the vulnerable 2025.1.0
-  copy flowed in transitively from BTCPayServer and travelled inside the artifact; the pin drops
-  once the pinned btcpayserver submodule carries a fixed version itself.
-
-### Security
-
+- **`SSH.NET` is pinned to 2026.0.0**, clearing NU1903 (CVE-2026-48798, GHSA-q939-rpr3-3284, high:
+  `ScpClient` recursive download could write outside the target directory on a malicious server).
+  The pin forces the resolved dependency graph to the fixed version while `ExcludeAssets` keeps
+  SSH.NET and its BouncyCastle dependency out of the plugin's build output — the plugin never
+  calls SSH.NET, so nothing about the shipped artifact changes. Drop the pin once the pinned
+  btcpayserver submodule carries a fixed SSH.NET on its own.
 - **All GitHub Actions are pinned by commit SHA** (`checkout`, `setup-dotnet`, `cache`,
   `upload-artifact`, `attest-build-provenance`) with Dependabot continuing to move the pins.
   Mutable major tags on the workflow that mints the release attestation were the same class of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this plugin are recorded here. The format follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [1.0.3] — 2026-08-28
 
 ### Changed
 
@@ -696,3 +696,4 @@ signet), the unrotated `sdk.log`, and the one SDK error classification with no a
 [1.0.0]: https://github.com/sethforprivacy/flint/releases/tag/v1.0.0
 [1.0.1]: https://github.com/sethforprivacy/flint/releases/tag/v1.0.1
 [1.0.2]: https://github.com/sethforprivacy/flint/releases/tag/v1.0.2
+[1.0.3]: https://github.com/sethforprivacy/flint/releases/tag/v1.0.3

--- a/docs/ci-and-releases.md
+++ b/docs/ci-and-releases.md
@@ -25,17 +25,24 @@
   and `SHA256SUMS`) as a workflow artifact, and attaches it to the corresponding GitHub Release when
   triggered by a tag. On a tag it also refuses to build if the tag disagrees with the version in the
   csproj, so a `v0.2.0` tag on a 0.1.0 tree fails rather than producing a mislabelled release.
-  - **The linux native payload is stripped at packaging time** by
+  - **All four ELF/Mach-O native payloads are stripped at packaging time** by
     [`scripts/strip-native-payloads.sh`](../scripts/strip-native-payloads.sh): Breez ships its Rust
-    `.so` files with ~28 MB of DWARF debug info apiece — never-mapped data that nonetheless travels
-    inside every `.btcpay` — and stripping takes the packaged runtimes from ~196 MB to ~100 MB
-    uncompressed. The trade (symbolised native backtraces on linux, and hashes that no longer match
-    Breez's upstream byte-for-byte — hence the upstream sha256 each strip prints) is argued in the
-    script's header, which is also the local pre-release recipe: run `dotnet build -c Release`, run
-    the script against the output directory, then `PluginPacker` by hand. The step is idempotent and
-    fails the package loudly if an ELF cannot be stripped; the osx dylibs are stripped on macOS
-    hosts only (GNU strip cannot rewrite Mach-O) and the Windows DLLs are not touched at all,
-    because they carry no strippable debug data.
+    libraries with DWARF debug info and fat symbol tables — never-mapped data that nonetheless
+    travels inside every `.btcpay` — and stripping takes the packaged runtimes from ~196 MB to
+    ~100 MB uncompressed. The step runs inside the digest-pinned `ubuntu:24.04` container with
+    apt-verified `llvm-18`, so the toolchain that rewrites the attested bytes is itself pinned (the
+    same policy as the script's own docker fallback for local runs). llvm-strip rewrites Mach-O, so
+    the osx dylibs strip on every host now, not just macOS ones; because signature validity after
+    that rewrite is an observed property rather than a contract, the script reads each dylib's
+    CodeDirectory before touching it (unsigned and ad-hoc/linker-signed only — a Developer
+    ID-signed payload is skipped) and re-verifies every page hash afterwards, discarding the
+    stripped copy if any hash fails. The stripped arm64 dylib was further proven with
+    `codesign -v --strict` and a real `dlopen` on arm64 macOS. The trade (symbolised native
+    backtraces, and hashes that no longer match Breez's upstream byte-for-byte — hence the upstream
+    sha256 each strip prints) is argued in the script's header, which is also the local pre-release
+    recipe: run `dotnet build -c Release`, run the script against the output directory, then
+    `PluginPacker` by hand. The step is idempotent and fails the package loudly if an ELF cannot be
+    stripped; the Windows DLLs are not touched at all, because they carry no strippable debug data.
   - **Artifacts are signed with keyless Sigstore build provenance**
     (`actions/attest-build-provenance`), not a maintainer GPG key: there is no long-lived key for
     anyone to generate, store, lose or leak, and the attestation binds the artifact's digest to this

--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "10.0.400",
+    "rollForward": "latestFeature"
+  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }

--- a/scripts/strip-native-payloads.sh
+++ b/scripts/strip-native-payloads.sh
@@ -13,7 +13,26 @@
 # ~200 MB instead of ~100 MB. Measured on Breez.Sdk.Spark 0.23.0:
 #
 #   linux-x64   60 MB -> 21 MB     linux-arm64  59 MB -> 18 MB
-#   osx-x64     25 MB -> 16 MB     osx-arm64    24 MB -> 13 MB
+#   osx-x64     26 MB -> 16 MB     osx-arm64    25 MB -> 14 MB
+#
+# The osx payload is stripped on every host now: llvm-strip rewrites Mach-O
+# (the earlier "LLVM strip cannot rewrite Mach-O" note was wrong — only GNU
+# strip cannot). For these files that rewrite keeps the code signature valid,
+# verified on llvm 18.1.3 (the version inside the pinned container) and on a
+# current brew llvm: `codesign -v --strict` passes, the stripped arm64 dylib
+# dlopens on a real arm64 macOS, and every CodeDirectory page hash recomputes.
+# Because signature validity is an observed property of llvm-strip rather than
+# a contract, the Mach-O path never ships on trust:
+#   - Before stripping, the CodeDirectory flags are read (the script's own
+#     Python parser): files with no signature and ad-hoc/linker-signed files
+#     are stripped; anything else — a Developer ID or other real identity —
+#     is skipped with a warning, exactly as the macOS path has always done.
+#   - After stripping, every CodeDirectory page hash is recomputed against the
+#     file (the same check dyld performs at load). A stripped copy that fails
+#     is discarded and the original bytes kept: a fat artifact is a size
+#     regression, an invalid signature is a broken plugin.
+# On a macOS host the Apple toolchain is used instead, where `strip -x`
+# re-establishes the ad-hoc signature and `codesign -v` proves it.
 #
 # What stripping costs, stated plainly:
 #   - Native crash triage: Rust panic *messages* (with file:line) survive, they
@@ -27,19 +46,19 @@
 # What it deliberately does not touch:
 #   - Windows DLLs. Checked on 0.23.0: the PE debug directory is a CodeView
 #     pointer of tens of bytes on win-x64; the payload is all real code.
-#   - Mach-O on a non-macOS host: GNU/LLVM strip cannot rewrite Mach-O. Warn and
-#     skip rather than fail — CI packaging runs on linux and the osx payload is
-#     dev-only there; a mac host strips it for free.
 #   - A Mach-O carrying a real (non-ad-hoc, non-linker-signed) signature: strip
-#     would invalidate the signing identity. Today the dylibs are ad-hoc and
-#     macOS strip re-establishes an ad-hoc signature (verified with codesign -v
-#     after each strip); if Breez ever ships Developer ID-signed binaries,
-#     skipping them is the correct behaviour, not a size loss.
+#     would invalidate the signing identity. Today the dylibs are unsigned
+#     (x86_64) and ad-hoc linker-signed (arm64); if Breez ever ships Developer
+#     ID-signed binaries, skipping them is the correct behaviour.
+#   - Fat/universal or 32-bit Mach-O: not among Breez's payloads, and not
+#     worth a second code path — they are detected and skipped.
 #
 # Toolchain resolution per ELF file (first that can handle the file's arch):
 # llvm-strip (any ELF arch) -> <arch>-linux-gnu-strip -> host strip (probed) ->
-# docker (ubuntu:24.04 + cross binutils). Idempotent: an already-stripped file
-# is a no-op, so re-running after an incremental build is always safe.
+# docker (ubuntu:24.04 + cross binutils). Per Mach-O file on a non-macOS host:
+# llvm-strip (host, or versioned llvm-strip-NN) -> docker (pinned container:
+# llvm-18 + python3 strip and verify together). Idempotent: an already-stripped
+# file is a no-op, so re-running after an incremental build is always safe.
 #
 # Usage: scripts/strip-native-payloads.sh <target-dir>   (expects <target-dir>/runtimes/)
 
@@ -53,8 +72,8 @@ RUNTIMES="$TARGET_DIR/runtimes"
 # produces rewrites libraries that ship inside the attested artifact, so a
 # repointed ubuntu:24.04 would put unverified bytes on the release path while
 # the Sigstore attestation still vouched for the result. The apt-installed
-# binutils are themselves GPG-verified against the Ubuntu archive key by apt.
-# This digest is what `ubuntu:24.04` resolved to when the first stripped,
+# binutils/llvm are themselves GPG-verified against the Ubuntu archive key by
+# apt. This digest is what `ubuntu:24.04` resolved to when the first stripped,
 # server-verified artifacts were produced; refresh deliberately (and re-verify
 # the output) when the base image is next needed for anything new.
 DOCKER_IMAGE="ubuntu:24.04@sha256:33ceb71981b602c1a7443a53469e4dba065f7503eab3078a2d7a57a2ab987517"
@@ -81,42 +100,108 @@ docker_strip() { # $1 = directory, $2 = file name — strips in place via bind m
   ' strip "$2"
 }
 
-strip_elf() { # $1 = path to .so
-  local f="$1" arch tool=""
-  arch="$(elf_arch "$f")"
-  [ "$arch" != unknown ] || { echo "error: $f has an unrecognised ELF machine id" >&2; return 1; }
+# ---------------------------------------------------------------------------
+# Mach-O signature inspection, shared by the guard and the verification.
+#
+# A thin little-endian 64-bit Mach-O only (Breez ships one dylib per RID).
+# Modes:
+#   flags  -> prints one of: unsigned (no LC_CODE_SIGNATURE), adhoc (ad-hoc or
+#             linker-signed CodeDirectory), signed (a real signing identity);
+#             dies on fat/32-bit/unrecognised files.
+#   verify -> exit 0 iff an ad-hoc CodeDirectory exists and every page hash
+#             recomputes against the file bytes — the check dyld performs at
+#             load time on arm64.
+# Code Signature blobs are BIG-endian (Apple's embedded signature
+# specification); only the Mach-O load commands themselves are LE.
+# ---------------------------------------------------------------------------
+MACHO_PY="$(mktemp "${TMPDIR:-/tmp}/flint-macho-sig.XXXXXX")"
+trap 'rm -f "$MACHO_PY"' EXIT
+cat > "$MACHO_PY" <<'PY'
+import hashlib, struct, sys
 
-  if command -v llvm-strip >/dev/null 2>&1; then
-    tool="llvm-strip"
-  elif command -v "${arch}-linux-gnu-strip" >/dev/null 2>&1; then
-    tool="${arch}-linux-gnu-strip"
-  elif command -v strip >/dev/null 2>&1; then
-    # Host GNU strip is single-arch on Debian/Ubuntu images and macOS has no ELF
-    # support at all; probe with a copy so a miss never touches the real file.
-    if cp "$f" "$f.probe" && strip -s "$f.probe" 2>/dev/null; then
-      tool="strip"
-    fi
-    rm -f "$f.probe"
-  fi
+def die(msg):
+    sys.stderr.write("error: " + msg + "\n")
+    sys.exit(2)
 
-  if [ -n "$tool" ]; then
-    "$tool" -s "$f"
-    return 0
-  fi
+with open(sys.argv[2], "rb") as fh:
+    data = fh.read()
+if len(data) < 32:
+    die("file too small to be a Mach-O")
+magic = struct.unpack_from("<I", data, 0)[0]
+if magic != 0xFEEDFACF:  # MH_MAGIC_64, little-endian
+    die("not a thin little-endian 64-bit Mach-O (fat/32-bit are skipped, not stripped)")
 
-  command -v docker >/dev/null 2>&1 || {
-    echo "error: no ELF stripper for $f (install llvm or binutils-${arch}-linux-gnu, or run with docker)" >&2
-    return 1
-  }
-  docker_strip "$(dirname "$f")" "$(basename "$f")"
-}
+ncmds = struct.unpack_from("<I", data, 16)[0]
+off = 32
+sig_off = None
+for _ in range(ncmds):
+    cmd, cmdsize = struct.unpack_from("<II", data, off)
+    if cmd == 0x1D:  # LC_CODE_SIGNATURE
+        sig_off = struct.unpack_from("<I", data, off + 8)[0]
+    off += cmdsize
 
-strip_macho() { # $1 = path to .dylib
+cd = None
+if sig_off is not None and sig_off + 12 <= len(data):
+    sb_magic, _sb_len, count = struct.unpack_from(">III", data, sig_off)
+    if sb_magic != 0xFADE0CC0:
+        die("code signature superblob has an unexpected magic")
+    for i in range(count):
+        blob_type, blob_off = struct.unpack_from(">II", data, sig_off + 12 + 8 * i)
+        if blob_type == 0:  # CSSLOT_CODEDIRECTORY
+            cd = sig_off + blob_off
+            # ld's linker-signed layout writes 0xfade0c02; codesign(1)-written
+            # CodeDirectories use 0xfade0cde. Both parse identically thereafter.
+            blob_magic = struct.unpack_from(">I", data, cd)[0]
+            if blob_magic not in (0xFADE0CDE, 0xFADE0C02):
+                die("CodeDirectory has an unexpected magic")
+            break
+    if cd is None:
+        die("code signature carries no CodeDirectory")
+
+mode = sys.argv[1]
+if mode == "flags":
+    if cd is None:
+        print("unsigned")
+    elif struct.unpack_from(">I", data, cd + 12)[0] & 0x2:  # CS_ADHOC
+        print("adhoc")
+    else:
+        print("signed")
+    sys.exit(0)
+
+# verify mode
+if cd is None:
+    # An unsigned payload has nothing to invalidate: after a strip the only
+    # requirement is that it is still a well-formed thin 64-bit Mach-O (we
+    # just parsed it), which x86_64 macOS loads as-is.
+    print("unsigned: no signature to invalidate, structure intact")
+    sys.exit(0)
+version = struct.unpack_from(">I", data, cd + 8)[0]
+if version < 0x20200:
+    die("CodeDirectory version too old to verify")
+flags = struct.unpack_from(">I", data, cd + 12)[0]
+if not flags & 0x2:
+    die("signature is not ad-hoc; refusing to vouch for it")
+(hash_offset, _ident, _n_special, n_code, code_limit,
+ hash_size, _hash_type, _platform, page_pow) = struct.unpack_from(">IIIIIBBBB", data, cd + 16)
+page = 1 << page_pow
+sha256 = hashlib.sha256
+for i in range(n_code):
+    start = i * page
+    end = min(start + page, code_limit)
+    if end > len(data) or start >= end:
+        die(f"code limit {code_limit} does not fit the file; signature cannot be valid")
+    slot = cd + hash_offset + i * hash_size
+    if slot + hash_size > len(data):
+        die("CodeDirectory hash slots run past end of file")
+    if sha256(data[start:end]).digest()[:hash_size] != data[slot:slot + hash_size]:
+        die(f"page hash mismatch in slot {i} (file bytes {start}..{end}); stripped copy is not loadable")
+print(f"verified: ad-hoc CodeDirectory, {n_code} page hashes match, page size {page}")
+PY
+
+macho_flags() { python3 "$MACHO_PY" flags "$1" || echo bad; }
+
+strip_macho_darwin() { # $1 = path to .dylib — Apple toolchain path
   local f="$1" sig
-  if [ "$(uname -s)" != "Darwin" ]; then
-    echo "warn: $f not stripped (Mach-O stripping needs a macOS host; linux CI ships the osx payload as-is)" >&2
-    return 2
-  fi
   # Safe to strip when unsigned (x86_64 payloads ship that way; x86_64 macOS
   # does not require signatures at load) or ad-hoc/linker-signed (strip
   # re-establishes an equivalent ad-hoc signature). A real signing identity
@@ -138,6 +223,105 @@ strip_macho() { # $1 = path to .dylib
   fi
   if printf '%s' "$sig" | grep -q 'adhoc\|linker-signed'; then codesign -v "$f"; fi   # verify the re-sign
   return 0
+}
+
+strip_macho_llvm() { # $1 = path to .dylib — non-macOS host: llvm-strip + explicit verification
+  local f="$1" mode tool out
+  mode="$(macho_flags "$f")"
+  case "$mode" in
+    unsigned|adhoc) ;;
+    *)
+      echo "warn: $f not stripped (Mach-O signature state: $mode; only unsigned and ad-hoc payloads are safe to rewrite)" >&2
+      return 2
+      ;;
+  esac
+
+  # Host llvm-strip first (package.yml's pinned container carries llvm-18; brew
+  # llvm exposes the unversioned name; Ubuntu only the versioned one). The
+  # fallback probe must not kill the script under pipefail when nothing matches.
+  tool="llvm-strip"
+  command -v llvm-strip >/dev/null 2>&1 || { tool="$(ls /usr/bin/llvm-strip-* 2>/dev/null | sort -V | tail -n 1)" || tool=""; }
+  if [ -n "$tool" ] && command -v python3 >/dev/null 2>&1; then
+    # Strip a copy, verify the copy, only then replace the original: a strip
+    # that invalidates the signature must degrade to "skipped", never ship.
+    out="$(mktemp "${TMPDIR:-/tmp}/flint-macho.XXXXXX")"
+    if cp "$f" "$out" && "$tool" -x "$out" 2>/dev/null && python3 "$MACHO_PY" verify "$out"; then
+      if [ "$(fsize "$out")" = "$before" ]; then
+        rm -f "$out"
+        printf 'no-op  %-12s %3s MB — already stripped\n' "$(basename "$(dirname "$(dirname "$f")")")" "$(mb "$before")"
+        return 3
+      fi
+      mv "$out" "$f"
+      return 0
+    fi
+    rm -f "$out"
+    echo "warn: $f stripped copy failed Mach-O signature verification; original kept" >&2
+    return 2
+  fi
+
+  command -v docker >/dev/null 2>&1 || {
+    echo "error: no Mach-O stripper for $f (install llvm, or run with docker)" >&2
+    return 1
+  }
+  local dir; dir="$(cd "$(dirname "$f")" && pwd)"
+  local work; work="$(mktemp -d "${TMPDIR:-/tmp}/flint-macho-work.XXXXXX")"
+  if docker run --rm -v "$dir:/src:ro" -v "$work:/out" -v "$MACHO_PY:/macho_sig.py:ro" "$DOCKER_IMAGE" bash -c '
+      set -e
+      apt-get update -qq >/dev/null && apt-get install -y -qq --no-install-recommends llvm-18 python3 >/dev/null
+      mode="$(python3 /macho_sig.py flags "/src/$1")"
+      case "$mode" in unsigned|adhoc) ;; *) echo "signature state: $mode" >&2; exit 3 ;; esac
+      cp "/src/$1" /out/stripped.dylib
+      "$(ls /usr/bin/llvm-strip-* | sort -V | tail -n 1)" -x /out/stripped.dylib
+      python3 /macho_sig.py verify /out/stripped.dylib
+    ' macho "$(basename "$f")"; then
+    if [ "$(fsize "$work/stripped.dylib")" = "$before" ]; then
+      rm -rf "$work"
+      printf 'no-op  %-12s %3s MB — already stripped\n' "$(basename "$(dirname "$(dirname "$f")")")" "$(mb "$before")"
+      return 3
+    fi
+    mv "$work/stripped.dylib" "$f"
+    rm -rf "$work"
+    return 0
+  fi
+  rm -rf "$work"
+  echo "warn: $f not stripped (container Mach-O strip declined or failed verification)" >&2
+  return 2
+}
+
+strip_elf() { # $1 = path to .so
+  local f="$1" arch tool=""
+  arch="$(elf_arch "$f")"
+  [ "$arch" != unknown ] || { echo "error: $f has an unrecognised ELF machine id" >&2; return 1; }
+
+  if command -v llvm-strip >/dev/null 2>&1; then
+    tool="llvm-strip"
+  elif tool="$(ls /usr/bin/llvm-strip-* 2>/dev/null | sort -V | tail -n 1)" && [ -n "$tool" ]; then
+    # llvm-strip handles every ELF arch; Ubuntu ships it versioned (llvm-strip-18)
+    :
+  elif command -v "${arch}-linux-gnu-strip" >/dev/null 2>&1; then
+    tool="${arch}-linux-gnu-strip"
+  elif command -v strip >/dev/null 2>&1; then
+    # Host GNU strip is single-arch on Debian/Ubuntu images and macOS has no ELF
+    # support at all; probe with a copy so a miss never touches the real file.
+    # The probe lives outside the TargetDir: a leaked probe file inside the
+    # build output would otherwise be zipped into the artifact by PluginPacker.
+    local probe; probe="$(mktemp "${TMPDIR:-/tmp}/flint-elf-probe.XXXXXX")"
+    if cp "$f" "$probe" && strip -s "$probe" 2>/dev/null; then
+      tool="strip"
+    fi
+    rm -f "$probe"
+  fi
+
+  if [ -n "$tool" ]; then
+    "$tool" -s "$f"
+    return 0
+  fi
+
+  command -v docker >/dev/null 2>&1 || {
+    echo "error: no ELF stripper for $f (install llvm or binutils-${arch}-linux-gnu, or run with docker)" >&2
+    return 1
+  }
+  docker_strip "$(dirname "$f")" "$(basename "$f")"
 }
 
 total_before=0; total_after=0
@@ -164,7 +348,11 @@ while read -r f; do
       ;;
     *.dylib)
       hash_before="$(sha "$f")"
-      rc=0; strip_macho "$f" || rc=$?
+      if [ "$(uname -s)" = "Darwin" ]; then
+        rc=0; strip_macho_darwin "$f" || rc=$?
+      else
+        rc=0; strip_macho_llvm "$f" || rc=$?
+      fi
       if [ "$rc" = 2 ] || [ "$rc" = 3 ]; then   # 2 = skipped (warn printed), 3 = no-op (printed)
         total_after=$((total_after + before))
         continue


### PR DESCRIPTION
## What

Session audit follow-up to #48 across three passes (perf/reliability, security, supply chain). Security came back clean on the hostile-tenant walk; this PR lands the contained findings.

### 1. The `.btcpay` drops again: ~51.7 MB → ~31 MB

The 1.0.2 strip covered the linux `.so` files; the osx dylibs shipped as-is from the linux runner because "GNU/LLVM strip cannot rewrite Mach-O" — the **LLVM half of that claim was wrong**. `llvm-strip` rewrites Mach-O fine, and for these payloads the rewrite preserves the code signature.

Because that validity is an observed property rather than a contract, the Mach-O path never ships on trust:

- **Before stripping**: the script's own parser reads each dylib's CodeDirectory flags — only unsigned and ad-hoc/linker-signed payloads are rewritten; anything carrying a real signing identity is skipped with a warning (same semantics the macOS path already had).
- **After stripping**: every CodeDirectory page hash is recomputed against the file — the check dyld performs at load. A stripped copy that fails is discarded and the original bytes kept: a fat artifact is a size regression, an invalid signature is a broken plugin.

Verified end to end, not just dlopen'd:

- bare `llvm-strip -x` → `codesign -v --strict` passes → real `dlopen` on arm64 macOS — on brew llvm **and** the pinned container's llvm-18.1.3;
- full script run **inside the digest-pinned `ubuntu:24.04` container**: 201 MB → 101 MB runtimes, second pass all no-op, container-stripped arm64 dylib codesign-valid + loadable on macOS;
- linux-x64 `.so` output byte-identical across mac-llvm / container-llvm-18 / GNU-strip paths;
- the verifier self-tested: single flipped byte caught at the exact page slot; non-ad-hoc flags → "signed" → guard skips; fat/universal → rejected.

The strip step in `package.yml` now runs **inside the pinned container** (apt-GPG-verified llvm-18), so the toolchain rewriting the attested bytes is itself pinned. Also fixed: the ELF probe file used to be created inside the TargetDir — a crash mid-probe could leak 60 MB of junk into the zipped artifact; probe/copy files now live outside it.

### 2. Credit sweep partial index

`ListStoreIdsAwaitingCreditAsync` (Paid, uncredited, settled in window, `DISTINCT StoreId`) — the every-minute cross-store walk — had no usable index and scanned the whole `InvoiceRecords` table each pass. New partial index on `(StoreId, SettledAt)` filtered to exactly that predicate. On real Postgres at 100k rows: **Index Only Scan, Heap Fetches 0**, 3.1 ms vs 6.0 ms forced-seqscan — and the old path is O(all invoices ever) while the new one is O(unsettled tail), so the gap widens with table age. `ListUncreditedAsync` benefits too.

### 3. Supply chain: the attestation path is now fully pinned

- **Every GitHub Action pinned by commit SHA** (checkout, setup-dotnet, cache, upload-artifact, attest-build-provenance; Dependabot keeps moving the pins). Mutable `@vN` tags on the workflow that **mints the release attestation** were the same risk class the docker digest pin already defends.
- **`SHA256SUMS` contents validated before attestation** — the sums file is what release consumers verify against, so CI now proves it lists exactly the shipped files with the hashes they carry.
- **CI Postgres image digest-pinned** (`store-test` gate), **update-workflow discovery jobs scoped to `contents: read`**, **`global.json` pins the .NET SDK** (10.0.400, latestFeature).

### 4. SSH.NET CVE-2026-48798 (NU1903, high)

Vulnerable 2025.1.0 flowed in transitively from BTCPayServer and travelled inside the artifact (plugin never calls it). Direct pin to 2026.0.0 (NuGet takes the highest version); drops when the pinned submodule carries a fixed copy.

## Verification

- Unit suite 1301/0; Postgres suite 99/99 against real Postgres 17 (migration applies cleanly); EXPLAIN proofs for the index; all five workflow YAMLs parse; `bash -n` + shellcheck clean.
- Payload test rigs from real Breez 0.23.0 natives: mac host, pinned container, idempotence passes (numbers above).
- No public API changed; deadline patterns untouched.

## Deliberately not in this PR (money-path, each needs its own reviewed change)

Sweep-engine SDK calls have no per-call deadlines (a hung call wedges a store's sweeping until the underlying call returns); request-thread SDK reads are unbounded; store teardown stalls the EventAggregator loop up to ~35 s; `ListUnresolvedAsync` is unbounded *by documented contract* (pass-batched chasing is the honest fix). Happy to take these next with the reconciler's `SparkDeadline` pattern.
