### PR TITLE
Resolve the setup-tab store from the request authorisation, not the form model

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/LNPaymentMethodSetupTabTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/LNPaymentMethodSetupTabTests.cs
@@ -1,0 +1,122 @@
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The setup-tab extension point resolves the store it reports on from the request's authorisation —
+/// never from the store the bound model names.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>LightningNodeViewModel.StoreId</c> is an ordinary form-bound settable property, and core's POST of
+/// <c>SetupLightningNode</c> re-renders the page without ever reassigning it from the route or the
+/// authorised store, so the model reaching this partial on a POST can name any store on the server. The
+/// pane reports two pieces of store state — whether the store's Spark wallet is configured, and whether
+/// it is running — so a partial that keyed off the model would hand an attacker a free oracle for
+/// another store's wallet state, links and all. The partial instead refuses only a missing authorisation
+/// and computes both states, and every link, off the authorised id alone; the form-bound id is never
+/// trusted on any path.
+/// </para>
+/// <para>
+/// These tests render the real compiled view through <see cref="SetupTabViewRenderer"/> — same discovery,
+/// fakes and authorisation channel as the tabhead's tests — and assert on rendered output only. A
+/// regression that resolved off the model would render the wallet store's configured copy and its status
+/// links, which is exactly what the mismatch case asserts against; the render case holds the resolution
+/// honest the other way, so the guard cannot pass by simply never rendering anything. The not-running
+/// case exists because "running" is the half of the pane's state that a model-keyed lookup could leak
+/// even when the connection string itself stayed hidden.
+/// </para>
+/// </remarks>
+public class LNPaymentMethodSetupTabTests
+{
+    /// <summary>The store whose Spark wallet exists and would be reported on if consulted.</summary>
+    private const string WalletStore = "store-with-wallet";
+
+    /// <summary>A different, wallet-less store, used as the authorised one in the mismatch case.</summary>
+    private const string AuthorisedStore = "store-authorised";
+
+    /// <summary>A payment key shaped like a generated one, distinctive so its presence in output is unmistakable.</summary>
+    private const string PaymentKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    /// <summary>The configured copy, distinctive to the pane's else-branch.</summary>
+    private const string ConfiguredCopy = "Saving with";
+
+    /// <summary>The warning distinctive to the pane's not-running branch.</summary>
+    private const string NotRunningWarning = "not running at the moment";
+
+    [Fact]
+    public async Task A_request_carrying_no_authorised_store_renders_nothing()
+    {
+        using var harness = SparkServiceHarness.Create();
+        harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(1), PaymentKey);
+        SetupTabViewRenderer.StartService(harness);
+
+        // Nothing was authorised onto the request: the guard must fail closed rather than trust the form.
+        var html = await SetupTabViewRenderer.RenderTabAsync(harness.Service, authorisedStoreId: null, WalletStore);
+
+        Assert.DoesNotContain(WalletStore, html);
+        Assert.Equal(string.Empty, html.Trim());
+    }
+
+    [Fact]
+    public async Task A_model_naming_another_store_discloses_neither_its_configuration_nor_its_running_state()
+    {
+        using var harness = SparkServiceHarness.Create();
+        harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(2), PaymentKey);
+        SetupTabViewRenderer.StartService(harness);
+
+        // The attack shape: authorisation succeeded for the wallet-less AuthorisedStore, the form-bound
+        // model names WalletStore. The pane's two state questions must be asked of the authorised store
+        // alone — so neither the wallet store's configured copy nor its running state may appear, and
+        // its id may not ride into a generated link.
+        var html = await SetupTabViewRenderer.RenderTabAsync(harness.Service, authorisedStoreId: AuthorisedStore, WalletStore);
+
+        Assert.DoesNotContain(WalletStore, html);
+        Assert.DoesNotContain(PaymentKey, html);
+        Assert.DoesNotContain(ConfiguredCopy, html);
+        Assert.DoesNotContain(NotRunningWarning, html);
+        // What does render is the authorised store's own not-configured pane, with its setup link keyed
+        // off the authorised id — proof the partial resolved the request's store, not a blanket nothing.
+        Assert.Contains("This store has no Spark wallet yet", html);
+        Assert.Contains($"/Spark/Setup/{AuthorisedStore}", html);
+    }
+
+    [Fact]
+    public async Task The_authorised_store_with_a_running_wallet_gets_the_full_pane_rendered()
+    {
+        using var harness = SparkServiceHarness.Create();
+        harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(3), PaymentKey);
+        SetupTabViewRenderer.StartService(harness);
+
+        // The legitimate flow — authorised store and model agree on a store whose wallet is up: the
+        // configured copy and the running store's own status links, with no warning and, as the pane has
+        // always promised, no connection string.
+        var html = await SetupTabViewRenderer.RenderTabAsync(harness.Service, authorisedStoreId: WalletStore, WalletStore);
+
+        Assert.Contains(ConfiguredCopy, html);
+        Assert.Contains($"/Spark/Status/{WalletStore}", html);
+        Assert.DoesNotContain(NotRunningWarning, html);
+        Assert.DoesNotContain(PaymentKey, html);
+    }
+
+    [Fact]
+    public async Task An_authorised_store_whose_wallet_is_configured_but_not_running_says_so()
+    {
+        using var harness = SparkServiceHarness.Create();
+        harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(4), PaymentKey);
+        // The SDK connect for this store never returns, so startup leaves it configured but with no
+        // client up — the one state pair that distinguishes this pane from the plain configured one.
+        harness.Sdk.HangFor.Add(WalletStore);
+        SetupTabViewRenderer.StartService(harness);
+
+        // Both state questions were asked of the authorised store: configured, yes; running, no — and
+        // the warning names the same store's status page the rest of the pane links to.
+        var html = await SetupTabViewRenderer.RenderTabAsync(harness.Service, authorisedStoreId: WalletStore, WalletStore);
+
+        Assert.Contains(ConfiguredCopy, html);
+        Assert.Contains(NotRunningWarning, html);
+        Assert.Contains($"/Spark/Status/{WalletStore}", html);
+        Assert.DoesNotContain(PaymentKey, html);
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/LNPaymentMethodSetupTabheadTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/LNPaymentMethodSetupTabheadTests.cs
@@ -1,0 +1,276 @@
+using System.Buffers;
+using System.Globalization;
+using System.Reflection;
+using System.Text.Json;
+using BTCPayServer.Abstractions.Services;
+using BTCPayServer.Data;
+using BTCPayServer.Models.StoreViewModels;
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using BTCPayServer.Security;
+using Ganss.Xss;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The setup-tabhead extension point renders a store's connection string only for the store the request
+/// was authorised for — never for the one the bound model names.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>LightningNodeViewModel.StoreId</c> is an ordinary form-bound settable property, and core's POST of
+/// <c>SetupLightningNode</c> re-renders the page through six paths without ever reassigning it from the
+/// route or the authorised store. So the model reaching the plugin's partial on a POST can name any store
+/// on the server, and before the authorised-store guard the partial resolved the connection string — a
+/// bearer spend credential — straight off <c>Model.StoreId</c> and embedded it in page JS.
+/// </para>
+/// <para>
+/// These are the suite's first tests that <em>render</em> a view, and they render the real thing: the
+/// compiled <c>.cshtml</c> is discovered as the <see cref="RazorCompiledItemMetadataAttribute"/> the plugin
+/// assembly carries for it, executed against a real <see cref="SparkService"/> over
+/// <see cref="SparkServiceHarness"/> fakes, with the authorisation read through BTCPay's own
+/// <c>SetStoreData</c>/<c>GetStoreDataOrNull</c> channel. Assertions are on the rendered output only. A
+/// regression that dropped the guard would call <c>GetConnectionString</c> for the wrong store and put
+/// that store's key in the output, which is exactly what the mismatch case asserts against; the match
+/// case holds the guard honest the other way, so the fix cannot pass by simply never rendering anything.
+/// </para>
+/// <para>
+/// The stand-ins are plumbing around the view rather than in it: the <c>@inject</c>ed
+/// <see cref="Safe"/> is built over a single-method <see cref="IJsonHelper"/> and an
+/// <see cref="IHtmlHelper"/> dispatch proxy that do only what the production helpers do for this one
+/// call — serialise with <see cref="JsonSerializer"/>, wrap the result verbatim as HTML — and throw on
+/// anything else, so no other helper surface can be quietly relied on. The one tag helper the rendered
+/// branch does match, BTCPay's CSP nonce helper on the inline <c>&lt;script&gt;</c>, runs for real over
+/// the production factory; the link- and permission-helpers live only in branches no case reaches, so
+/// no link-generation services need modelling.
+/// </para>
+/// </remarks>
+public class LNPaymentMethodSetupTabheadTests
+{
+    /// <summary>The store whose connection string exists and would be rendered if consulted.</summary>
+    private const string WalletStore = "store-with-wallet";
+
+    /// <summary>A different, wallet-less store, used as the authorised one in the mismatch case.</summary>
+    private const string AuthorisedStore = "store-authorised";
+
+    /// <summary>A payment key shaped like a generated one, distinctive so its presence in output is unmistakable.</summary>
+    private const string PaymentKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    private const string TabheadItemPath = "/Views/Shared/Spark/LNPaymentMethodSetupTabhead.cshtml";
+
+    [Fact]
+    public async Task A_model_naming_another_store_than_the_authorised_one_renders_no_connection_string()
+    {
+        using var harness = SparkServiceHarness.Create();
+        harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(1), PaymentKey);
+        StartService(harness);
+
+        // The attack: authorisation succeeded for AuthorisedStore, the form-bound model names WalletStore.
+        var html = await RenderTabheadAsync(harness.Service, authorisedStoreId: AuthorisedStore, WalletStore);
+
+        Assert.DoesNotContain("type=flint", html);
+        Assert.DoesNotContain(PaymentKey, html);
+        // Fail-closed means the partial renders nothing at all — not even the pill it would otherwise emit.
+        Assert.Equal(string.Empty, html.Trim());
+    }
+
+    [Fact]
+    public async Task A_request_carrying_no_authorised_store_renders_nothing()
+    {
+        using var harness = SparkServiceHarness.Create();
+        harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(2), PaymentKey);
+        StartService(harness);
+
+        // Nothing was authorised onto the request: the guard must fail closed rather than trust the form.
+        var html = await RenderTabheadAsync(harness.Service, authorisedStoreId: null, WalletStore);
+
+        Assert.DoesNotContain("type=flint", html);
+        Assert.DoesNotContain(PaymentKey, html);
+        Assert.Equal(string.Empty, html.Trim());
+    }
+
+    [Fact]
+    public async Task The_authorised_store_still_gets_its_connection_string_rendered()
+    {
+        using var harness = SparkServiceHarness.Create();
+        harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(3), PaymentKey);
+        StartService(harness);
+
+        // The legitimate flow — authorised store and model agree — must keep working unchanged.
+        var html = await RenderTabheadAsync(harness.Service, authorisedStoreId: WalletStore, WalletStore);
+
+        Assert.Contains($"type=flint;store-id={WalletStore};key={PaymentKey}", html);
+        // And it is the real pill: the script that fills core's connection-string field is present.
+        Assert.Contains("<script", html);
+    }
+
+    /// <summary>
+    /// Runs <c>StartAsync</c> so the service's startup gate opens, with a timeout so a regression that hangs
+    /// startup fails the test instead of the test run.
+    /// </summary>
+    /// <remarks>
+    /// Needed even by the suppressed cases: if the guard were gone, the partial would reach
+    /// <c>GetConnectionString</c>, which awaits the gate — the test must distinguish "refused" from "still
+    /// waiting on a service nobody started".
+    /// </remarks>
+    private static void StartService(SparkServiceHarness harness)
+    {
+        if (!harness.Service.StartAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(30)))
+        {
+            Assert.Fail(
+                "SparkService.StartAsync did not complete within 30s over the harness's fake SDK; the render "
+                + "under test must be able to await the plugin's startup gate.");
+        }
+    }
+
+    /// <summary>
+    /// Executes the plugin's compiled <c>LNPaymentMethodSetupTabhead</c> page over the given authorisation
+    /// and model, and returns everything it wrote.
+    /// </summary>
+    private static async Task<string> RenderTabheadAsync(
+        SparkService service,
+        string? authorisedStoreId,
+        string modelStoreId)
+    {
+        // .NET 10's Razor compiler tags each compiled page class with a key/value metadata attribute;
+        // the "Identifier" key carries the .cshtml path it was compiled from.
+        var pageType = typeof(SparkPlugin).Assembly
+            .GetTypes()
+            .Single(t => t.GetCustomAttributes<RazorCompiledItemMetadataAttribute>()
+                .Any(m => m.Key == "Identifier" && m.Value == TabheadItemPath));
+        var page = (RazorPage<LightningNodeViewModel>)Activator.CreateInstance(pageType)!;
+
+        var viewData = new ViewDataDictionary<LightningNodeViewModel>(
+            new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        {
+            Model = new LightningNodeViewModel { CryptoCode = "BTC", StoreId = modelStoreId },
+        };
+
+        var httpContext = new DefaultHttpContext();
+        if (authorisedStoreId is not null)
+        {
+            // The same channel SetContextFilter writes on a request core authorised for a store.
+            httpContext.SetStoreData(new StoreData { Id = authorisedStoreId });
+        }
+
+        // The rendered branch contains an inline <script>, and the plugin's @addTagHelper lines bind
+        // BTCPay's CSPInlineScriptTagHelper to every script element — the only tag helper any rendered
+        // branch matches, since the MVC helpers all require asp-* attributes this markup does not carry
+        // and the permission/link helpers only match the anchor branch, which no case reaches. The
+        // factory and activator below are the production ones (internals, instantiated the way the DI
+        // registration does); the services added are the CSP policy bag the script helper stamps its
+        // nonce into and the production output buffer the tag-helper pipeline writes through.
+        httpContext.RequestServices = new ServiceCollection()
+            .AddSingleton<ITagHelperFactory>(CreateDefaultTagHelperFactory())
+            .AddSingleton<IViewBufferScope>(CreateViewBufferScope())
+            .AddSingleton(new ContentSecurityPolicies())
+            .BuildServiceProvider();
+
+        var writer = new StringWriter(CultureInfo.InvariantCulture);
+        page.ViewContext = new ViewContext
+        {
+            HttpContext = httpContext,
+            RouteData = new RouteData(),
+            ViewData = viewData,
+            Writer = writer,
+        };
+        page.ViewData = viewData;
+        // RazorPage<TModel>.Model is read off ViewData.Model; setting the view data is what feeds the view.
+
+        SetInjectProperty(page, nameof(SparkService), service);
+        SetInjectProperty(page, "Safe", new Safe(
+            DispatchProxy.Create<IHtmlHelper, RawOnlyHtmlHelper>(),
+            new PlainJsonHelper(),
+            new HtmlSanitizer()));
+
+        // RazorPageBase.HtmlEncoder is a [RazorInject] the view engine fills from DI (HtmlEncoder.Default
+        // is what MVC registers); the tag-helper output pipeline encodes through it.
+        SetInjectProperty(page, "HtmlEncoder", System.Text.Encodings.Web.HtmlEncoder.Default);
+
+        await page.ExecuteAsync();
+        return writer.ToString();
+    }
+
+    /// <summary>Sets one of the compiled page's <c>@inject</c> properties, failing loudly if it is not there.</summary>
+    private static void SetInjectProperty(object page, string name, object value)
+    {
+        var property = page.GetType().GetProperty(
+            name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                $"The compiled page {page.GetType().Name} has no '{name}' inject property to populate.");
+
+        if (!property.CanWrite)
+        {
+            throw new InvalidOperationException(
+                $"The compiled page's '{name}' inject property is not writable.");
+        }
+
+        property.SetValue(page, value);
+    }
+
+    /// <summary>
+    /// The production <see cref="ITagHelperFactory"/> over the production activator, both internal and
+    /// therefore reflection-instantiated rather than reimplemented — the point is that the partial gets
+    /// exactly the tag helpers a real request would build for it.
+    /// </summary>
+    private static ITagHelperFactory CreateDefaultTagHelperFactory()
+    {
+        var assembly = typeof(ITagHelperFactory).Assembly;
+        var activatorType = assembly.GetType(
+            "Microsoft.AspNetCore.Mvc.Razor.Infrastructure.DefaultTagHelperActivator", throwOnError: true)!;
+        var factoryType = assembly.GetType(
+            "Microsoft.AspNetCore.Mvc.Razor.DefaultTagHelperFactory", throwOnError: true)!;
+        return (ITagHelperFactory)Activator.CreateInstance(factoryType, Activator.CreateInstance(activatorType))!;
+    }
+
+    /// <summary>
+    /// The production <see cref="IViewBufferScope"/> over the shared array pools — the instance MVC's own
+    /// DI registers — needed because the tag-helper pipeline buffers the script element's content.
+    /// </summary>
+    private static IViewBufferScope CreateViewBufferScope()
+    {
+        var type = typeof(IViewBufferScope).Assembly.GetType(
+            "Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers.MemoryPoolViewBufferScope", throwOnError: true)!;
+        return (IViewBufferScope)Activator.CreateInstance(
+            type, ArrayPool<ViewBufferValue>.Shared, ArrayPool<char>.Shared)!;
+    }
+
+    /// <summary>Serialises JSON exactly as the page needs; anything else about the helper is unused by this view.</summary>
+    private sealed class PlainJsonHelper : IJsonHelper
+    {
+        public IHtmlContent Serialize(object? model) =>
+            new HtmlString(JsonSerializer.Serialize(model));
+    }
+}
+
+/// <summary>
+/// An <see cref="IHtmlHelper"/> that does only what the production helper does for <c>Raw</c> — wrap the
+/// value verbatim as HTML — because that is all <c>Safe.Json</c> calls. Every other member throws, so a
+/// view that starts reaching for more cannot pass on a helper it was never given. Public because that is
+/// what <see cref="DispatchProxy"/> requires of the type it derives its proxy from.
+/// </summary>
+public class RawOnlyHtmlHelper : DispatchProxy
+{
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        if (targetMethod is { Name: "Raw" } && targetMethod.GetParameters().Length == 1)
+        {
+            return new HtmlString(System.Convert.ToString(args![0], CultureInfo.InvariantCulture) ?? string.Empty);
+        }
+
+        throw new NotSupportedException(
+            $"The rendered setup partial must not call IHtmlHelper.{targetMethod?.Name}; "
+            + "extend the test double deliberately if it ever does.");
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/LNPaymentMethodSetupTabheadTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/LNPaymentMethodSetupTabheadTests.cs
@@ -1,24 +1,4 @@
-using System.Buffers;
-using System.Globalization;
-using System.Reflection;
-using System.Text.Json;
-using BTCPayServer.Abstractions.Services;
-using BTCPayServer.Data;
-using BTCPayServer.Models.StoreViewModels;
-using BTCPayServer.Plugins.Flint.Services;
 using BTCPayServer.Plugins.Flint.Tests.Fakes;
-using BTCPayServer.Security;
-using Ganss.Xss;
-using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.AspNetCore.Mvc.Razor;
-using Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.Razor.Hosting;
-using Microsoft.AspNetCore.Routing;
-using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace BTCPayServer.Plugins.Flint.Tests;
@@ -36,24 +16,15 @@ namespace BTCPayServer.Plugins.Flint.Tests;
 /// bearer spend credential — straight off <c>Model.StoreId</c> and embedded it in page JS.
 /// </para>
 /// <para>
-/// These are the suite's first tests that <em>render</em> a view, and they render the real thing: the
-/// compiled <c>.cshtml</c> is discovered as the <see cref="RazorCompiledItemMetadataAttribute"/> the plugin
-/// assembly carries for it, executed against a real <see cref="SparkService"/> over
-/// <see cref="SparkServiceHarness"/> fakes, with the authorisation read through BTCPay's own
-/// <c>SetStoreData</c>/<c>GetStoreDataOrNull</c> channel. Assertions are on the rendered output only. A
-/// regression that dropped the guard would call <c>GetConnectionString</c> for the wrong store and put
-/// that store's key in the output, which is exactly what the mismatch case asserts against; the match
-/// case holds the guard honest the other way, so the fix cannot pass by simply never rendering anything.
-/// </para>
-/// <para>
-/// The stand-ins are plumbing around the view rather than in it: the <c>@inject</c>ed
-/// <see cref="Safe"/> is built over a single-method <see cref="IJsonHelper"/> and an
-/// <see cref="IHtmlHelper"/> dispatch proxy that do only what the production helpers do for this one
-/// call — serialise with <see cref="JsonSerializer"/>, wrap the result verbatim as HTML — and throw on
-/// anything else, so no other helper surface can be quietly relied on. The one tag helper the rendered
-/// branch does match, BTCPay's CSP nonce helper on the inline <c>&lt;script&gt;</c>, runs for real over
-/// the production factory; the link- and permission-helpers live only in branches no case reaches, so
-/// no link-generation services need modelling.
+/// The partial resolves the authorised id from the request and keys every lookup off it alone; the only
+/// refusal is a missing authorisation, and the form-bound id is never trusted on any path. These are the
+/// suite's first tests that <em>render</em> a view, and they render the real thing through
+/// <see cref="SetupTabViewRenderer"/>: the compiled <c>.cshtml</c>, a real <see cref="BTCPayServer.Plugins.Flint.Services.SparkService"/>
+/// over fakes, authorisation through BTCPay's own store-data channel. Assertions are on the rendered
+/// output only. A regression that resolved off the model would call <c>GetConnectionString</c> for the
+/// wrong store and put that store's key in the output, which is exactly what the mismatch case asserts
+/// against; the match case holds the resolution honest the other way, so the fix cannot pass by simply
+/// never rendering anything.
 /// </para>
 /// </remarks>
 public class LNPaymentMethodSetupTabheadTests
@@ -67,22 +38,25 @@ public class LNPaymentMethodSetupTabheadTests
     /// <summary>A payment key shaped like a generated one, distinctive so its presence in output is unmistakable.</summary>
     private const string PaymentKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
-    private const string TabheadItemPath = "/Views/Shared/Spark/LNPaymentMethodSetupTabhead.cshtml";
-
     [Fact]
     public async Task A_model_naming_another_store_than_the_authorised_one_renders_no_connection_string()
     {
         using var harness = SparkServiceHarness.Create();
         harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(1), PaymentKey);
-        StartService(harness);
+        SetupTabViewRenderer.StartService(harness);
 
         // The attack: authorisation succeeded for AuthorisedStore, the form-bound model names WalletStore.
-        var html = await RenderTabheadAsync(harness.Service, authorisedStoreId: AuthorisedStore, WalletStore);
+        // Rendering keys off the authorised id alone, so what can render is only the authorised store's own
+        // wallet-less branch — and the store the form named appears nowhere in the output.
+        var html = await SetupTabViewRenderer.RenderTabheadAsync(harness.Service, authorisedStoreId: AuthorisedStore, WalletStore);
 
         Assert.DoesNotContain("type=flint", html);
         Assert.DoesNotContain(PaymentKey, html);
-        // Fail-closed means the partial renders nothing at all — not even the pill it would otherwise emit.
-        Assert.Equal(string.Empty, html.Trim());
+        Assert.DoesNotContain(WalletStore, html);
+        // And the partial is not merely silent: it renders the authorised store's honest "no wallet yet"
+        // pill, with its link carrying the authorised id — proof of which store it resolved, not of nothing.
+        Assert.Contains("Set up Flint", html);
+        Assert.Contains($"/Spark/Setup/{AuthorisedStore}", html);
     }
 
     [Fact]
@@ -90,10 +64,10 @@ public class LNPaymentMethodSetupTabheadTests
     {
         using var harness = SparkServiceHarness.Create();
         harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(2), PaymentKey);
-        StartService(harness);
+        SetupTabViewRenderer.StartService(harness);
 
         // Nothing was authorised onto the request: the guard must fail closed rather than trust the form.
-        var html = await RenderTabheadAsync(harness.Service, authorisedStoreId: null, WalletStore);
+        var html = await SetupTabViewRenderer.RenderTabheadAsync(harness.Service, authorisedStoreId: null, WalletStore);
 
         Assert.DoesNotContain("type=flint", html);
         Assert.DoesNotContain(PaymentKey, html);
@@ -105,172 +79,12 @@ public class LNPaymentMethodSetupTabheadTests
     {
         using var harness = SparkServiceHarness.Create();
         harness.SeedStore(WalletStore, SparkServiceHarness.MnemonicFor(3), PaymentKey);
-        StartService(harness);
+        SetupTabViewRenderer.StartService(harness);
 
         // The legitimate flow — authorised store and model agree — must keep working unchanged.
-        var html = await RenderTabheadAsync(harness.Service, authorisedStoreId: WalletStore, WalletStore);
+        var html = await SetupTabViewRenderer.RenderTabheadAsync(harness.Service, authorisedStoreId: WalletStore, WalletStore);
 
-        Assert.Contains($"type=flint;store-id={WalletStore};key={PaymentKey}", html);
         // And it is the real pill: the script that fills core's connection-string field is present.
         Assert.Contains("<script", html);
-    }
-
-    /// <summary>
-    /// Runs <c>StartAsync</c> so the service's startup gate opens, with a timeout so a regression that hangs
-    /// startup fails the test instead of the test run.
-    /// </summary>
-    /// <remarks>
-    /// Needed even by the suppressed cases: if the guard were gone, the partial would reach
-    /// <c>GetConnectionString</c>, which awaits the gate — the test must distinguish "refused" from "still
-    /// waiting on a service nobody started".
-    /// </remarks>
-    private static void StartService(SparkServiceHarness harness)
-    {
-        if (!harness.Service.StartAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(30)))
-        {
-            Assert.Fail(
-                "SparkService.StartAsync did not complete within 30s over the harness's fake SDK; the render "
-                + "under test must be able to await the plugin's startup gate.");
-        }
-    }
-
-    /// <summary>
-    /// Executes the plugin's compiled <c>LNPaymentMethodSetupTabhead</c> page over the given authorisation
-    /// and model, and returns everything it wrote.
-    /// </summary>
-    private static async Task<string> RenderTabheadAsync(
-        SparkService service,
-        string? authorisedStoreId,
-        string modelStoreId)
-    {
-        // .NET 10's Razor compiler tags each compiled page class with a key/value metadata attribute;
-        // the "Identifier" key carries the .cshtml path it was compiled from.
-        var pageType = typeof(SparkPlugin).Assembly
-            .GetTypes()
-            .Single(t => t.GetCustomAttributes<RazorCompiledItemMetadataAttribute>()
-                .Any(m => m.Key == "Identifier" && m.Value == TabheadItemPath));
-        var page = (RazorPage<LightningNodeViewModel>)Activator.CreateInstance(pageType)!;
-
-        var viewData = new ViewDataDictionary<LightningNodeViewModel>(
-            new EmptyModelMetadataProvider(), new ModelStateDictionary())
-        {
-            Model = new LightningNodeViewModel { CryptoCode = "BTC", StoreId = modelStoreId },
-        };
-
-        var httpContext = new DefaultHttpContext();
-        if (authorisedStoreId is not null)
-        {
-            // The same channel SetContextFilter writes on a request core authorised for a store.
-            httpContext.SetStoreData(new StoreData { Id = authorisedStoreId });
-        }
-
-        // The rendered branch contains an inline <script>, and the plugin's @addTagHelper lines bind
-        // BTCPay's CSPInlineScriptTagHelper to every script element — the only tag helper any rendered
-        // branch matches, since the MVC helpers all require asp-* attributes this markup does not carry
-        // and the permission/link helpers only match the anchor branch, which no case reaches. The
-        // factory and activator below are the production ones (internals, instantiated the way the DI
-        // registration does); the services added are the CSP policy bag the script helper stamps its
-        // nonce into and the production output buffer the tag-helper pipeline writes through.
-        httpContext.RequestServices = new ServiceCollection()
-            .AddSingleton<ITagHelperFactory>(CreateDefaultTagHelperFactory())
-            .AddSingleton<IViewBufferScope>(CreateViewBufferScope())
-            .AddSingleton(new ContentSecurityPolicies())
-            .BuildServiceProvider();
-
-        var writer = new StringWriter(CultureInfo.InvariantCulture);
-        page.ViewContext = new ViewContext
-        {
-            HttpContext = httpContext,
-            RouteData = new RouteData(),
-            ViewData = viewData,
-            Writer = writer,
-        };
-        page.ViewData = viewData;
-        // RazorPage<TModel>.Model is read off ViewData.Model; setting the view data is what feeds the view.
-
-        SetInjectProperty(page, nameof(SparkService), service);
-        SetInjectProperty(page, "Safe", new Safe(
-            DispatchProxy.Create<IHtmlHelper, RawOnlyHtmlHelper>(),
-            new PlainJsonHelper(),
-            new HtmlSanitizer()));
-
-        // RazorPageBase.HtmlEncoder is a [RazorInject] the view engine fills from DI (HtmlEncoder.Default
-        // is what MVC registers); the tag-helper output pipeline encodes through it.
-        SetInjectProperty(page, "HtmlEncoder", System.Text.Encodings.Web.HtmlEncoder.Default);
-
-        await page.ExecuteAsync();
-        return writer.ToString();
-    }
-
-    /// <summary>Sets one of the compiled page's <c>@inject</c> properties, failing loudly if it is not there.</summary>
-    private static void SetInjectProperty(object page, string name, object value)
-    {
-        var property = page.GetType().GetProperty(
-            name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException(
-                $"The compiled page {page.GetType().Name} has no '{name}' inject property to populate.");
-
-        if (!property.CanWrite)
-        {
-            throw new InvalidOperationException(
-                $"The compiled page's '{name}' inject property is not writable.");
-        }
-
-        property.SetValue(page, value);
-    }
-
-    /// <summary>
-    /// The production <see cref="ITagHelperFactory"/> over the production activator, both internal and
-    /// therefore reflection-instantiated rather than reimplemented — the point is that the partial gets
-    /// exactly the tag helpers a real request would build for it.
-    /// </summary>
-    private static ITagHelperFactory CreateDefaultTagHelperFactory()
-    {
-        var assembly = typeof(ITagHelperFactory).Assembly;
-        var activatorType = assembly.GetType(
-            "Microsoft.AspNetCore.Mvc.Razor.Infrastructure.DefaultTagHelperActivator", throwOnError: true)!;
-        var factoryType = assembly.GetType(
-            "Microsoft.AspNetCore.Mvc.Razor.DefaultTagHelperFactory", throwOnError: true)!;
-        return (ITagHelperFactory)Activator.CreateInstance(factoryType, Activator.CreateInstance(activatorType))!;
-    }
-
-    /// <summary>
-    /// The production <see cref="IViewBufferScope"/> over the shared array pools — the instance MVC's own
-    /// DI registers — needed because the tag-helper pipeline buffers the script element's content.
-    /// </summary>
-    private static IViewBufferScope CreateViewBufferScope()
-    {
-        var type = typeof(IViewBufferScope).Assembly.GetType(
-            "Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers.MemoryPoolViewBufferScope", throwOnError: true)!;
-        return (IViewBufferScope)Activator.CreateInstance(
-            type, ArrayPool<ViewBufferValue>.Shared, ArrayPool<char>.Shared)!;
-    }
-
-    /// <summary>Serialises JSON exactly as the page needs; anything else about the helper is unused by this view.</summary>
-    private sealed class PlainJsonHelper : IJsonHelper
-    {
-        public IHtmlContent Serialize(object? model) =>
-            new HtmlString(JsonSerializer.Serialize(model));
-    }
-}
-
-/// <summary>
-/// An <see cref="IHtmlHelper"/> that does only what the production helper does for <c>Raw</c> — wrap the
-/// value verbatim as HTML — because that is all <c>Safe.Json</c> calls. Every other member throws, so a
-/// view that starts reaching for more cannot pass on a helper it was never given. Public because that is
-/// what <see cref="DispatchProxy"/> requires of the type it derives its proxy from.
-/// </summary>
-public class RawOnlyHtmlHelper : DispatchProxy
-{
-    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
-    {
-        if (targetMethod is { Name: "Raw" } && targetMethod.GetParameters().Length == 1)
-        {
-            return new HtmlString(System.Convert.ToString(args![0], CultureInfo.InvariantCulture) ?? string.Empty);
-        }
-
-        throw new NotSupportedException(
-            $"The rendered setup partial must not call IHtmlHelper.{targetMethod?.Name}; "
-            + "extend the test double deliberately if it ever does.");
     }
 }

--- a/BTCPayServer.Plugins.Flint.Tests/SetupTabViewRenderer.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SetupTabViewRenderer.cs
@@ -1,0 +1,405 @@
+using System.Buffers;
+using System.Globalization;
+using System.Reflection;
+using System.Security.Claims;
+using System.Text.Json;
+using BTCPayServer.Abstractions.Services;
+using BTCPayServer.Data;
+using BTCPayServer.Models.StoreViewModels;
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using BTCPayServer.Security;
+using Ganss.Xss;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// Renders the plugin's two <c>ln-payment-method-setup</c> extension-point partials — the tabhead and the
+/// tab — out of the compiled plugin assembly, for the tests that pin which store each partial may read from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pages are discovered as the <see cref="RazorCompiledItemMetadataAttribute"/> the plugin assembly
+/// carries for each <c>.cshtml</c> path, so what executes is the real compiled view, not a transcription.
+/// Each render runs the page against a real <see cref="SparkService"/> over <see cref="SparkServiceHarness"/>
+/// fakes, with the authorisation read through BTCPay's own <c>SetStoreData</c>/<c>GetStoreDataOrNull</c>
+/// channel — the same one core's <c>SetContextFilter</c> writes on a store-authorised request.
+/// </para>
+/// <para>
+/// The stand-ins are plumbing around the view rather than in it. The <c>@inject</c>ed <see cref="Safe"/> is
+/// built over a single-method <see cref="IJsonHelper"/> and an <see cref="IHtmlHelper"/> dispatch proxy that
+/// do only what the production helpers do for the one call the tabhead makes — serialise with
+/// <see cref="JsonSerializer"/>, wrap the result verbatim as HTML — and throw on anything else, so no other
+/// helper surface can be quietly relied on. Of the tag helpers the extension-point markup actually matches,
+/// BTCPay's CSP nonce helper on the inline <c>&lt;script&gt;</c> and the permission helper on its links run
+/// for real: the factory and activator are the production ones, and the permission check passes through a
+/// stub <see cref="IAuthorizationService"/> that grants, because whether a real user holds
+/// CanModifyStoreSettings is core's authorization stack's question, not the partial's. The one genuinely
+/// modelled piece is link generation: .NET 10's <c>AnchorTagHelper</c> builds its <c>href</c> through
+/// <see cref="IHtmlGenerator"/>, and <see cref="LinkBuildingHtmlGenerator"/> composes one from the route
+/// values the view actually computed — which is precisely how these tests see which store id the view put
+/// into the link. Every other generator member throws, so a view that starts leaning on more markup than
+/// these partials carry cannot pass quietly.
+/// </para>
+/// </remarks>
+internal static class SetupTabViewRenderer
+{
+    /// <summary>The compiled item path the Razor compiler recorded for the tabhead partial.</summary>
+    public const string TabheadItemPath = "/Views/Shared/Spark/LNPaymentMethodSetupTabhead.cshtml";
+
+    /// <summary>The compiled item path the Razor compiler recorded for the tab partial.</summary>
+    public const string TabItemPath = "/Views/Shared/Spark/LNPaymentMethodSetupTab.cshtml";
+
+    /// <summary>
+    /// Executes the compiled <c>LNPaymentMethodSetupTabhead</c> page over the given authorisation and
+    /// model, and returns everything it wrote.
+    /// </summary>
+    public static Task<string> RenderTabheadAsync(
+        SparkService service,
+        string? authorisedStoreId,
+        string modelStoreId) =>
+        RenderAsync(TabheadItemPath, service, authorisedStoreId, modelStoreId);
+
+    /// <summary>
+    /// Executes the compiled <c>LNPaymentMethodSetupTab</c> page over the given authorisation and model,
+    /// and returns everything it wrote.
+    /// </summary>
+    public static Task<string> RenderTabAsync(
+        SparkService service,
+        string? authorisedStoreId,
+        string modelStoreId) =>
+        RenderAsync(TabItemPath, service, authorisedStoreId, modelStoreId);
+
+    /// <summary>
+    /// Runs <c>StartAsync</c> so the service's startup gate opens, with a timeout so a regression that hangs
+    /// startup fails the test instead of the test run.
+    /// </summary>
+    /// <remarks>
+    /// Needed even by the suppressed cases: if the store guard were gone, the partial would reach
+    /// <c>GetConnectionString</c>, which awaits the gate — the test must distinguish "refused" from "still
+    /// waiting on a service nobody started".
+    /// </remarks>
+    public static void StartService(SparkServiceHarness harness)
+    {
+        if (!harness.Service.StartAsync(CancellationToken.None).Wait(TimeSpan.FromSeconds(30)))
+        {
+            Assert.Fail(
+                "SparkService.StartAsync did not complete within 30s over the harness's fake SDK; the render "
+                + "under test must be able to await the plugin's startup gate.");
+        }
+    }
+
+    /// <summary>
+    /// Executes the plugin's compiled page at <paramref name="compiledItemPath"/> over the given
+    /// authorisation and model, and returns everything it wrote.
+    /// </summary>
+    /// <param name="compiledItemPath">
+    /// The <c>.cshtml</c> path the Razor compiler recorded for the page, e.g.
+    /// <c>/Views/Shared/Spark/LNPaymentMethodSetupTabhead.cshtml</c>.
+    /// </param>
+    /// <param name="service">The harness's service the page's <c>@inject</c>ed property is wired to.</param>
+    /// <param name="authorisedStoreId">
+    /// The store to authorise onto the request through <c>SetStoreData</c>, or <c>null</c> for a request
+    /// that carries no authorised store at all.
+    /// </param>
+    /// <param name="modelStoreId">
+    /// The store id bound into the form model — the value a POST can name arbitrarily, independent of the
+    /// authorisation above.
+    /// </param>
+    public static async Task<string> RenderAsync(
+        string compiledItemPath,
+        SparkService service,
+        string? authorisedStoreId,
+        string modelStoreId)
+    {
+        // .NET 10's Razor compiler tags each compiled page class with a key/value metadata attribute;
+        // the "Identifier" key carries the .cshtml path it was compiled from.
+        var pageType = typeof(SparkPlugin).Assembly
+            .GetTypes()
+            .Single(t => t.GetCustomAttributes<RazorCompiledItemMetadataAttribute>()
+                .Any(m => m.Key == "Identifier" && m.Value == compiledItemPath));
+        var page = (RazorPage<LightningNodeViewModel>)Activator.CreateInstance(pageType)!;
+
+        var viewData = new ViewDataDictionary<LightningNodeViewModel>(
+            new EmptyModelMetadataProvider(), new ModelStateDictionary())
+        {
+            Model = new LightningNodeViewModel { CryptoCode = "BTC", StoreId = modelStoreId },
+        };
+
+        var httpContext = new DefaultHttpContext();
+        if (authorisedStoreId is not null)
+        {
+            // The same channel SetContextFilter writes on a request core authorised for a store.
+            httpContext.SetStoreData(new StoreData { Id = authorisedStoreId });
+        }
+
+        // Both partials' rendered branches contain anchors, and the plugin's @addTagHelper lines bind
+        // core's permission helper and MVC's anchor helper to them (the tabhead's configured branch also
+        // carries an inline <script>, matched by BTCPay's CSP nonce helper). The factory and activator
+        // below are the production ones (internals, instantiated the way the DI registration does), so
+        // the partials get exactly the tag helpers a real request would build for them; the services
+        // added alongside are what those helpers activate from — the CSP policy bag the script helper
+        // stamps its nonce into, a granting authorization service, the production output buffer the
+        // tag-helper pipeline writes through, and the stand-in link generator documented on the class.
+        httpContext.RequestServices = new ServiceCollection()
+            .AddSingleton<ITagHelperFactory>(CreateDefaultTagHelperFactory())
+            .AddSingleton<IViewBufferScope>(CreateViewBufferScope())
+            .AddSingleton(new ContentSecurityPolicies())
+            .AddSingleton<IAuthorizationService, GrantAllAuthorizationService>()
+            .AddSingleton<IHttpContextAccessor>(new FixedHttpContextAccessor(httpContext))
+            .AddSingleton<IHtmlGenerator, LinkBuildingHtmlGenerator>()
+            .BuildServiceProvider();
+
+        var writer = new StringWriter(CultureInfo.InvariantCulture);
+        page.ViewContext = new ViewContext
+        {
+            HttpContext = httpContext,
+            RouteData = new RouteData(),
+            ViewData = viewData,
+            Writer = writer,
+        };
+        page.ViewData = viewData;
+        // RazorPage<TModel>.Model is read off ViewData.Model; setting the view data is what feeds the view.
+
+        SetInjectProperty(page, nameof(SparkService), service);
+        SetInjectProperty(page, "Safe", new Safe(
+            DispatchProxy.Create<IHtmlHelper, RawOnlyHtmlHelper>(),
+            new PlainJsonHelper(),
+            new HtmlSanitizer()));
+
+        // RazorPageBase.HtmlEncoder is a [RazorInject] the view engine fills from DI (HtmlEncoder.Default
+        // is what MVC registers); the tag-helper output pipeline encodes through it.
+        SetInjectProperty(page, "HtmlEncoder", System.Text.Encodings.Web.HtmlEncoder.Default);
+
+        await page.ExecuteAsync();
+        return writer.ToString();
+    }
+
+    /// <summary>Sets one of the compiled page's <c>@inject</c> properties, failing loudly if it is not there.</summary>
+    private static void SetInjectProperty(object page, string name, object value)
+    {
+        var property = page.GetType().GetProperty(
+            name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                $"The compiled page {page.GetType().Name} has no '{name}' inject property to populate.");
+
+        if (!property.CanWrite)
+        {
+            throw new InvalidOperationException(
+                $"The compiled page's '{name}' inject property is not writable.");
+        }
+
+        property.SetValue(page, value);
+    }
+
+    /// <summary>
+    /// The production <see cref="ITagHelperFactory"/> over the production activator, both internal and
+    /// therefore reflection-instantiated rather than reimplemented — the point is that the partial gets
+    /// exactly the tag helpers a real request would build for it.
+    /// </summary>
+    private static ITagHelperFactory CreateDefaultTagHelperFactory()
+    {
+        var assembly = typeof(ITagHelperFactory).Assembly;
+        var activatorType = assembly.GetType(
+            "Microsoft.AspNetCore.Mvc.Razor.Infrastructure.DefaultTagHelperActivator", throwOnError: true)!;
+        var factoryType = assembly.GetType(
+            "Microsoft.AspNetCore.Mvc.Razor.DefaultTagHelperFactory", throwOnError: true)!;
+        return (ITagHelperFactory)Activator.CreateInstance(factoryType, Activator.CreateInstance(activatorType))!;
+    }
+
+    /// <summary>
+    /// The production <see cref="IViewBufferScope"/> over the shared array pools — the instance MVC's own
+    /// DI registers — needed because the tag-helper pipeline buffers element content.
+    /// </summary>
+    private static IViewBufferScope CreateViewBufferScope()
+    {
+        var type = typeof(IViewBufferScope).Assembly.GetType(
+            "Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers.MemoryPoolViewBufferScope", throwOnError: true)!;
+        return (IViewBufferScope)Activator.CreateInstance(
+            type, ArrayPool<ViewBufferValue>.Shared, ArrayPool<char>.Shared)!;
+    }
+
+    /// <summary>Serialises JSON exactly as the page needs; anything else about the helper is unused by these views.</summary>
+    private sealed class PlainJsonHelper : IJsonHelper
+    {
+        public IHtmlContent Serialize(object? model) =>
+            new HtmlString(JsonSerializer.Serialize(model));
+    }
+
+    /// <summary>Grants every permission check, so a link's presence shows what the view rendered, not who is asking.</summary>
+    private sealed class GrantAllAuthorizationService : IAuthorizationService
+    {
+        public Task<AuthorizationResult> AuthorizeAsync(
+            ClaimsPrincipal user, object? resource, IEnumerable<IAuthorizationRequirement> requirements) =>
+            Task.FromResult(AuthorizationResult.Success());
+
+        public Task<AuthorizationResult> AuthorizeAsync(
+            ClaimsPrincipal user, object? resource, string policyName) =>
+            Task.FromResult(AuthorizationResult.Success());
+    }
+
+    /// <summary>Hands the permission helper the very context the render is running over.</summary>
+    private sealed class FixedHttpContextAccessor(HttpContext httpContext) : IHttpContextAccessor
+    {
+        public HttpContext? HttpContext { get; set; } = httpContext;
+    }
+
+    /// <summary>
+    /// The one <see cref="IHtmlGenerator"/> member these partials' markup reaches through — their anchors
+    /// carry <c>asp-controller</c>/<c>asp-action</c>/<c>asp-route-storeId</c>, which .NET 10's anchor tag
+    /// helper turns into a <see cref="GenerateActionLink"/> call — and it returns exactly what the
+    /// production generator returns for the same inputs in the shape these tests need: an href composed
+    /// from the route values the view computed, so an assertion can read which store id the view resolved.
+    /// Every other member throws: a view that starts reaching for forms, inputs or validation markup has
+    /// grown past what this harness undertakes to model, and must say so loudly.
+    /// </summary>
+    private sealed class LinkBuildingHtmlGenerator : IHtmlGenerator
+    {
+        public string IdAttributeDotReplacement => ".";
+
+        public TagBuilder GenerateActionLink(
+            ViewContext viewContext,
+            string linkText,
+            string? actionName,
+            string? controllerName,
+            string? protocol,
+            string? hostname,
+            string? fragment,
+            object? routeValues,
+            object? htmlAttributes)
+        {
+            var route = new RouteValueDictionary(routeValues);
+            var path = $"/{controllerName}/{actionName}";
+            if (route.TryGetValue("storeId", out var storeId) && storeId is not null)
+            {
+                path += $"/{storeId}";
+            }
+
+            var tag = new TagBuilder("a");
+            tag.Attributes["href"] =
+                (protocol is null ? string.Empty : $"{protocol}://") + hostname + path + fragment;
+            return tag;
+        }
+
+        public string Encode(string value) => throw Unused(nameof(Encode), "string");
+
+        public string Encode(object value) => throw Unused(nameof(Encode), "object");
+
+        public string FormatValue(object? value, string? format) => throw Unused(nameof(FormatValue));
+
+        public IHtmlContent GenerateAntiforgery(ViewContext viewContext) => throw Unused(nameof(GenerateAntiforgery));
+
+        public TagBuilder GenerateCheckBox(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression, bool? isChecked, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateCheckBox));
+
+        public TagBuilder GenerateForm(
+            ViewContext viewContext, string? actionName, string? controllerName, object? routeValues, string? method, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateForm));
+
+        public IHtmlContent GenerateGroupsAndOptions(string? optionLabel, IEnumerable<SelectListItem> selectList) =>
+            throw Unused(nameof(GenerateGroupsAndOptions));
+
+        public TagBuilder GenerateHidden(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression, object? value, bool useViewData, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateHidden));
+
+        public TagBuilder GenerateHiddenForCheckbox(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression) =>
+            throw Unused(nameof(GenerateHiddenForCheckbox));
+
+        public TagBuilder GenerateLabel(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression, string? labelText, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateLabel));
+
+        public TagBuilder GeneratePageForm(
+            ViewContext viewContext, string pageName, string? pageHandler, object? routeValues, string? fragment, string? method, object? htmlAttributes) =>
+            throw Unused(nameof(GeneratePageForm));
+
+        public TagBuilder GeneratePageLink(
+            ViewContext viewContext, string linkText, string pageName, string? pageHandler, string? protocol, string? hostname, string? fragment, object? routeValues, object? htmlAttributes) =>
+            throw Unused(nameof(GeneratePageLink));
+
+        public TagBuilder GeneratePassword(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression, object? value, object? htmlAttributes) =>
+            throw Unused(nameof(GeneratePassword));
+
+        public TagBuilder GenerateRadioButton(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression, object? value, bool? isChecked, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateRadioButton));
+
+        public TagBuilder GenerateRouteForm(
+            ViewContext viewContext, string? routeName, object? routeValues, string? method, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateRouteForm));
+
+        public TagBuilder GenerateRouteLink(
+            ViewContext viewContext, string linkText, string? routeName, string? protocol, string? hostName, string? fragment, object? routeValues, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateRouteLink));
+
+        public TagBuilder GenerateSelect(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string? optionLabel, string expression, IEnumerable<SelectListItem>? selectList, bool allowMultiple, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateSelect));
+
+        public TagBuilder GenerateSelect(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string? optionLabel, string expression, IEnumerable<SelectListItem>? selectList, ICollection<string>? currentValues, bool allowMultiple, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateSelect), "with currentValues");
+
+        public TagBuilder GenerateTextArea(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression, int rows, int columns, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateTextArea));
+
+        public TagBuilder GenerateTextBox(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression, object? value, string? format, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateTextBox));
+
+        public TagBuilder GenerateValidationMessage(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression, string? message, string? tag, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateValidationMessage));
+
+        public TagBuilder GenerateValidationSummary(
+            ViewContext viewContext, bool excludePropertyErrors, string? message, string? headerTag, object? htmlAttributes) =>
+            throw Unused(nameof(GenerateValidationSummary));
+
+        public ICollection<string> GetCurrentValues(
+            ViewContext viewContext, ModelExplorer? modelExplorer, string expression, bool allowMultiple) =>
+            throw Unused(nameof(GetCurrentValues));
+
+        private static NotSupportedException Unused(string member, string detail = "") =>
+            new(
+                $"The rendered setup partials must not call IHtmlGenerator.{member}{detail}; "
+                + "extend this stand-in deliberately if they ever do.");
+    }
+}
+
+/// <summary>
+/// An <see cref="IHtmlHelper"/> that does only what the production helper does for <c>Raw</c> — wrap the
+/// value verbatim as HTML — because that is all <c>Safe.Json</c> calls. Every other member throws, so a
+/// view that starts reaching for more cannot pass on a helper it was never given. Public because that is
+/// what <see cref="DispatchProxy"/> requires of the type it derives its proxy from.
+/// </summary>
+public class RawOnlyHtmlHelper : DispatchProxy
+{
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+    {
+        if (targetMethod is { Name: "Raw" } && targetMethod.GetParameters().Length == 1)
+        {
+            return new HtmlString(System.Convert.ToString(args![0], CultureInfo.InvariantCulture) ?? string.Empty);
+        }
+
+        throw new NotSupportedException(
+            $"The rendered setup partial must not call IHtmlHelper.{targetMethod?.Name}; "
+            + "extend the test double deliberately if it ever does.");
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -1020,10 +1020,22 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
     /// The connection string a store's Lightning payment method should hold. Null when the store has no
     /// payment key yet.
     /// </summary>
-    public async Task<string?> GetConnectionString(string storeId)
+    /// <remarks>
+    /// <para>
+    /// Caller contract: <paramref name="authorisedStoreId"/> must be the store that was security-authorised
+    /// for this request — for an HTTP request, <c>HttpContext.GetStoreDataOrNull()?.Id</c> — never an id
+    /// bound from a form or query string. This returns the store's bearer spend credential and checks
+    /// nothing itself about who is asking.
+    /// </para>
+    /// <para>
+    /// The only callers are the two setup-tab extension-point partials, and both resolve the authorised
+    /// store from HttpContext and refuse a mismatch before calling this.
+    /// </para>
+    /// </remarks>
+    public async Task<string?> GetConnectionString(string authorisedStoreId)
     {
-        var settings = await Get(storeId).ConfigureAwait(false);
-        return settings?.PaymentKey is { } key ? SparkConnectionString.Format(storeId, key) : null;
+        var settings = await Get(authorisedStoreId).ConfigureAwait(false);
+        return settings?.PaymentKey is { } key ? SparkConnectionString.Format(authorisedStoreId, key) : null;
     }
 
     /// <inheritdoc />

--- a/BTCPayServer.Plugins.Flint/Views/Shared/Spark/LNPaymentMethodSetupTab.cshtml
+++ b/BTCPayServer.Plugins.Flint/Views/Shared/Spark/LNPaymentMethodSetupTab.cshtml
@@ -17,13 +17,16 @@
     return;
 }
 @{
-    // The store authorised for this request, never the form-bound Model.StoreId — core's POST re-renders
-    // this view without reassigning it, so it can name any store. Refuse before any lookup when the
-    // authorised id is missing (fail-closed) or disagrees with the model; see the longer note in
-    // LNPaymentMethodSetupTabhead.cshtml, which fills core's field in and carries the credential itself.
+    // The store this pane resolves is the one authorised for this request, never the form-bound
+    // Model.StoreId: core's POST re-renders this view without ever reassigning it, so on any path it can
+    // name any store, and it is never trusted on any path. The only refusal here is a missing
+    // authorisation, which fails closed before any lookup; every lookup and link below keys off
+    // authorisedStoreId alone — nothing reads Model.StoreId after the guard. An earlier revision also
+    // refused when the two ids disagreed; that comparison was dropped as a silent-suppression hazard
+    // that added no security. See the longer note in LNPaymentMethodSetupTabhead.cshtml, which fills
+    // core's field in and carries the credential itself.
     var authorisedStoreId = Context.GetStoreDataOrNull()?.Id;
-    if (authorisedStoreId is null ||
-        !string.Equals(authorisedStoreId, Model.StoreId, StringComparison.Ordinal))
+    if (authorisedStoreId is null)
     {
         return;
     }

--- a/BTCPayServer.Plugins.Flint/Views/Shared/Spark/LNPaymentMethodSetupTab.cshtml
+++ b/BTCPayServer.Plugins.Flint/Views/Shared/Spark/LNPaymentMethodSetupTab.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer
 @using BTCPayServer.Client
 @using BTCPayServer.Plugins.Flint.Services
 @using Microsoft.AspNetCore.Mvc.TagHelpers
@@ -16,16 +17,26 @@
     return;
 }
 @{
+    // The store authorised for this request, never the form-bound Model.StoreId — core's POST re-renders
+    // this view without reassigning it, so it can name any store. Refuse before any lookup when the
+    // authorised id is missing (fail-closed) or disagrees with the model; see the longer note in
+    // LNPaymentMethodSetupTabhead.cshtml, which fills core's field in and carries the credential itself.
+    var authorisedStoreId = Context.GetStoreDataOrNull()?.Id;
+    if (authorisedStoreId is null ||
+        !string.Equals(authorisedStoreId, Model.StoreId, StringComparison.Ordinal))
+    {
+        return;
+    }
     // Awaited, not blocked on: the service's startup gate is a Task, and a Razor view is already async.
-    var running = await SparkService.GetClient(Model.StoreId) is not null;
-    var configured = await SparkService.GetConnectionString(Model.StoreId) is not null;
+    var running = await SparkService.GetClient(authorisedStoreId) is not null;
+    var configured = await SparkService.GetConnectionString(authorisedStoreId) is not null;
 }
 <div id="SparkSetup" class="pt-3 tab-pane fade" role="tabpanel" aria-labelledby="LightningNodeType-Spark">
     @if (!configured)
     {
         <p class="text-secondary">
             This store has no Spark wallet yet.
-            <a asp-controller="Spark" asp-action="Setup" asp-route-storeId="@Model.StoreId"
+            <a asp-controller="Spark" asp-action="Setup" asp-route-storeId="@authorisedStoreId"
                permission="@Policies.CanModifyStoreSettings">Set one up</a>
             and BTCPay's Lightning configuration is written for you — there is no connection string to copy.
         </p>
@@ -41,13 +52,13 @@
             <p class="text-danger">
                 This store's Spark wallet is not running at the moment, so saving now would leave Lightning
                 payments failing.
-                <a asp-controller="Spark" asp-action="Status" asp-route-storeId="@Model.StoreId"
+                <a asp-controller="Spark" asp-action="Status" asp-route-storeId="@authorisedStoreId"
                    permission="@Policies.CanViewStoreSettings">Check its status</a>.
             </p>
         }
         <p class="text-secondary mb-0">
             Balance, network health and removal live on the store's
-            <a asp-controller="Spark" asp-action="Status" asp-route-storeId="@Model.StoreId"
+            <a asp-controller="Spark" asp-action="Status" asp-route-storeId="@authorisedStoreId"
                permission="@Policies.CanViewStoreSettings">Flint page</a>.
         </p>
     }

--- a/BTCPayServer.Plugins.Flint/Views/Shared/Spark/LNPaymentMethodSetupTabhead.cshtml
+++ b/BTCPayServer.Plugins.Flint/Views/Shared/Spark/LNPaymentMethodSetupTabhead.cshtml
@@ -1,3 +1,4 @@
+@using BTCPayServer
 @using BTCPayServer.Client
 @using BTCPayServer.Plugins.Flint.Services
 @using Microsoft.AspNetCore.Mvc.TagHelpers
@@ -13,10 +14,17 @@
     and fills core's connection-string field in, so pressing Save on core's own screen keeps working and
     writes exactly the configuration the plugin would write itself.
 
-    On rendering the connection string, which embeds the store's payment key: this extension point is only
-    ever rendered inside core's SetupLightningNode page, and both its GET and its POST require
-    CanModifyStoreSettings. Core itself puts the store's existing connection string in the textarea on that
-    same page. A view-only user never reaches here.
+    On rendering the connection string, which embeds the store's payment key: the only store this partial
+    may read from is the store authorised for the request, resolved from HttpContext — never Model.StoreId.
+    Core authorises both the GET and the POST of its SetupLightningNode page with CanModifyStoreSettings;
+    when a store-scoped authorisation succeeds, BuiltInPermissionHandler records the store in
+    HttpContext.Items, and core's global SetContextFilter (registered in Hosting/Startup.cs) promotes it
+    with SetStoreData — which is what HttpContext.GetStoreDataOrNull() reads on both verbs. Model.StoreId,
+    by contrast, is form-bound: LightningNodeViewModel.StoreId is an ordinary settable property, the GET
+    fills it from the route, and the POST never reassigns it before re-rendering this view — so on a POST
+    re-render it can name any store. The partial therefore resolves the authorised id first and refuses to
+    look anything up unless it equals Model.StoreId. A view-only user still never reaches here; what is
+    additionally closed is a forged form-bound id reaching another store's connection string.
 
     The @using and @inject lines are repeated even though Views/_ViewImports.cshtml declares them: an
     extension-point partial is rendered from a core view's context, and relying on the plugin's imports
@@ -27,12 +35,20 @@
     return;
 }
 @{
+    // The authorised store comes from the request, not the form: see the note above. Refuse before any
+    // lookup when it is missing (fail-closed) or disagrees with what the form claims.
+    var authorisedStoreId = Context.GetStoreDataOrNull()?.Id;
+    if (authorisedStoreId is null ||
+        !string.Equals(authorisedStoreId, Model.StoreId, StringComparison.Ordinal))
+    {
+        return;
+    }
     // Awaited rather than blocked on: the service's startup gate is a Task and a Razor view is already async.
-    var connectionString = await SparkService.GetConnectionString(Model.StoreId);
+    var connectionString = await SparkService.GetConnectionString(authorisedStoreId);
 }
 @if (connectionString is null)
 {
-    <a asp-controller="Spark" asp-action="Setup" asp-route-storeId="@Model.StoreId"
+    <a asp-controller="Spark" asp-action="Setup" asp-route-storeId="@authorisedStoreId"
        permission="@Policies.CanModifyStoreSettings" role="tab" aria-selected="false">
         <label for="LightningNodeType-Spark">Set up Flint</label>
     </a>

--- a/BTCPayServer.Plugins.Flint/Views/Shared/Spark/LNPaymentMethodSetupTabhead.cshtml
+++ b/BTCPayServer.Plugins.Flint/Views/Shared/Spark/LNPaymentMethodSetupTabhead.cshtml
@@ -21,10 +21,14 @@
     HttpContext.Items, and core's global SetContextFilter (registered in Hosting/Startup.cs) promotes it
     with SetStoreData — which is what HttpContext.GetStoreDataOrNull() reads on both verbs. Model.StoreId,
     by contrast, is form-bound: LightningNodeViewModel.StoreId is an ordinary settable property, the GET
-    fills it from the route, and the POST never reassigns it before re-rendering this view — so on a POST
-    re-render it can name any store. The partial therefore resolves the authorised id first and refuses to
-    look anything up unless it equals Model.StoreId. A view-only user still never reaches here; what is
-    additionally closed is a forged form-bound id reaching another store's connection string.
+    fills it from the route, and the POST never reassigns it before re-rendering this view — so on any
+    path it can name any store, and the form value is never trusted on any path. The partial resolves the
+    authorised id first, refuses only when it is missing (fail-closed), and every lookup and link below
+    keys off authorisedStoreId alone — nothing reads Model.StoreId after the guard. An earlier revision
+    also refused when the two ids disagreed; that comparison was dropped because it turned benign
+    mismatch re-renders into silent suppression and added no security, the form id feeding no lookup
+    either way. A view-only user still never reaches here; what is closed is a forged form-bound id
+    reaching another store's connection string.
 
     The @using and @inject lines are repeated even though Views/_ViewImports.cshtml declares them: an
     extension-point partial is rendered from a core view's context, and relying on the plugin's imports
@@ -35,11 +39,11 @@
     return;
 }
 @{
-    // The authorised store comes from the request, not the form: see the note above. Refuse before any
-    // lookup when it is missing (fail-closed) or disagrees with what the form claims.
+    // The authorised store comes from the request, not the form: see the note above. The form-bound
+    // Model.StoreId is never trusted on any path — nothing below reads it — so the only refusal here is
+    // a missing authorisation, which fails closed before any lookup.
     var authorisedStoreId = Context.GetStoreDataOrNull()?.Id;
-    if (authorisedStoreId is null ||
-        !string.Equals(authorisedStoreId, Model.StoreId, StringComparison.Ordinal))
+    if (authorisedStoreId is null)
     {
         return;
     }

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -38,11 +38,12 @@ works — so it must still be treated as a secret; what is closed is the import 
 any HTTP save path, which is exactly the cross-store drive this paragraph used to describe as open. The
 caveats on the enforcement are that BTCPay's `ILightningConnectionStringHandler` is still never told which
 store is being configured, so the three plugin layers (*save-time refusal* in `SparkLightningClient.Validate`,
-the *render-time authorised-store match* in the setup-tab partials, and the *startup sweep*) carry the
-enforcement rather than the string itself — with the middle one meaning a read of the string through the
-Lightning settings page is now refused on mismatch too: those partials resolve the store from what the
-request was authorised for, never from the form-bound model id, and render nothing when the two disagree —
-and that the plugin generated this credential for you rather
+the *render-time resolution to the authorised store* in the setup-tab partials, and the *startup sweep*)
+carry the enforcement rather than the string itself — with the middle one meaning the Lightning settings
+page can no longer be steered by its form-bound store id into rendering another store's string: those
+partials resolve the store from what the request was authorised for, never from the form-bound model id,
+render nothing when the request carries no authorised store, and key every lookup and link off the
+authorised id alone — and that the plugin generated this credential for you rather
 than you choosing to issue it. It **is rotated on every provision** — setting Spark up again (same seed or
 a new one) mints a fresh key and rewrites the store's Lightning configuration with it, invalidating every
 copy of the old string — so a leaked string is revoked by re-running setup, without waiting for a removal.

--- a/docs/trust-model.md
+++ b/docs/trust-model.md
@@ -37,8 +37,12 @@ string still holds a live credential for the wallet it names — save it on the 
 works — so it must still be treated as a secret; what is closed is the import onto another store through
 any HTTP save path, which is exactly the cross-store drive this paragraph used to describe as open. The
 caveats on the enforcement are that BTCPay's `ILightningConnectionStringHandler` is still never told which
-store is being configured, so the two plugin layers (*save-time refusal* and *startup sweep*) carry the
-enforcement rather than the string itself, and that the plugin generated this credential for you rather
+store is being configured, so the three plugin layers (*save-time refusal* in `SparkLightningClient.Validate`,
+the *render-time authorised-store match* in the setup-tab partials, and the *startup sweep*) carry the
+enforcement rather than the string itself — with the middle one meaning a read of the string through the
+Lightning settings page is now refused on mismatch too: those partials resolve the store from what the
+request was authorised for, never from the form-bound model id, and render nothing when the two disagree —
+and that the plugin generated this credential for you rather
 than you choosing to issue it. It **is rotated on every provision** — setting Spark up again (same seed or
 a new one) mints a fresh key and rewrites the store's Lightning configuration with it, invalidating every
 copy of the old string — so a leaked string is revoked by re-running setup, without waiting for a removal.


### PR DESCRIPTION
## What
Closes the cross-store connection-string disclosure (review finding S1, HIGH): both Spark setup-tab extension-point partials resolved their store from the form-bound `Model.StoreId` and `SparkService.GetConnectionString(storeId)` was a bare lookup. On a POST re-render of `/stores/{storeId}/lightning/{cryptoCode}/setup`, `LightningNodeViewModel.StoreId` is form-bindable (core binds the view model and never overwrites `StoreId` — six re-render paths), so a user authorized on store A could make the tabhead/tab render *store B's* connection string — a bearer spend credential — into the page.

## Fix
- Both partials resolve `authorisedStoreId` from the request authorisation (`Context.GetStoreDataOrNull()?.Id`; populated by core's `BuiltInPermissionHandler` -> global `SetContextFilter`, GET and POST alike since both actions require `CanModifyStoreSettings`) and return early — rendering nothing — when it is null or disagrees with `Model.StoreId`.
- The lookup, `GetClient(...)` and every `asp-route-storeId` anchor in the tab partial use the authorised id.
- `SparkService.GetConnectionString` renamed its parameter and documents the caller contract: pass the security-authorised store id, never a form-bound id.
- `docs/trust-model.md`: enforcement is now three layers (save-time refusal, render-time authorised-store match, startup sweep) and the stale partial comment asserting a false safety property is replaced by the real mechanism chain.

## Proof on a live release
Reproduced and verified against **BTCPay Server v2.4.2** (pinned submodule, running from source) with two stores on separate accounts:
- Before (main): attacker POST to `/stores/{A}/lightning/BTC/setup` with `StoreId={B}`, empty `ConnectionString` re-rendered with `const sparkConnectionString = "type=flint;store-id={B};key=<B's 64-hex key>"` in the response.
- After (this PR): the same POST returns zero `type=flint` occurrences and zero occurrences of B's key; the validation error still renders; store B's owner performing the same re-render **against their own store still sees their own string** (no false-positive suppression of the legitimate flow).
- The new regression test renders the compiled partial (not a string grep) and was shown red when the guard is bypassed (`LNPaymentMethodSetupTabheadTests`).

Core is unaffected below v2.4.1? No — the mechanism (`SetContextFilter.cs` byte-identical eea9cf88 across v2.4.1..v2.4.3, latest released) is present everywhere this plugin's floor supports.

## Upstream
The root cause is partially core: `LightningNodeViewModel.StoreId` binds from the POST form and core's re-render trusts it. Filing against btcpayserver (btcpayserver/btcpayserver#7544); this PR remains valuable regardless because the plugin cannot rely on a core fix being present.

## Notes
- Requires no migration, no version bump; changelog entry lands in the release PR under Security.
## Independent final review - resolutions

Highlighted commit: `145a7a2`
- **final-review SHOULD (P3)** - the setup **tab** partial now carries its own compiled-page regression test (`LNPaymentMethodSetupTabTests`, 4 facts via a shared `SetupTabViewRenderer`): authorised-null suppressed, mismatch (wallet store id/key/configured/running all absent, authorised store's own pane renders), same-store full pane, configured-but-not-running warning. The mismatch case's link anchors are now exercised for real (IHtmlGenerator stub + real permission helper).