### PR TITLE
Release the storage lock when the Spark SDK connect throws

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkServiceHarness.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkServiceHarness.cs
@@ -123,10 +123,16 @@ public sealed class SparkServiceHarness : IDisposable
         return new Mnemonic(Wordlist.English, entropy).ToString();
     }
 
+    /// <param name="failWalletAdoption">
+    /// Builds the service without the BOLT11 parser, so <c>SparkLightningClient</c>'s own ctor throws the
+    /// moment it tries to adopt a connected wallet. The throw is production code's own argument check, not a
+    /// fake standing in for it — the only thing this withholds is a real dependency.
+    /// </param>
     public static SparkServiceHarness Create(
         TimeSpan? connectDeadline = null,
         TimeSpan? confirmStatusDeadline = null,
-        TimeSpan? abandonedConnectGrace = null)
+        TimeSpan? abandonedConnectGrace = null,
+        bool failWalletAdoption = false)
     {
         var dataDir = Path.Combine(
             Path.GetTempPath(), "spark-service-tests", Guid.NewGuid().ToString("N"));
@@ -146,7 +152,8 @@ public sealed class SparkServiceHarness : IDisposable
                 confirmStatusDeadline ?? Constants.SdkCallDeadline,
                 // Long by default so the existing abandon tests still observe a late connect being adopted and
                 // shut down; the release-the-lock test shortens it deliberately.
-                abandonedConnectGrace ?? TimeSpan.FromMinutes(5)));
+                abandonedConnectGrace ?? TimeSpan.FromMinutes(5)),
+            failWalletAdoption);
     }
 
     /// <summary>
@@ -170,7 +177,8 @@ public sealed class SparkServiceHarness : IDisposable
         return Create(_dataDir, _durable, _deadlines);
     }
 
-    private static SparkServiceHarness Create(string dataDir, Durable durable, Deadlines deadlines)
+    private static SparkServiceHarness Create(
+        string dataDir, Durable durable, Deadlines deadlines, bool failWalletAdoption = false)
     {
         var log = new CapturingLogger<SparkService>();
         var logs = new Logs();
@@ -193,6 +201,11 @@ public sealed class SparkServiceHarness : IDisposable
             NullLogger<SparkSettlementReconciler>.Instance);
         var wiring = new SparkLightningWiring(lightning, NullLogger<SparkLightningWiring>.Instance);
 
+        // The one dependency a test may ask to be withheld. SparkLightningClient's own ctor rejects a null
+        // BOLT11 parser, so a service built without one throws at the moment it adopts a connected wallet —
+        // that throw is production code's own argument check, and nothing in production gained a seam for it.
+        IBolt11Parser bolt11Parser = failWalletAdoption ? null! : durable.Bolt11;
+
         // The startup sweep is real here — it runs against the stores this harness knows about — so the
         // deferred factory is wired to a sweeper built over the same fakes. The sweeper is constructed after
         // the service because its settings store is the service itself; the closure makes that ordering safe.
@@ -213,7 +226,7 @@ public sealed class SparkServiceHarness : IDisposable
             broadcaster,
             protector,
             wiring,
-            durable.Bolt11,
+            bolt11Parser,
             TimeProvider.System,
             () => sweeper ?? throw new InvalidOperationException("harness sweep not wired"),
             NullLoggerFactory.Instance,

--- a/BTCPayServer.Plugins.Flint.Tests/SparkServiceStartupTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkServiceStartupTests.cs
@@ -40,6 +40,7 @@ public class SparkServiceStartupTests
     private const string HangingStore = "store-that-hangs";
     private const string HealthyStore = "store-that-works";
     private const string ThrowingStore = "store-that-throws";
+    private const string NeverAdoptedStore = "store-never-adopted";
 
     [Fact]
     public void A_store_whose_SDK_connect_never_returns_does_not_hold_up_the_host()
@@ -229,6 +230,44 @@ public class SparkServiceStartupTests
         Assert.False(
             writer.TryWrite(new Sdk.SparkEventEnvelope(HangingStore, Sdk.SparkEventKind.Synced, null)),
             "a completed writer refuses, which is what makes the listener report the loss rather than hide it");
+    }
+
+    /// <summary>
+    /// A wallet that connected but that no client ever adopted must die with the attempt, not leak.
+    /// </summary>
+    /// <remarks>
+    /// The <c>finally</c> guards a failed adoption on three halves — the storage claim, the SDK handle, and
+    /// the event channel — and the throwing-connect tests above cover only the claim, because that throw
+    /// lands before a handle exists. This reaches the other two: the harness builds the service without the
+    /// BOLT11 parser, so <c>SparkLightningClient</c>'s own argument check throws precisely where a real bad
+    /// dependency would, after a successful connect. No production seam was added for the test; the throw is
+    /// shipped code refusing a shipped-null argument.
+    /// </remarks>
+    [Fact]
+    public async Task A_wallet_that_connected_but_was_never_adopted_is_disposed_and_its_events_refused()
+    {
+        using var h = SparkServiceHarness.Create(failWalletAdoption: true);
+        h.SeedStore(NeverAdoptedStore, SparkServiceHarness.MnemonicFor(4));
+
+        // Startup swallows the adoption throw per-store, exactly as it swallows a connect throw: one broken
+        // store must not stop BTCPay starting.
+        StartWithinTimeout(h);
+        Assert.Contains("could not start its Spark wallet", h.Log.AllText);
+
+        var client = h.Sdk.Clients[NeverAdoptedStore];
+        Assert.True(
+            client.Disposed,
+            "a connected SDK handle that no instance ever adopted must die in the finally next to the claim "
+            + "it was meant to guard");
+
+        // And nothing is left buffering events for a consumer that will never start — the same proof the
+        // abandonment test above makes, now on the finally's own path.
+        Assert.False(
+            h.Sdk.EventWriters[NeverAdoptedStore].TryWrite(
+                new Sdk.SparkEventEnvelope(NeverAdoptedStore, Sdk.SparkEventKind.Synced, null)),
+            "the failed attempt's event writer must be completed, not left open and unreferenced");
+
+        Assert.Null(await h.Service.GetClient(NeverAdoptedStore));
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint.Tests/SparkServiceStartupTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkServiceStartupTests.cs
@@ -39,6 +39,7 @@ public class SparkServiceStartupTests
 
     private const string HangingStore = "store-that-hangs";
     private const string HealthyStore = "store-that-works";
+    private const string ThrowingStore = "store-that-throws";
 
     [Fact]
     public void A_store_whose_SDK_connect_never_returns_does_not_hold_up_the_host()
@@ -97,14 +98,55 @@ public class SparkServiceStartupTests
     public async Task A_store_whose_connect_throws_does_not_stop_another_stores_wallet_from_starting()
     {
         using var h = SparkServiceHarness.Create();
-        h.SeedStore("store-that-throws", SparkServiceHarness.MnemonicFor(3));
+        h.SeedStore(ThrowingStore, SparkServiceHarness.MnemonicFor(3));
         h.SeedStore(HealthyStore, SparkServiceHarness.MnemonicFor(2));
-        h.Sdk.FailFor["store-that-throws"] = new InvalidOperationException("the SDK refused this seed");
+        h.Sdk.FailFor[ThrowingStore] = new InvalidOperationException("the SDK refused this seed");
 
         StartWithinTimeout(h);
 
         Assert.NotNull(await h.Service.GetClient(HealthyStore));
-        Assert.Null(await h.Service.GetClient("store-that-throws"));
+        Assert.Null(await h.Service.GetClient(ThrowingStore));
+    }
+
+    /// <summary>
+    /// A connect that throws must not lock its store out of its own wallet either.
+    /// </summary>
+    /// <remarks>
+    /// The timeout path already released the storage claim it had taken (see
+    /// <see cref="A_permanently_hung_connect_releases_the_storage_lock_so_the_store_can_be_reconfigured"/>),
+    /// but a connect that fails immediately is rethrown by <c>SparkDeadline</c> past both ownership handoffs,
+    /// and the leaked <c>FileShare.None</c> handle then refused the store's own next attempt with the
+    /// two-BTCPay-instances message — accusing another process of a hold this process was doing to itself,
+    /// which reconfiguring could never clear.
+    /// </remarks>
+    [Fact]
+    public async Task A_store_whose_connect_throws_leaves_the_storage_lock_claimable()
+    {
+        using var h = SparkServiceHarness.Create();
+        h.SeedStore(ThrowingStore, SparkServiceHarness.MnemonicFor(3));
+        h.Sdk.FailFor[ThrowingStore] = new InvalidOperationException("the SDK refused this seed");
+
+        StartWithinTimeout(h);
+
+        // The refused attempt named the failure it actually hit — the connection error — never the lock
+        // message. Startup swallows the throw per-store, so it surfaces in the operator's log.
+        Assert.Contains("the SDK refused this seed", h.Log.AllText);
+        Assert.DoesNotContain("Another process", h.Log.AllText);
+
+        // The decisive half: the claim the throwing attempt took is back on the shelf. Before the fix a
+        // FileStream nothing could any longer reach still held the directory, and this returned null.
+        var reclaimed = Sdk.SparkStorageLock.TryAcquire(h.StorageDirFor(ThrowingStore), out _);
+        Assert.NotNull(reclaimed);
+        reclaimed!.Dispose();
+
+        // And reconfiguring the store starts its wallet, rather than being told another process holds it.
+        h.Sdk.FailFor.Remove(ThrowingStore);
+        var settings = (await h.Service.Get(ThrowingStore))!;
+        var applied = await h.Service.Set(ThrowingStore, settings);
+
+        // Before the fix this came back not-running with the "Another process" refusal.
+        Assert.True(applied.WalletRunning, $"the store should be running, got: {applied.Reason}");
+        Assert.NotNull(await h.Service.GetClient(ThrowingStore));
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -445,6 +445,7 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
         // BTCPay held it.
         var handedOff = false;
         ISparkSdkClient? sdk = null;
+        Channel<SparkEventEnvelope>? events = null;
         try
         {
             var options = new SparkConnectOptions(
@@ -466,7 +467,7 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
 
             // Created before the SDK because the factory registers the event listener against this writer, and
             // events can arrive the moment it does. The channel buffers until the consumer starts below.
-            var events = Channel.CreateBounded<SparkEventEnvelope>(new BoundedChannelOptions(EventQueueCapacity)
+            events = Channel.CreateBounded<SparkEventEnvelope>(new BoundedChannelOptions(EventQueueCapacity)
             {
                 // Wait, combined with the listener only ever using the non-blocking TryWrite. That pairing is the
                 // one that reports a full queue: TryWrite returns false and the listener logs it. DropOldest and
@@ -502,12 +503,11 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
 
             if (sdk is null)
             {
-                // Ownership of the claim moves with the abandoned connect: releasing it here would let the next
-                // attempt start a second instance on storage the late arrival is still holding.
-                AbandonConnect(storeId, connect, events, storageLock);
-                // From its entry, the abandoned connect's cleanup owns the claim; releasing it here would
-                // let the next attempt connect while the late wallet still holds the storage.
+                // The abandoned connect's cleanup owns the claim from this call's entry: releasing it here
+                // would let the next attempt start a second instance on storage the late wallet is still
+                // holding.
                 handedOff = true;
+                AbandonConnect(storeId, connect, events, storageLock);
                 return "This store's Spark wallet did not finish connecting in time, so it is not running. Check "
                        + "the server logs, then reconfigure the store or restart the server to try again.";
             }
@@ -544,7 +544,11 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
             if (!handedOff)
             {
                 // Partial construction: an SDK that connected but that no instance ever adopted belongs to
-                // nobody yet, so it dies here next to the claim it was meant to guard.
+                // nobody yet, so it dies here next to the claim it was meant to guard. Its event channel is
+                // completed for the reason AbandonConnect completes one: no consumer was ever started for it,
+                // so an open writer would only buffer envelopes silently, while a completed one makes the
+                // listener's TryWrite report the refusal.
+                events?.Writer.TryComplete();
                 sdk?.Dispose();
                 storageLock.Dispose();
             }

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -437,91 +437,118 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
             return lockReason;
         }
 
-        var options = new SparkConnectOptions(
-            storeId,
-            mnemonic,
-            // NBXplorer does not store BIP39 passphrases, so a hot-wallet seed reused from BTCPay never
-            // carries one, and a passphrase changes the Spark identity entirely. Defaulting one silently
-            // would derive a different wallet from the seed the merchant backed up.
-            passphrase: null,
-            apiKey: string.IsNullOrWhiteSpace(settings.ApiKeyOverride)
-                ? Constants.BreezApiKey
-                : settings.ApiKeyOverride,
-            network: sdkNetwork,
-            // Always supplied, never left to the SDK. Its default is Rate(1 sat/vB) — a cap rather than a bid —
-            // which is below the mainnet floor essentially always, and above it a deposit is never claimed and
-            // never surfaces anywhere the merchant looks.
-            maxDepositClaimFee: (settings.Deposits ?? new SparkDepositSettings()).ToMaxFee(),
-            stableBalance: BuildStableBalance(settings));
-
-        // Created before the SDK because the factory registers the event listener against this writer, and
-        // events can arrive the moment it does. The channel buffers until the consumer starts below.
-        var events = Channel.CreateBounded<SparkEventEnvelope>(new BoundedChannelOptions(EventQueueCapacity)
+        // The two handoffs below — AbandonConnect in the timeout branch, and the instance registration —
+        // are the only things that can own the claim past this point, so every other route out of the
+        // guarded region goes through the finally: until it existed, only the timeout path released the
+        // claim, and an already-faulted connect (SparkDeadline rethrows it rather than returning null)
+        // leaked the FileShare.None handle so the store's own next attempt was refused as if a second
+        // BTCPay held it.
+        var handedOff = false;
+        ISparkSdkClient? sdk = null;
+        try
         {
-            // Wait, combined with the listener only ever using the non-blocking TryWrite. That pairing is the
-            // one that reports a full queue: TryWrite returns false and the listener logs it. DropOldest and
-            // DropWrite both return true and evict silently, and silently losing a settlement notification is
-            // exactly the class of bug this plugin exists to avoid. The listener never blocks regardless,
-            // because it never calls WriteAsync.
-            FullMode = BoundedChannelFullMode.Wait,
-            SingleReader = true,
-            SingleWriter = false
-        });
+            var options = new SparkConnectOptions(
+                storeId,
+                mnemonic,
+                // NBXplorer does not store BIP39 passphrases, so a hot-wallet seed reused from BTCPay never
+                // carries one, and a passphrase changes the Spark identity entirely. Defaulting one silently
+                // would derive a different wallet from the seed the merchant backed up.
+                passphrase: null,
+                apiKey: string.IsNullOrWhiteSpace(settings.ApiKeyOverride)
+                    ? Constants.BreezApiKey
+                    : settings.ApiKeyOverride,
+                network: sdkNetwork,
+                // Always supplied, never left to the SDK. Its default is Rate(1 sat/vB) — a cap rather than a bid —
+                // which is below the mainnet floor essentially always, and above it a deposit is never claimed and
+                // never surfaces anywhere the merchant looks.
+                maxDepositClaimFee: (settings.Deposits ?? new SparkDepositSettings()).ToMaxFee(),
+                stableBalance: BuildStableBalance(settings));
 
-        // Bounded, and this is the one call site where that matters most. This method runs on the host's
-        // IHostedService.StartAsync path, once per configured store, inside _instanceLock — and
-        // HostOptions.StartupTimeout is infinite by default. An unbounded await here is
-        // therefore a silent, permanent hang of BTCPay's startup: no exception, so no log line and no
-        // auto-disable, which is exactly how PR #6's deadlock presented. Today's SDK Connect does no network
-        // I/O and returns in tens of milliseconds, but that is an SDK property and not a guarantee this plugin
-        // holds, so the wait is bounded rather than trusted.
-        var connect = _sdkClientFactory.ConnectAsync(options, events.Writer, cancellationToken);
-        var deadline = ConnectDeadline;
-        var sdk = await SparkDeadline.OrNullAsync(
-                connect,
-                deadline,
-                () => _logger.LogError(
-                    "Store {StoreId}: connecting its Spark wallet exceeded {Seconds}s, so it was abandoned and "
-                    + "the store was left without a running wallet. BTCPay itself started normally. No SDK call "
-                    + "can be cancelled, so the connect is still running and whatever it produces will be shut "
-                    + "down; nothing will be started on this wallet until the store is reconfigured or the "
-                    + "server is restarted",
-                    storeId, deadline.TotalSeconds),
-                cancellationToken)
-            .ConfigureAwait(false);
+            // Created before the SDK because the factory registers the event listener against this writer, and
+            // events can arrive the moment it does. The channel buffers until the consumer starts below.
+            var events = Channel.CreateBounded<SparkEventEnvelope>(new BoundedChannelOptions(EventQueueCapacity)
+            {
+                // Wait, combined with the listener only ever using the non-blocking TryWrite. That pairing is the
+                // one that reports a full queue: TryWrite returns false and the listener logs it. DropOldest and
+                // DropWrite both return true and evict silently, and silently losing a settlement notification is
+                // exactly the class of bug this plugin exists to avoid. The listener never blocks regardless,
+                // because it never calls WriteAsync.
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                SingleWriter = false
+            });
 
-        if (sdk is null)
-        {
-            // Ownership of the claim moves with the abandoned connect: releasing it here would let the next
-            // attempt start a second instance on storage the late arrival is still holding.
-            AbandonConnect(storeId, connect, events, storageLock);
-            return "This store's Spark wallet did not finish connecting in time, so it is not running. Check "
-                   + "the server logs, then reconfigure the store or restart the server to try again.";
+            // Bounded, and this is the one call site where that matters most. This method runs on the host's
+            // IHostedService.StartAsync path, once per configured store, inside _instanceLock — and
+            // HostOptions.StartupTimeout is infinite by default. An unbounded await here is
+            // therefore a silent, permanent hang of BTCPay's startup: no exception, so no log line and no
+            // auto-disable, which is exactly how PR #6's deadlock presented. Today's SDK Connect does no network
+            // I/O and returns in tens of milliseconds, but that is an SDK property and not a guarantee this plugin
+            // holds, so the wait is bounded rather than trusted.
+            var connect = _sdkClientFactory.ConnectAsync(options, events.Writer, cancellationToken);
+            var deadline = ConnectDeadline;
+            sdk = await SparkDeadline.OrNullAsync(
+                    connect,
+                    deadline,
+                    () => _logger.LogError(
+                        "Store {StoreId}: connecting its Spark wallet exceeded {Seconds}s, so it was abandoned and "
+                        + "the store was left without a running wallet. BTCPay itself started normally. No SDK call "
+                        + "can be cancelled, so the connect is still running and whatever it produces will be shut "
+                        + "down; nothing will be started on this wallet until the store is reconfigured or the "
+                        + "server is restarted",
+                        storeId, deadline.TotalSeconds),
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (sdk is null)
+            {
+                // Ownership of the claim moves with the abandoned connect: releasing it here would let the next
+                // attempt start a second instance on storage the late arrival is still holding.
+                AbandonConnect(storeId, connect, events, storageLock);
+                // From its entry, the abandoned connect's cleanup owns the claim; releasing it here would
+                // let the next attempt connect while the late wallet still holds the storage.
+                handedOff = true;
+                return "This store's Spark wallet did not finish connecting in time, so it is not running. Check "
+                       + "the server logs, then reconfigure the store or restart the server to try again.";
+            }
+
+            var client = new SparkLightningClient(
+                storeId,
+                settings.PaymentKey,
+                sdk,
+                _invoiceStore,
+                _outgoingStore,
+                _reconciler,
+                _broadcaster,
+                _bolt11Parser,
+                _loggerFactory.CreateLogger<SparkLightningClient>());
+
+            var instance = new SparkStoreInstance(storeId, sdk, client, events, storageLock);
+            _instances[storeId] = instance;
+            // Owned from the registration, not from the constructor call: a SparkStoreInstance ctor throw
+            // means the instance never accepted the lock.
+            handedOff = true;
+            _walletOwners[walletKey] = storeId;
+            instance.StartConsumer(envelope => HandleEventAsync(envelope, instance), _logger);
+
+            _logger.LogInformation("Store {StoreId}: Spark wallet connected on {Network}", storeId, sdkNetwork);
+
+            // Connect does no network I/O and validates no credentials, so it is not evidence of health. The first
+            // synced call costs ~2.2 s, which is why this is deliberately not awaited: N stores would otherwise
+            // add N × 2.2 s to BTCPay's startup for information nothing is waiting on.
+            _ = WarmUpAsync(storeId, sdk);
+            return null;
         }
-
-        var client = new SparkLightningClient(
-            storeId,
-            settings.PaymentKey,
-            sdk,
-            _invoiceStore,
-            _outgoingStore,
-            _reconciler,
-            _broadcaster,
-            _bolt11Parser,
-            _loggerFactory.CreateLogger<SparkLightningClient>());
-
-        var instance = new SparkStoreInstance(storeId, sdk, client, events, storageLock);
-        _instances[storeId] = instance;
-        _walletOwners[walletKey] = storeId;
-        instance.StartConsumer(envelope => HandleEventAsync(envelope, instance), _logger);
-
-        _logger.LogInformation("Store {StoreId}: Spark wallet connected on {Network}", storeId, sdkNetwork);
-
-        // Connect does no network I/O and validates no credentials, so it is not evidence of health. The first
-        // synced call costs ~2.2 s, which is why this is deliberately not awaited: N stores would otherwise
-        // add N × 2.2 s to BTCPay's startup for information nothing is waiting on.
-        _ = WarmUpAsync(storeId, sdk);
-        return null;
+        finally
+        {
+            if (!handedOff)
+            {
+                // Partial construction: an SDK that connected but that no instance ever adopted belongs to
+                // nobody yet, so it dies here next to the claim it was meant to guard.
+                sdk?.Dispose();
+                storageLock.Dispose();
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## What
Review finding S2 (MEDIUM): `SparkService.StartInstanceAsync` acquired the store's `SparkStorageLock` and handed ownership on only two paths — `AbandonConnect` (timeout) and the finished `SparkStoreInstance` (success). A connect that **throws** (bad Breez API key, corrupt SQLite storage, unsupported target, `AddEventListener`
+`sdk.Dispose(); throw;`) escaped both paths and leaked the `FileShare.None` lock. Every later reconfiguration of that store then failed with the misleading "Another process is already using this store's Spark wallet storage" refusal until a server restart.

## Fix
`try/finally` with an `handedOff` ownership flag: the finally disposes the SDK client (when connected but not yet adopted) and the storage lock unless ownership was handed to `AbandonConnect`'s Task.Run or to the `SparkStoreInstance`. The two ownership boundaries set the flag; a `SparkStoreInstance` constructor throw still releases (the instance never accepted the lock).

## Tests
- New `A_store_whose_connect_throws_leaves_the_storage_lock_claimable` (`SparkServiceStartupTests`): factory `FailFor` produces the exact trigger (already-faulted task through `SparkDeadline.CompletedWithinAsync`'s fast path); asserts the reclaim probe (`SparkStorageLock.TryAcquire`) succeeds after the failure and a second `Set` returns `WalletRunning` instead of the lock refusal.
- Negative control: reverting `SparkService.cs` to base makes the new fact fail at the reclaim probe.

Default suite green (1302 total / 1196 pass / 0 fail). `SparkDeadline.cs` untouched.
## Independent final review - resolutions

Highlighted commit: `4ca99e0`
- **final-review SHOULD (P3)** - on the non-timeout release path the SDK's event channel is now completed (`events?.Writer.TryComplete()`) beside the sdk/cache lock disposal, matching `AbandonConnect`'s no-consumer reasoning; a new Fact drives the honest hook (connected-but-never-adopted via a withheld `IBolt11Parser`) asserting `Disposed`, event-refusal, and no registered client; `handedOff` moved before the `AbandonConnect` call to match its ownership comment.