### PR TITLE
Gate payment-hash prompt recording on Flint presence; 14-day retention

### DIFF
--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemoryInvoicePaymentHashIndex.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/InMemoryInvoicePaymentHashIndex.cs
@@ -37,6 +37,16 @@ public sealed class InMemoryInvoicePaymentHashIndex : IInvoicePaymentHashIndex
         CancellationToken cancellationToken = default) =>
         Task.FromResult(_entries.GetValueOrDefault(paymentHash.ToLowerInvariant()));
 
+    public Task<int> PruneBeforeAsync(DateTimeOffset cutoff, CancellationToken cancellationToken = default)
+    {
+        var stale = _entries.Where(pair => pair.Value.FirstSeenAt < cutoff)
+            .Select(pair => pair.Key)
+            .ToList();
+        foreach (var hash in stale)
+            _entries.Remove(hash);
+        return Task.FromResult(stale.Count);
+    }
+
     /// <summary>Seeds an association directly, standing in for a row written before this instance existed.</summary>
     public void Seed(InvoicePaymentHash entry) => _entries[entry.PaymentHash.ToLowerInvariant()] = entry;
 }

--- a/BTCPayServer.Plugins.Flint.Tests/InvoicePaymentHashIndexContractTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/InvoicePaymentHashIndexContractTests.cs
@@ -28,6 +28,13 @@ public abstract class InvoicePaymentHashIndexContractTests
 
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
+    // Association rows for the prune fact, distinct from PaymentFixture's so the write-once facts' rows
+    // (never pruned, recorded at roughly "now") cannot overlap this fact's deletes on Postgres.
+    private const string StaleHash =
+        "a1b2c3d4e5f60718293a4b5c6d7e8f90123456789012345678901234567890aa";
+    private const string RecentHash =
+        "b2c3d4e5f60718293a4b5c6d7e8f90123456789012345678901234567890aabb";
+
     private static InvoicePaymentHash Entry(string? hash = null, string? invoiceId = null) => new()
     {
         PaymentHash = hash ?? PaymentFixture.PaymentHash,
@@ -82,6 +89,52 @@ public abstract class InvoicePaymentHashIndexContractTests
         Assert.NotNull(after);
         Assert.Equal(InvoiceId, after.InvoiceId);
         Assert.Equal(original.FirstSeenAt, after.FirstSeenAt);
+    }
+
+    [Fact]
+    public async Task Pruning_deletes_only_associations_first_seen_before_the_cutoff()
+    {
+        // The retention pass (Services.SparkPaymentHashRetentionTask) deletes the stale head of the table on
+        // every run, in the EF implementation as a set DELETE that never sees the rows it removes — which is
+        // exactly why the predicate has to be pinned against the real store, not just the in-memory copy.
+        // Rows older than the credit walk's listing floor must actually leave (that is the whole point of
+        // retention); rows the walk can still consult must not budge. The hashes are literals rather than
+        // PaymentFixture values so this fact cannot collide with the write-once facts' rows on Postgres,
+        // where the table is not truncated between facts.
+        var index = await CreateIndexAsync();
+        var now = DateTimeOffset.UtcNow;
+        var cutoff = now
+            - Services.SparkInvoiceCreditor.CreditRetryHorizon
+            - Services.SparkInvoiceCreditor.AbandonedReportingGrace;
+
+        await index.RecordAsync(
+            new InvoicePaymentHash
+            {
+                PaymentHash = StaleHash,
+                InvoiceId = InvoiceId,
+                PaymentMethodId = PaymentMethodId,
+                FirstSeenAt = cutoff - TimeSpan.FromMinutes(1)
+            },
+            Ct);
+        await index.RecordAsync(
+            new InvoicePaymentHash
+            {
+                PaymentHash = RecentHash,
+                InvoiceId = InvoiceId,
+                PaymentMethodId = PaymentMethodId,
+                FirstSeenAt = now
+            },
+            Ct);
+
+        var removed = await index.PruneBeforeAsync(cutoff, Ct);
+
+        Assert.Equal(1, removed);
+        Assert.Null(await index.FindByPaymentHashAsync(StaleHash, Ct));
+        Assert.NotNull(await index.FindByPaymentHashAsync(RecentHash, Ct));
+
+        // Idempotent: a second pass with the same cutoff finds nothing left to do.
+        Assert.Equal(0, await index.PruneBeforeAsync(cutoff, Ct));
+        Assert.NotNull(await index.FindByPaymentHashAsync(RecentHash, Ct));
     }
 }
 

--- a/BTCPayServer.Plugins.Flint.Tests/SparkInvoicePaymentHashIndexerTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkInvoicePaymentHashIndexerTests.cs
@@ -12,8 +12,9 @@ using Xunit;
 namespace BTCPayServer.Plugins.Flint.Tests;
 
 /// <summary>
-/// The decision in <see cref="SparkInvoicePaymentHashIndexer"/>: which prompt-mint events become the plugin's
-/// own payment-hash → invoice association.
+/// The decisions in <see cref="SparkInvoicePaymentHashIndexer"/>: which prompt-mint events become the plugin's
+/// own payment-hash → invoice association, and whether the server has any Flint store for the association to
+/// matter to.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -24,14 +25,37 @@ namespace BTCPayServer.Plugins.Flint.Tests;
 /// decision; the wiring from the event aggregator to it is covered by
 /// <see cref="SparkPluginStartupTests"/>, which resolves the hosted service from BTCPay's own container.
 /// </para>
+/// <para>
+/// Every recording fact runs against the real <see cref="SparkService"/> with one store provisioned, through
+/// <see cref="SparkServiceHarness"/> — the gate the writes pass is that service's live settings cache, and a
+/// fake of it would make the recording facts assert only that the fake says yes. The no-store skip and the
+/// turn-on-when-provisioned facts run against the same harness with nothing seeded, because the gate is read
+/// per event and must open the moment the first store exists, without a restart.
+/// </para>
 /// </remarks>
 public class SparkInvoicePaymentHashIndexerTests
 {
     private const string InvoiceId = "btcpay-invoice-1";
+    private const string StoreId = "flint-store-1";
 
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
-    private static SparkInvoicePaymentHashIndexer Create(out InMemoryInvoicePaymentHashIndex index)
+    /// <summary>
+    /// The harness's service, started so its startup gate is open — seeded with one store when
+    /// <paramref name="provisioned"/>, which is what the recording facts need the gate to pass for.
+    /// </summary>
+    private static async Task<SparkServiceHarness> StartedSpark(bool provisioned)
+    {
+        var h = SparkServiceHarness.Create();
+        if (provisioned)
+            h.SeedStore(StoreId, SparkServiceHarness.MnemonicFor(1));
+        await h.Service.StartAsync(Ct);
+        return h;
+    }
+
+    private static SparkInvoicePaymentHashIndexer Create(
+        SparkService sparkService,
+        out InMemoryInvoicePaymentHashIndex index)
     {
         var logs = new Logs();
         logs.Configure(NullLoggerFactory.Instance);
@@ -39,6 +63,7 @@ public class SparkInvoicePaymentHashIndexerTests
         return new SparkInvoicePaymentHashIndexer(
             new BTCPayServer.EventAggregator(logs),
             index,
+            sparkService,
             NullLogger<SparkInvoicePaymentHashIndexer>.Instance);
     }
 
@@ -50,7 +75,8 @@ public class SparkInvoicePaymentHashIndexerTests
     public async Task An_LNURL_prompt_mint_records_the_association()
     {
         // The case this exists for: an LNURL prompt, which BTCPay's own index only covers while LUD-21 is on.
-        var indexer = Create(out var index);
+        using var spark = await StartedSpark(provisioned: true);
+        var indexer = Create(spark.Service, out var index);
         await indexer.RecordAssociationAsync(
             new InvoiceNewPaymentDetailsEvent(
                 InvoiceId,
@@ -70,7 +96,8 @@ public class SparkInvoicePaymentHashIndexerTests
     {
         // A plain checkout prompt: core always indexes this hash itself, so this row is redundant — but the
         // event carries it too, and recording both rails keeps the index uniform.
-        var indexer = Create(out var index);
+        using var spark = await StartedSpark(provisioned: true);
+        var indexer = Create(spark.Service, out var index);
         await indexer.RecordAssociationAsync(
             new InvoiceNewPaymentDetailsEvent(
                 InvoiceId,
@@ -87,8 +114,11 @@ public class SparkInvoicePaymentHashIndexerTests
     public async Task A_prompt_for_another_crypto_is_not_recorded()
     {
         // The plugin credits only Bitcoin Lightning payments, so another crypto's prompts are not its business
-        // — and a same-named hash could in principle be minted on two networks without meaning the same thing.
-        var indexer = Create(out var index);
+        // — and a same-named hash could in principle be minted on two networks without meaning the same
+        // thing. Provisioned, so the skip below is provably the payment-method filter rather than the store
+        // gate.
+        using var spark = await StartedSpark(provisioned: true);
+        var indexer = Create(spark.Service, out var index);
         await indexer.RecordAssociationAsync(
             new InvoiceNewPaymentDetailsEvent(
                 InvoiceId,
@@ -102,9 +132,8 @@ public class SparkInvoicePaymentHashIndexerTests
     [Fact]
     public async Task A_prompt_without_a_payment_hash_yet_is_not_recorded()
     {
-        // The LNURL request event precedes the mint that gives a prompt its hash; there is nothing to index
-        // until the mint event follows.
-        var indexer = Create(out var index);
+        using var spark = await StartedSpark(provisioned: true);
+        var indexer = Create(spark.Service, out var index);
         await indexer.RecordAssociationAsync(
             new InvoiceNewPaymentDetailsEvent(
                 InvoiceId,
@@ -118,8 +147,8 @@ public class SparkInvoicePaymentHashIndexerTests
     [Fact]
     public async Task A_prompt_of_an_unrelated_payment_type_is_not_recorded()
     {
-        // The details of an on-chain prompt, say, derive from a different base and carry no payment hash.
-        var indexer = Create(out var index);
+        using var spark = await StartedSpark(provisioned: true);
+        var indexer = Create(spark.Service, out var index);
         await indexer.RecordAssociationAsync(
             new InvoiceNewPaymentDetailsEvent(
                 InvoiceId,
@@ -137,7 +166,8 @@ public class SparkInvoicePaymentHashIndexerTests
         // on, core's own index covers the hash anyway, and the next mint of the same invoice re-fires the
         // event. The base class's loop logs unhandled exceptions and continues, but this method must not even
         // get to that — it is called from ProcessEvent deliberately.
-        var indexer = Create(out var index);
+        using var spark = await StartedSpark(provisioned: true);
+        var indexer = Create(spark.Service, out var index);
         index.FailRecordWith = new InvalidOperationException("db down");
 
         await indexer.RecordAssociationAsync(
@@ -154,7 +184,8 @@ public class SparkInvoicePaymentHashIndexerTests
     public async Task The_stored_hash_is_lower_case()
     {
         // The primary key is case-sensitive, and the caller's event could carry the hash in either case.
-        var indexer = Create(out var index);
+        using var spark = await StartedSpark(provisioned: true);
+        var indexer = Create(spark.Service, out var index);
         await indexer.RecordAssociationAsync(
             new InvoiceNewPaymentDetailsEvent(
                 InvoiceId,
@@ -164,5 +195,56 @@ public class SparkInvoicePaymentHashIndexerTests
 
         var stored = Assert.Single(index.Entries.Values);
         Assert.Equal(PaymentFixture.PaymentHash, stored.PaymentHash);
+    }
+
+    [Fact]
+    public async Task A_prompt_mint_records_nothing_while_no_store_has_flint()
+    {
+        // Core publishes the mint event for every store's prompt whether or not this plugin serves anyone,
+        // and on a server with no Flint store the write is noise the plugin's table never gets to use:
+        // core's own index covers the association for every store this plugin does not serve.
+        using var spark = await StartedSpark(provisioned: false);
+        Assert.False(await spark.Service.HasAnyStoreProvisioned());
+        var indexer = Create(spark.Service, out var index);
+
+        await indexer.RecordAssociationAsync(
+            new InvoiceNewPaymentDetailsEvent(
+                InvoiceId,
+                new LNURLPayPaymentMethodDetails { PaymentHash = Hash() },
+                Pmi("BTC", PaymentTypes.LNURL)),
+            Ct);
+
+        Assert.Empty(index.Entries);
+    }
+
+    [Fact]
+    public async Task Provisioning_the_first_store_turns_recording_on_without_a_restart()
+    {
+        // The gate is re-read on every event rather than latched at startup, and this pins it: the same
+        // indexer instance that skipped before the store existed records the very next prompt after the
+        // settings cache gains its first entry. A cached flag with no invalidation hook would fail here.
+        using var spark = await StartedSpark(provisioned: false);
+        var indexer = Create(spark.Service, out var index);
+        var firstPrompt = new InvoiceNewPaymentDetailsEvent(
+            InvoiceId,
+            new LNURLPayPaymentMethodDetails { PaymentHash = Hash() },
+            Pmi("BTC", PaymentTypes.LNURL));
+
+        await indexer.RecordAssociationAsync(firstPrompt, Ct);
+        Assert.Empty(index.Entries);
+
+        var applied = await spark.Service.Set(StoreId, new SparkSettings
+        {
+            ProtectedMnemonic = spark.Protector.Protect(SparkServiceHarness.MnemonicFor(2)),
+            PaymentKey = SparkConnectionString.GeneratePaymentKey(),
+            SeedSource = SeedSource.Generated
+        });
+        Assert.True(applied.WalletRunning);
+        Assert.True(await spark.Service.HasAnyStoreProvisioned());
+
+        await indexer.RecordAssociationAsync(firstPrompt, Ct);
+
+        var entry = Assert.Single(index.Entries.Values);
+        Assert.Equal(InvoiceId, entry.InvoiceId);
     }
 }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkMigrationTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkMigrationTests.cs
@@ -176,4 +176,38 @@ public class SparkMigrationTests
         Assert.Equal(operation.Schema, drop.Schema);
         Assert.Equal(operation.Table, drop.Table);
     }
+
+    /// <summary>
+    /// The retention delete gets its range index, changes nothing else, and drops cleanly.
+    /// </summary>
+    /// <remarks>
+    /// <c>SparkPaymentHashRetentionTask</c>'s pass is a <c>DELETE ... WHERE "FirstSeenAt" &lt; cutoff</c> on a
+    /// table that grows with every prompt mint on the server; without this index the retention pass full-
+    /// scans the very table it exists to shrink. No read path touches <c>FirstSeenAt</c>, so dropping the
+    /// index would degrade only the delete, silently, on a real merchant's server. The migration must also
+    /// carry nothing else: the retention work is a schema addition, not a row change, and an unexpected
+    /// column or backfill riding along with an index migration is exactly the surprise this pin exists to
+    /// surface. The <c>Down</c> must drop the same named index in the same schema, or unwinding an upgrade
+    /// strands it.
+    /// </remarks>
+    [Fact]
+    public void The_retention_index_covers_the_delete_column_and_carries_nothing_else()
+    {
+        var operation = Assert.Single(
+            new PaymentHashRetentionIndex().UpOperations.OfType<CreateIndexOperation>());
+
+        Assert.Equal("IX_InvoicePaymentHashes_FirstSeenAt", operation.Name);
+        Assert.Equal("BTCPayServer.Plugins.Flint", operation.Schema);
+        Assert.Equal("InvoicePaymentHashes", operation.Table);
+        Assert.Equal(new[] { nameof(InvoicePaymentHash.FirstSeenAt) }, operation.Columns);
+
+        // Index only — no column, data, or other-table operations ride along.
+        Assert.Single(new PaymentHashRetentionIndex().UpOperations);
+
+        var drop = Assert.Single(
+            new PaymentHashRetentionIndex().DownOperations.OfType<DropIndexOperation>());
+        Assert.Equal(operation.Name, drop.Name);
+        Assert.Equal(operation.Schema, drop.Schema);
+        Assert.Equal(operation.Table, drop.Table);
+    }
 }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkPaymentHashRetentionTaskTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkPaymentHashRetentionTaskTests.cs
@@ -1,0 +1,85 @@
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The bound and the pass of <see cref="SparkPaymentHashRetentionTask"/>.
+/// </summary>
+/// <remarks>
+/// The data layer is deliberately not exercised here: <c>EfInvoicePaymentHashIndex.PruneBeforeAsync</c> is a
+/// set <c>ExecuteDeleteAsync</c> that only runs against Postgres, and its predicate is pinned by
+/// <see cref="InvoicePaymentHashIndexContractTests"/> — whose in-memory half runs in this suite and whose
+/// Postgres half runs when <c>SPARK_POSTGRES_TESTS</c> is set. What is left to pin in-process is the task's
+/// own two decisions: where the cutoff comes from, and that a pass acts on it.
+/// </remarks>
+public class SparkPaymentHashRetentionTaskTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private const string StaleHash =
+        "c1d2e3f4051627384950a1b2c3d4e5f60718293a4b5c6d7e8f901234567800cc";
+    private const string KeptHash =
+        "d2e3f4051627384950a1b2c3d4e5f60718293a4b5c6d7e8f901234567800ccdd";
+
+    private static InvoicePaymentHash Row(string hash, DateTimeOffset firstSeenAt) => new()
+    {
+        PaymentHash = hash,
+        InvoiceId = "btcpay-invoice-1",
+        PaymentMethodId = "BTC-LNURL",
+        FirstSeenAt = firstSeenAt
+    };
+
+    [Fact]
+    public void The_retention_window_is_the_credit_walks_own_listing_floor()
+    {
+        // Not a copied constant: retention prunes exactly what the walk can no longer list, so widening
+        // SparkInvoiceCreditor's horizons moves this boundary with it, and a future edit that "simplifies"
+        // the cutoff to a bare 14 days — or, worse, to the shorter CreditRetryHorizon, which would delete
+        // rows the walk still lists for another week — fails here.
+        var now = new DateTimeOffset(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+
+        Assert.Equal(SparkInvoiceCreditor.ListableFrom(now), SparkPaymentHashRetentionTask.CutoffFor(now));
+        Assert.Equal(now - TimeSpan.FromDays(14), SparkPaymentHashRetentionTask.CutoffFor(now));
+    }
+
+    [Fact]
+    public async Task A_pass_removes_only_associations_older_than_the_window()
+    {
+        var index = new InMemoryInvoicePaymentHashIndex();
+        var cutoff = SparkPaymentHashRetentionTask.CutoffFor(DateTimeOffset.UtcNow);
+        // One minute either side of the boundary: a pass that prunes by settlement-adjacent clocks rather
+        // than first-seen time, or whose comparison is off by an equality flip at the cutoff, is caught by
+        // which side of this pair dies.
+        index.Seed(Row(StaleHash, cutoff - TimeSpan.FromMinutes(1)));
+        index.Seed(Row(KeptHash, cutoff + TimeSpan.FromMinutes(1)));
+
+        await new SparkPaymentHashRetentionTask(
+            index,
+            NullLogger<SparkPaymentHashRetentionTask>.Instance)
+            .Do(Ct);
+
+        Assert.Null(await index.FindByPaymentHashAsync(StaleHash, Ct));
+        Assert.NotNull(await index.FindByPaymentHashAsync(KeptHash, Ct));
+        Assert.Single(index.Entries);
+    }
+
+    [Fact]
+    public async Task A_pass_on_an_empty_or_fresh_table_is_a_no_op()
+    {
+        // The ordinary case on a healthy server, on nearly every pass: nothing past the window exists, and
+        // the pass must leave the recent rows alone rather than sweep the table.
+        var index = new InMemoryInvoicePaymentHashIndex();
+        index.Seed(Row(KeptHash, DateTimeOffset.UtcNow));
+
+        await new SparkPaymentHashRetentionTask(
+            index,
+            NullLogger<SparkPaymentHashRetentionTask>.Instance)
+            .Do(Ct);
+
+        Assert.NotNull(await index.FindByPaymentHashAsync(KeptHash, Ct));
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Constants.cs
+++ b/BTCPayServer.Plugins.Flint/Constants.cs
@@ -206,6 +206,15 @@ public static class Constants
     /// <summary>How often <c>SweepTask</c> runs, measured from the end of the previous pass.</summary>
     public static readonly TimeSpan SweepInterval = TimeSpan.FromMinutes(2);
 
+    /// <summary>How often <c>SparkPaymentHashRetentionTask</c> runs, measured from the end of the previous pass.</summary>
+    /// <remarks>
+    /// Hourly: the statement it runs is one indexed <c>DELETE</c>, so an hour buys a server an idle-day pass
+    /// that costs a point lookup, while the freshest a row can be when it dies stays within an hour of the
+    /// walk's own 14-day floor. Making the pass any sharper would prune nothing sooner that the walk could
+    /// still have consulted.
+    /// </remarks>
+    public static readonly TimeSpan PaymentHashRetentionInterval = TimeSpan.FromHours(1);
+
     /// <summary>
     /// Wall clock a single reconciliation pass may spend before it stops starting new stores.
     /// </summary>

--- a/BTCPayServer.Plugins.Flint/Data/EfInvoicePaymentHashIndex.cs
+++ b/BTCPayServer.Plugins.Flint/Data/EfInvoicePaymentHashIndex.cs
@@ -75,4 +75,21 @@ public class EfInvoicePaymentHashIndex : IInvoicePaymentHashIndex
             .AsNoTracking()
             .FirstOrDefaultAsync(h => h.PaymentHash == paymentHash.ToLowerInvariant(), cancellationToken);
     }
+
+    /// <remarks>
+    /// <c>ExecuteDeleteAsync</c> rather than load-and-<c>Remove</c>: the retrying execution strategy refuses
+    /// user-initiated transactions (the class remarks above), and set-delete is the whole operation anyway —
+    /// no row is examined first, so there is nothing for a context to track. It emits the single
+    /// <c>DELETE ... WHERE "FirstSeenAt" &lt; {cutoff}</c> the <c>FirstSeenAt</c> index exists to serve; the
+    /// Postgres contract suite pins that it deletes exactly the rows the cutoff selects.
+    /// </remarks>
+    public async Task<int> PruneBeforeAsync(
+        DateTimeOffset cutoff,
+        CancellationToken cancellationToken = default)
+    {
+        await using var context = _contextFactory.CreateContext();
+        return await context.InvoicePaymentHashes
+            .Where(hash => hash.FirstSeenAt < cutoff)
+            .ExecuteDeleteAsync(cancellationToken);
+    }
 }

--- a/BTCPayServer.Plugins.Flint/Data/IInvoicePaymentHashIndex.cs
+++ b/BTCPayServer.Plugins.Flint/Data/IInvoicePaymentHashIndex.cs
@@ -21,7 +21,8 @@ namespace BTCPayServer.Plugins.Flint.Data;
 /// <para>
 /// Write-once per hash, read by payment hash only — a payment hash is unique to the BOLT11 minted for one
 /// invoice, so there is no update path and no store-scoped key, exactly as in core's insert-only
-/// <c>AddressInvoices</c>.
+/// <c>AddressInvoices</c>. It is not insert-only forever, though: <see cref="PruneBeforeAsync"/> retires
+/// associations the credit walk can no longer consult, which is the one deletion this table ever sees.
 /// </para>
 /// </remarks>
 public interface IInvoicePaymentHashIndex
@@ -41,4 +42,17 @@ public interface IInvoicePaymentHashIndex
     Task<InvoicePaymentHash?> FindByPaymentHashAsync(
         string paymentHash,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes every association first seen strictly before <paramref name="cutoff"/> and returns how many
+    /// rows went. Idempotent: a second pass with the same cutoff deletes nothing.
+    /// </summary>
+    /// <remarks>
+    /// The one delete path on a table otherwise modeled on core's insert-only <c>AddressInvoices</c>. The
+    /// caller's bound is <c>SparkInvoiceCreditor.ListableFrom</c> — the age past which no settlement is
+    /// still listed by the credit walk, so an association older than it can never be consulted again.
+    /// See <c>Services.SparkPaymentHashRetentionTask</c>.
+    /// </remarks>
+    /// <param name="cutoff">Associations with a first-seen time older than this are removed.</param>
+    Task<int> PruneBeforeAsync(DateTimeOffset cutoff, CancellationToken cancellationToken = default);
 }

--- a/BTCPayServer.Plugins.Flint/Data/SparkPluginDbContext.cs
+++ b/BTCPayServer.Plugins.Flint/Data/SparkPluginDbContext.cs
@@ -93,6 +93,14 @@ public class SparkPluginDbContext : DbContext
             // The table name is pinned so the raw SQL in EfInvoicePaymentHashIndex.RecordAsync names the same
             // table EF creates, rather than relying on both ending up at EF's default pluralisation.
             entity.ToTable("InvoicePaymentHashes");
+            // The retention pass (Services.SparkPaymentHashRetentionTask) deletes by exactly this column:
+            // DELETE ... WHERE "FirstSeenAt" < cutoff. Without an index that delete is a full scan of the
+            // whole association table on every pass; with one it is a range seek over the stale head of the
+            // table. The read path (FindByPaymentHashAsync) never touches FirstSeenAt, so this index serves
+            // the delete alone. Name pinned rather than left to EF's default, as the settleable index above
+            // pins its own.
+            entity.HasIndex(record => record.FirstSeenAt)
+                .HasDatabaseName("IX_InvoicePaymentHashes_FirstSeenAt");
         });
     }
 }

--- a/BTCPayServer.Plugins.Flint/Migrations/20260901235325_PaymentHashRetentionIndex.Designer.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260901235325_PaymentHashRetentionIndex.Designer.cs
@@ -100,12 +100,6 @@ namespace BTCPayServer.Plugins.Flint.Migrations
 
                     b.HasIndex("StoreId", "CreatedAt");
 
-                    b.HasIndex("StoreId", "ExpiresAt")
-                        .HasDatabaseName("IX_InvoiceRecords_StoreId_ExpiresAt_Settleable")
-                        .HasFilter("\"Status\" <> 1");
-
-                    NpgsqlIndexBuilderExtensions.IncludeProperties(b.HasIndex("StoreId", "ExpiresAt"), new[] { "CreatedAt", "PaymentHash" });
-
                     b.HasIndex("StoreId", "SettledAt")
                         .HasFilter("\"Status\" = 1 AND \"CreditedAt\" IS NULL AND \"CreditAbandonedAt\" IS NULL AND \"SettledAt\" IS NOT NULL");
 

--- a/BTCPayServer.Plugins.Flint/Migrations/20260901235325_PaymentHashRetentionIndex.Designer.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260901235325_PaymentHashRetentionIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BTCPayServer.Plugins.Flint.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BTCPayServer.Plugins.Flint.Migrations
 {
     [DbContext(typeof(SparkPluginDbContext))]
-    partial class SparkPluginDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260901235325_PaymentHashRetentionIndex")]
+    partial class PaymentHashRetentionIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -100,6 +103,8 @@ namespace BTCPayServer.Plugins.Flint.Migrations
                     b.HasIndex("StoreId", "ExpiresAt")
                         .HasDatabaseName("IX_InvoiceRecords_StoreId_ExpiresAt_Settleable")
                         .HasFilter("\"Status\" <> 1");
+
+                    NpgsqlIndexBuilderExtensions.IncludeProperties(b.HasIndex("StoreId", "ExpiresAt"), new[] { "CreatedAt", "PaymentHash" });
 
                     b.HasIndex("StoreId", "SettledAt")
                         .HasFilter("\"Status\" = 1 AND \"CreditedAt\" IS NULL AND \"CreditAbandonedAt\" IS NULL AND \"SettledAt\" IS NOT NULL");

--- a/BTCPayServer.Plugins.Flint/Migrations/20260901235325_PaymentHashRetentionIndex.cs
+++ b/BTCPayServer.Plugins.Flint/Migrations/20260901235325_PaymentHashRetentionIndex.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BTCPayServer.Plugins.Flint.Migrations
+{
+    /// <inheritdoc />
+    public partial class PaymentHashRetentionIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_InvoicePaymentHashes_FirstSeenAt",
+                schema: "BTCPayServer.Plugins.Flint",
+                table: "InvoicePaymentHashes",
+                column: "FirstSeenAt");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_InvoicePaymentHashes_FirstSeenAt",
+                schema: "BTCPayServer.Plugins.Flint",
+                table: "InvoicePaymentHashes");
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkInvoicePaymentHashIndexer.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkInvoicePaymentHashIndexer.cs
@@ -32,6 +32,14 @@ namespace BTCPayServer.Plugins.Flint.Services;
 /// that gives a prompt its hash) are skipped; the mint event that follows carries the hash.
 /// </para>
 /// <para>
+/// <b>Gated on the plugin actually serving anyone.</b> The event carries no store id (core's
+/// <c>InvoiceNewPaymentDetailsEvent</c> is invoice + details + payment method), and the association this index
+/// exists to restore only matters for a store this plugin has provisioned — for every other store core's own
+/// <c>AddressInvoices</c> is complete and the write is noise on a server-wide hot path. The gate is therefore
+/// the any-store question, read live from <see cref="SparkService"/> on every event: true from the moment the
+/// first Flint store is provisioned, without a restart.
+/// </para>
+/// <para>
 /// <b>Best-effort, and why that is the right bound.</b> A failed write is logged and swallowed — it must
 /// not unwind the event-aggregator loop. This index is a fallback over core's own table, not the primary
 /// authority: for a store with LUD-21 on (which this plugin forces when it provisions a store), core's
@@ -44,14 +52,17 @@ namespace BTCPayServer.Plugins.Flint.Services;
 public class SparkInvoicePaymentHashIndexer : EventHostedServiceBase
 {
     private readonly IInvoicePaymentHashIndex _index;
+    private readonly SparkService _sparkService;
     private readonly ILogger<SparkInvoicePaymentHashIndexer> _logger;
 
     public SparkInvoicePaymentHashIndexer(
         EventAggregator eventAggregator,
         IInvoicePaymentHashIndex index,
+        SparkService sparkService,
         ILogger<SparkInvoicePaymentHashIndexer> logger) : base(eventAggregator, logger)
     {
         _index = index;
+        _sparkService = sparkService;
         _logger = logger;
     }
 
@@ -92,6 +103,15 @@ public class SparkInvoicePaymentHashIndexer : EventHostedServiceBase
             // that follows does.
             if (!BTCPayInvoiceCreditGateway.CreditablePaymentMethods.Contains(prompt.PaymentMethodId)
                 || prompt.Details is not LigthningPaymentPromptDetails { PaymentHash: not null } details)
+            {
+                return;
+            }
+
+            // The any-store gate, re-read per event rather than cached: provisioning is rare and the settings
+            // cache offers no invalidation hook to hang a flag on, while a stale false would silently stop
+            // recording associations for a store provisioned since startup. Placed after the payment-method
+            // filter so the common skip — a prompt this plugin could never credit — costs no dictionary read.
+            if (!await _sparkService.HasAnyStoreProvisioned().ConfigureAwait(false))
             {
                 return;
             }

--- a/BTCPayServer.Plugins.Flint/Services/SparkPaymentHashRetentionTask.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkPaymentHashRetentionTask.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace BTCPayServer.Plugins.Flint.Services;
 
 /// <summary>
-/// Periodically deletes payment-hash associations the credit walk can no longer consult.
+/// Periodically deletes payment-hash associations the credit walk can no longer plausibly consult.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -24,19 +24,23 @@ namespace BTCPayServer.Plugins.Flint.Services;
 /// reader of this table is the credit gateway's fallback lookup, reached only for settlements the credit walk
 /// still lists, and the walk lists nothing older than <c>now − 14 days</c> (<see
 /// cref="SparkInvoiceCreditor.CreditRetryHorizon"/> plus <see
-/// cref="SparkInvoiceCreditor.AbandonedReportingGrace"/>). An association first seen before that boundary can
-/// therefore never be consulted again, and keeping it buys nothing. The bound is deliberately the walk's own
-/// constant rather than a copy: widen the walk's horizons and retention follows automatically. The bound this
-/// does buy back is stated honestly in the limitations doc: a payment that arrives more than fourteen days
-/// after its prompt was <em>minted</em> reaches a row this task may already have deleted, and is reported
-/// unattributable — the same outcome the outage paragraph already accepts for older-than-the-walk payments.
+/// cref="SparkInvoiceCreditor.AbandonedReportingGrace"/>). One edge keeps the claim short of absolute: the
+/// cut deletes by mint time (<c>FirstSeenAt</c>) while the walk lists by settle time, and
+/// <c>FirstSeenAt &lt;= SettledAt</c>, so a row deleted at the mint-window floor can still have a settlement
+/// that is listable by settle time. That needs a mint-to-settle gap wider than the whole window, is closed
+/// in practice by BOLT11 expiry, and is stated in the limitations doc: a payment that arrives more than
+/// fourteen days after its prompt was <em>minted</em> reaches a row this task may already have deleted, and
+/// is reported unattributable — the same outcome the outage paragraph already accepts for older-than-the-walk
+/// payments. Beyond that edge, an association first seen before the boundary buys the walk nothing. The bound
+/// is deliberately the walk's own constant rather than a copy: widen the walk's horizons and retention follows
+/// automatically.
 /// </para>
 /// <para>
 /// Registered through BTCPay's <c>AddScheduledTask</c> on <see
 /// cref="Constants.PaymentHashRetentionInterval"/> — its own task rather than a line appended to
 /// <see cref="SparkReconciliationTask"/>, because that pass runs every minute over live wallets and this one
-/// is a single indexed <c>DELETE</c> whose useful cadence is daily; sharing the task would tie a
-/// once-a-day-and-done statement to the settlement guarantee's hot loop. <c>AddScheduledTask</c> logs rather
+/// is a single indexed <c>DELETE</c> that runs hourly at negligible cost; sharing the task would tie a
+/// background janitor to the settlement guarantee's hot loop. <c>AddScheduledTask</c> logs rather
 /// than rethrows, so a database outage delays pruning to the next pass instead of faulting anything.
 /// </para>
 /// </remarks>

--- a/BTCPayServer.Plugins.Flint/Services/SparkPaymentHashRetentionTask.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkPaymentHashRetentionTask.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.HostedServices;
+using BTCPayServer.Plugins.Flint.Data;
+using Microsoft.Extensions.Logging;
+
+namespace BTCPayServer.Plugins.Flint.Services;
+
+/// <summary>
+/// Periodically deletes payment-hash associations the credit walk can no longer consult.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why this table needs a delete path at all.</b> The indexer writes one row per LN/LNURL prompt mint
+/// server-wide — every invoice quoted on the server, not just Flint stores' — and until now nothing ever
+/// removed a row, making the plugin's one Postgres table unbounded on a host that otherwise caps its own
+/// data (see <c>docs/limitations.md</c> on <c>sdk.log</c> for the other half of that story). The write gate
+/// added alongside this task stops rows being minted for servers with no Flint store; this task retires the
+/// rows the walk has left behind for every server.
+/// </para>
+/// <para>
+/// <b>The bound is <see cref="SparkInvoiceCreditor.ListableFrom"/>, not an invented horizon.</b> The only
+/// reader of this table is the credit gateway's fallback lookup, reached only for settlements the credit walk
+/// still lists, and the walk lists nothing older than <c>now − 14 days</c> (<see
+/// cref="SparkInvoiceCreditor.CreditRetryHorizon"/> plus <see
+/// cref="SparkInvoiceCreditor.AbandonedReportingGrace"/>). An association first seen before that boundary can
+/// therefore never be consulted again, and keeping it buys nothing. The bound is deliberately the walk's own
+/// constant rather than a copy: widen the walk's horizons and retention follows automatically. The bound this
+/// does buy back is stated honestly in the limitations doc: a payment that arrives more than fourteen days
+/// after its prompt was <em>minted</em> reaches a row this task may already have deleted, and is reported
+/// unattributable — the same outcome the outage paragraph already accepts for older-than-the-walk payments.
+/// </para>
+/// <para>
+/// Registered through BTCPay's <c>AddScheduledTask</c> on <see
+/// cref="Constants.PaymentHashRetentionInterval"/> — its own task rather than a line appended to
+/// <see cref="SparkReconciliationTask"/>, because that pass runs every minute over live wallets and this one
+/// is a single indexed <c>DELETE</c> whose useful cadence is daily; sharing the task would tie a
+/// once-a-day-and-done statement to the settlement guarantee's hot loop. <c>AddScheduledTask</c> logs rather
+/// than rethrows, so a database outage delays pruning to the next pass instead of faulting anything.
+/// </para>
+/// </remarks>
+public class SparkPaymentHashRetentionTask : IPeriodicTask
+{
+    private readonly IInvoicePaymentHashIndex _index;
+    private readonly ILogger<SparkPaymentHashRetentionTask> _logger;
+
+    public SparkPaymentHashRetentionTask(
+        IInvoicePaymentHashIndex index,
+        ILogger<SparkPaymentHashRetentionTask> logger)
+    {
+        _index = index;
+        _logger = logger;
+    }
+
+    /// <summary>The oldest association a pass keeps: exactly the credit walk's own listing floor.</summary>
+    public static DateTimeOffset CutoffFor(DateTimeOffset now) => SparkInvoiceCreditor.ListableFrom(now);
+
+    public async Task Do(CancellationToken cancellationToken)
+    {
+        var cutoff = CutoffFor(DateTimeOffset.UtcNow);
+        var removed = await _index.PruneBeforeAsync(cutoff, cancellationToken).ConfigureAwait(false);
+        if (removed > 0)
+        {
+            _logger.LogInformation(
+                "Spark payment-hash retention removed {Removed} association(s) first seen before {Cutoff}",
+                removed, cutoff);
+        }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -989,9 +989,13 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
     /// <para>
     /// The any-store form of <see cref="Get"/>, for the rare reader whose question is not about one store but
     /// about whether the plugin has anything to serve at all — today only the prompt-mint indexer, which gates
-    /// its writes on it (see <see cref="SparkInvoicePaymentHashIndexer"/>). Like every other cache read it
-    /// waits on the startup gate: an empty cache before the load is not evidence that no store is configured,
-    /// and a reader that concluded so during startup would skip work on a fiction.
+    /// its writes on it (see <see cref="SparkInvoicePaymentHashIndexer"/>). An empty cache before the load is
+    /// not evidence that no store is configured, so the read waits on the startup gate — but on the bounded
+    /// wait of <see cref="Resolve"/> (<see cref="StartupWaitTimeout"/>), not unboundedly: this runs on the
+    /// indexer's server-wide event-loop path, and a hung SDK call at startup must not stall its ProcessEvents
+    /// loop with an unbounded event channel. A wait that expires fails open — the caller proceeds as though a
+    /// store existed and records — because a wrong "no" silently drops a row the reconciliation story cannot
+    /// recover, while a wrong "yes" only costs a row retention will retire.
     /// </para>
     /// <para>
     /// A snapshot, not a lease: a store provisioned concurrently with the read may or may not be counted,
@@ -1000,7 +1004,17 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
     /// </remarks>
     public async Task<bool> HasAnyStoreProvisioned()
     {
-        await _startupGate.Task.ConfigureAwait(false);
+        if (!_startupGate.Task.IsCompleted)
+        {
+            try
+            {
+                await _startupGate.Task.WaitAsync(StartupWaitTimeout).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                return true;
+            }
+        }
         return !_settings.IsEmpty;
     }
 

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -983,6 +983,28 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
     }
 
     /// <summary>
+    /// Whether any store on this server has Flint configured.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The any-store form of <see cref="Get"/>, for the rare reader whose question is not about one store but
+    /// about whether the plugin has anything to serve at all — today only the prompt-mint indexer, which gates
+    /// its writes on it (see <see cref="SparkInvoicePaymentHashIndexer"/>). Like every other cache read it
+    /// waits on the startup gate: an empty cache before the load is not evidence that no store is configured,
+    /// and a reader that concluded so during startup would skip work on a fiction.
+    /// </para>
+    /// <para>
+    /// A snapshot, not a lease: a store provisioned concurrently with the read may or may not be counted,
+    /// which is exactly the granularity its one consumer needs — it re-reads on every event.
+    /// </para>
+    /// </remarks>
+    public async Task<bool> HasAnyStoreProvisioned()
+    {
+        await _startupGate.Task.ConfigureAwait(false);
+        return !_settings.IsEmpty;
+    }
+
+    /// <summary>
     /// One pass of the cross-store Lightning configuration sweep: clears any store whose Lightning payment
     /// method embeds another store's Spark wallet, and rotates that victim's payment key. See
     /// <see cref="SparkLightningConfigSweeper"/> for why this exists and why clearing cannot damage a

--- a/BTCPayServer.Plugins.Flint/SparkPlugin.cs
+++ b/BTCPayServer.Plugins.Flint/SparkPlugin.cs
@@ -273,6 +273,13 @@ public class SparkPlugin : BaseBTCPayServerPlugin
         // SyncWallet plus one GetInfo per configured store per pass. See SweepTask for the full argument.
         services.AddScheduledTask<SweepTask>(Constants.SweepInterval);
 
+        // Payment-hash retention. The indexer's write gate stops this plugin recording prompts on a server
+        // with no Flint store; this pass retires rows — on any server — older than the credit walk's own
+        // 14-day listing floor, which is the last moment any reader can still consult them. Hourly, because
+        // the pass is one indexed DELETE and the freshest a row can die is bounded by this interval; see
+        // SparkPaymentHashRetentionTask for why it is its own task and not a line in the reconciliation pass.
+        services.AddScheduledTask<SparkPaymentHashRetentionTask>(Constants.PaymentHashRetentionInterval);
+
         // UI extension points. Paths are relative to Views/Shared/ and resolved as partials.
         services.AddUIExtension("ln-payment-method-setup-tabhead", "Spark/LNPaymentMethodSetupTabhead");
         services.AddUIExtension("ln-payment-method-setup-tab", "Spark/LNPaymentMethodSetupTab");

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -56,6 +56,16 @@
     it provisions a store; while that setting is on, core's own index covers the hash even through an
     outage.)
 
+    The plugin's own copy of the association is also bounded, and that bound is worth knowing by name:
+    rows are kept for **fourteen days** — the credit walk's own floor (seven days of credit retries plus the
+    seven-day abandoned-reporting grace), the point past which nothing in the plugin will ever read the row
+    again — and an hourly background pass deletes everything older, so this table, unlike `sdk.log` below,
+    cannot grow without bound. On a server with no Flint store it never grows at all: prompt-mint recording
+    is gated on at least one store being provisioned. The bound costs one case: a payment arriving **more
+    than fourteen days after its prompt was minted** reaches an association this pass may already have
+    deleted, and is reported unattributable — the same outcome as the outage gap above, and the same
+    fourteen-day line as the bullet before it.
+
   One thing the plugin does *not* keep from BTCPay's own listener is worth naming as a non-limitation:
   the preimage is written onto the payment prompt as well as onto the payment, so LNURL
   proof-of-payment (LUD-21 `verify`) works for a Flint checkout exactly as it does for any other


### PR DESCRIPTION
## What
Review finding P3 (verified): `InvoicePaymentHashes` is written for every store on the server — the payer mint events it records are globally broadcast and the indexer filters only on payment method — and nothing ever deletes from it. Only rows within `CreditRetryHorizon + AbandonedReportingGrace` (7+7 = 14 days) are ever read for credit attribution.
## Fix
1. The prompt recording is gated on **any Flint store being provisioned** — read live per event from `SparkService`'s settings cache (`HasAnyStoreProvisioned()`, startup gate awaited, then `!_settings.IsEmpty`), not a captured bool, so provisioning re-arms recording without a restart. The event carries no `StoreId`, so per-store filtering would cost an extra invoice lookup per event; the write gate is the cheap, honest cut (core's own AddressInvoices already covers non-Flint stores' payment history).
2. Retention: a dedicated `IPeriodicTask` (`SparkPaymentHashRetentionTask`, 1h cadence) prunes rows with `FirstSeenAt < SparkInvoiceCreditor.ListableFrom(now)` — the walk's own listing floor, not a copied constant — via a single indexed `ExecuteDeleteAsync` (set-delete; the retry strategy refuses user transactions for Remove-range ops).
3. Migration `PaymentHashRetentionIndex` adds `IX_InvoicePaymentHashes_FirstSeenAt` (named explicitly; asserts in `SparkMigrationTests`).
4. `docs/limitations.md` documents the 14-day window and its honest bound (a settlement arriving >14 days after the prompt mint becomes unattributable).

## Verified
- Default suite green (1203 pass / 0 fail — indexer facts re-driven through the real harness incl. the no-store skip and the re-arm-on-provision fact); Postgres contract suite green (97/0) including the prune predicate as a real `ExecuteDeleteAsync` on Postgres against the fresh per-run DB.

## Stack
STACKED on `perf/settleable-invoice-index` (PR6) — shares the EF model snapshot; merge PR6 first, then this rebases trivially onto it.
## Independent final review - resolutions
- **final-review SHOULDs (P3)** - the gate's startup wait is bounded (`WaitAsync(StartupWaitTimeout)`, reusing the service's existing 1 s bound) and fails OPEN on timeout - a hung SDK call at startup can no longer stall the indexer's event loop while its channel accumulates every LNURL prompt; the retention remark was softened to the real semantics (mint-time cut vs settle-time listing edge, closed in practice by BOLT11 expiry, documented in limitations.md); cadence prose says hourly.
- **Rebase** - the branch is now stacked on PR #61's post-review tip (rebase of the two feature commits + this resolve's own commits; the settleable migration's regeneration is reconciled in the shared ModelSnapshot/Designers; both PR designers differ only by their own blocks).
- Documented in-body (MAY): the retention migration's CREATE INDEX takes a brief ACCESS EXCLUSIVE lock on `InvoicePaymentHashes` inside the migration transaction - one-time at deploy, bounded by table size; the first prune after upgrade is one unbatched indexed DELETE.