### PR TITLE
Low-risk hardening batch: scrubbed SDK errors, path-free lock reason, packaging and test hygiene

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -151,6 +151,35 @@ jobs:
               bash scripts/strip-native-payloads.sh "$TARGET_DIR"
             '
 
+      # Prune the one native RID no BTCPay Server deployment can load. Measured on
+      # Breez.Sdk.Spark 0.23.0 before this step: linux-x64 60 MB, linux-arm64 60 MB,
+      # osx-arm64 25 MB, osx-x64 26 MB, win-x64 17 MB, win-x86 15 MB. A 32-bit Windows
+      # process is not a BTCPay Server deployment target, and unlike the ELF/Mach-O
+      # payloads the PE cannot be stripped (the script header says why: its debug
+      # directory is a tens-of-bytes CodeView pointer — all payload, no DWARF), so
+      # removal is the only reduction available for it. The assertion that follows is
+      # what makes the prune safe in both directions: a RID set that gains an entry is
+      # Breez shipping a platform nobody here has verified, and one that loses an entry
+      # is this plugin about to fail loading for somebody. Neither should ship silently
+      # just because win-x86 stopped being there.
+      - name: Prune the win-x86 native payload
+        env:
+          TARGET_DIR: ${{ steps.build-dir.outputs.path }}
+        run: |
+          set -euo pipefail
+          rm -rf "$TARGET_DIR/runtimes/win-x86"
+          rids="$(cd "$TARGET_DIR/runtimes" \
+            && LC_ALL=C find . -mindepth 1 -maxdepth 1 -type d -printf '%f\n' \
+            | LC_ALL=C sort | tr '\n' ' ')"
+          expected="linux-arm64 linux-x64 osx-arm64 osx-x64 win-x64 "
+          if [ "$rids" != "$expected" ]; then
+            echo "error: after pruning win-x86 the shipped RID set is not the expected one." >&2
+            echo "  expected: linux-arm64 linux-x64 osx-arm64 osx-x64 win-x64" >&2
+            echo "  actual:   $rids" >&2
+            exit 1
+          fi
+          echo "Native payloads ship for: $rids"
+
       - name: Run PluginPacker
         env:
           PLUGIN_DIR: ${{ steps.build-dir.outputs.path }}

--- a/BTCPayServer.Plugins.Flint.Tests/Postgres/PostgresTestDatabase.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Postgres/PostgresTestDatabase.cs
@@ -101,6 +101,7 @@ public sealed class PostgresTestDatabase : IAsyncLifetime
         await context.Database.ExecuteSqlRawAsync(
             $"""
              TRUNCATE TABLE
+                 "{Constants.DatabaseSchema}"."InvoicePaymentHashes",
                  "{Constants.DatabaseSchema}"."InvoiceRecords",
                  "{Constants.DatabaseSchema}"."OutgoingPayments",
                  "{Constants.DatabaseSchema}"."SweepRecords";

--- a/BTCPayServer.Plugins.Flint.Tests/SparkControllerStoreScopeTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkControllerStoreScopeTests.cs
@@ -609,4 +609,29 @@ public class SparkControllerStoreScopeTests
                 + "never authorised for.");
         }
     }
+
+    /// <summary>
+    /// The controller-level response-cache refusal is load-bearing, and nothing but this test notices
+    /// when it is dropped.
+    /// </summary>
+    /// <remarks>
+    /// The setup page deliberately re-renders a rejected import with the recovery phrase just typed, so a
+    /// cached page would park a mnemonic on browser or proxy machinery outside the session that typed it.
+    /// MVC does not fail if the attribute disappears — every page keeps working — so the only thing
+    /// between a future refactor and that leak is this assertion. It checks the class, not the actions:
+    /// the attribute is stated once for the controller, which is also how it outlives per-action churn.
+    /// </remarks>
+    [Fact]
+    public void The_controller_refuses_response_caching_at_the_class_level()
+    {
+        var cache = typeof(SparkController)
+            .GetCustomAttributes(typeof(ResponseCacheAttribute), inherit: false)
+            .Single();
+
+        Assert.True(
+            cache is ResponseCacheAttribute { NoStore: true, Location: ResponseCacheLocation.None },
+            "SparkController must carry [ResponseCache(NoStore = true, Location = None)] at class "
+            + "level: the setup page re-renders a rejected import with the phrase just typed, and a "
+            + "cached response would keep that mnemonic outside the session that typed it.");
+    }
 }

--- a/BTCPayServer.Plugins.Flint.Tests/SparkLogBridgeTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkLogBridgeTests.cs
@@ -118,6 +118,32 @@ public class SparkLogBridgeTests
     }
 
     /// <summary>
+    /// The other exit an SDK payload has: error text a merchant is shown.
+    /// </summary>
+    /// <remarks>
+    /// <c>SparkErrors.Describe</c> relays the SDK's own payload to banners, Greenfield validation
+    /// bodies, stored sweep errors and claim outcome messages — none of which stand in front of
+    /// the bridge above. The scrubbing therefore also sits at <c>Describe</c>'s choke point, and
+    /// this is what pins that it does: an SDK error whose payload carries the shape the trace-level
+    /// leak was observed in must come out with the value replaced and the diagnosis intact.
+    /// </remarks>
+    [Fact]
+    public void An_SDK_error_relayed_to_a_merchant_is_scrubbed()
+    {
+        const string token = "eyJ1aWQiOiIwMTlmZDQ5Ny03Yjc3LTZlZDgifQ.anPdDQ.9noMLLWPhHNXSkl3YtayTfpEtMbvonj";
+
+        var described = SparkErrors.Describe(new SdkException.SparkException(
+            $"@v1=Tree service error: verify_challenge rejected session_token: \"{token}\""));
+
+        Assert.DoesNotContain(token, described);
+        Assert.Contains(SparkLogScrubber.Redacted, described);
+
+        // Not merely redacted: still the error the merchant needs to see, prefix stripped.
+        Assert.Contains("Tree service error: verify_challenge rejected session_token:", described);
+        Assert.DoesNotContain("@v1=", described);
+    }
+
+    /// <summary>
     /// The other half: the lines that carry the diagnostic value must survive intact.
     /// </summary>
     /// <remarks>

--- a/BTCPayServer.Plugins.Flint.Tests/SparkStorageLockTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkStorageLockTests.cs
@@ -52,6 +52,62 @@ public class SparkStorageLockTests
         first!.Dispose();
     }
 
+    /// <summary>
+    /// A claim the platform itself refuses says what is wrong without saying where on the disk.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A permission refusal surfaces as an <c>UnauthorizedAccessException</c> whose own message
+    /// embeds the absolute path of the denied file, and the reason returned here is relayed to
+    /// whoever saves the store's settings — a store manager on a <c>CanViewStoreSettings</c>
+    /// route, not necessarily a server operator. The host's filesystem layout is a fact about the
+    /// server, and it belongs in the operator's log (which names the directory deliberately),
+    /// not in the banner.
+    /// </para>
+    /// <para>
+    /// Triggered honestly rather than by mocking: a read-only lock file cannot be opened
+    /// <c>ReadWrite</c> on either platform, which is the exact throw. The pre-check skips the
+    /// test where the environment does not enforce that anyway — running as root, where the
+    /// open would succeed and there is nothing to route.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void A_claim_the_platform_refuses_names_no_path_to_the_merchant()
+    {
+        using var dir = new TempDirectory();
+        var lockFile = Path.Combine(dir.Path, SparkStorageLock.FileName);
+        File.WriteAllText(lockFile, "held elsewhere\n");
+        File.SetAttributes(lockFile, FileAttributes.ReadOnly);
+        try
+        {
+            var openSucceeded = false;
+            try
+            {
+                new FileStream(lockFile, FileMode.Open, FileAccess.ReadWrite, FileShare.None).Dispose();
+                openSucceeded = true;
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            Assert.SkipUnless(
+                !openSucceeded, "the platform let a read-only file be opened for writing (root?), so the refusal never happens");
+
+            var claimed = SparkStorageLock.TryAcquire(dir.Path, out var reason);
+
+            Assert.Null(claimed);
+            Assert.NotNull(reason);
+            Assert.Contains("could not be claimed", reason);
+            Assert.DoesNotContain(dir.Path, reason);
+            Assert.DoesNotContain(SparkStorageLock.FileName, reason);
+        }
+        finally
+        {
+            // Restored so TempDirectory can clean the whole thing up.
+            File.SetAttributes(lockFile, FileAttributes.Normal);
+        }
+    }
+
     [Fact]
     public void Releasing_a_claim_lets_the_next_one_take_it()
     {
@@ -131,7 +187,7 @@ public class SparkStorageLockTests
         // the file, not to close one afterwards.
         Assert.DoesNotContain("contended", h.Sdk.Connects);
 
-        Assert.Contains("another process holds the lock", h.Log.AllText);
+        Assert.Contains("Another process is already using", h.Log.AllText);
 
         other!.Dispose();
     }

--- a/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
+++ b/BTCPayServer.Plugins.Flint/Controllers/SparkController.cs
@@ -62,6 +62,12 @@ namespace BTCPayServer.Plugins.Flint.Controllers;
 /// for sweeping. What is left in this class is rendering and redirecting.
 /// </para>
 /// </remarks>
+// The setup page deliberately re-renders a rejected import with the recovery phrase the person
+// just typed (see BuildSetupViewModel's remarks) — right behaviour for the page, but a cached
+// response would then keep a mnemonic on browser or proxy machinery outside the session that
+// typed it. Every page here is authorised, per-user, and followed by POSTs, so none of it is
+// cacheable in principle and the refusal is stated once for the controller rather than per action.
+[ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
 [Route("plugins/{storeId}/spark")]
 [Authorize(AuthenticationSchemes = AuthenticationSchemes.Cookie, Policy = Policies.CanViewStoreSettings)]
 // Stated rather than inherited. Every POST here changes money-handling configuration, and CSRF protection

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkErrors.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkErrors.cs
@@ -23,7 +23,13 @@ public static class SparkErrors
     public static string Describe(Exception exception)
     {
         ArgumentNullException.ThrowIfNull(exception);
-        return exception switch
+        // Scrubbed at the choke point. What leaves this method is free text from the SDK and its
+        // service providers, and every one of its sinks is merchant-facing — TempData banners,
+        // Greenfield validation bodies, stored `SweepRecord.Error`s, claim outcome messages —
+        // none of them standing behind the log bridge's scrubbing. The rules that cover the
+        // operator's log cover the merchant's error by standing here; scrubbing at each call
+        // site instead would be forty chances to forget one.
+        return SparkLogScrubber.Scrub(exception switch
         {
             SdkException.InsufficientFunds => "Insufficient Spark balance.",
             SdkException.SparkException spark => Strip(spark.v1),
@@ -40,7 +46,7 @@ public static class SparkErrors
             SdkException => Strip(exception.Message),
             ObjectDisposedException => "The Spark wallet for this store is no longer running.",
             _ => Strip(exception.Message)
-        };
+        });
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkErrors.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkErrors.cs
@@ -29,7 +29,11 @@ public static class SparkErrors
         // none of them standing behind the log bridge's scrubbing. The rules that cover the
         // operator's log cover the merchant's error by standing here; scrubbing at each call
         // site instead would be forty chances to forget one.
-        return SparkLogScrubber.Scrub(exception switch
+        // Two trades taken knowingly: the scrubber's HeaderCredential pattern eats to end-of-line
+        // on an authorization/bearer/cookie word (fail-closed — a truncated sentence beats a leaked
+        // token), and RedactPhrases may run the Bip39English static ctor inside a catch handler
+        // (low risk: it only loads an embedded wordlist).
+        var merchantFacing = exception switch
         {
             SdkException.InsufficientFunds => "Insufficient Spark balance.",
             SdkException.SparkException spark => Strip(spark.v1),
@@ -46,7 +50,10 @@ public static class SparkErrors
             SdkException => Strip(exception.Message),
             ObjectDisposedException => "The Spark wallet for this store is no longer running.",
             _ => Strip(exception.Message)
-        });
+        };
+        // The total-redaction fallback is this sink's own sentence, not the log bridge's: a banner
+        // quoting a failed request should not gain a stray clause about SDK log lines.
+        return SparkLogScrubber.Scrub(merchantFacing, "Spark reported an error that could not be shown safely.");
     }
 
     /// <summary>

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkLogScrubber.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkLogScrubber.cs
@@ -200,7 +200,19 @@ internal static class SparkLogScrubber
     /// the process deadlocks — so a regex timeout, or anything else, yields a wholly redacted line rather than
     /// a partially scrubbed one. Losing a log line is always cheaper than leaking one.
     /// </remarks>
-    internal static string Scrub(string? line)
+    internal static string Scrub(string? line) =>
+        Scrub(line, $"{Redacted} (a Spark SDK log line could not be scrubbed and was dropped)");
+
+    /// <summary>
+    /// The same, with the caller's own sentence for the total-redaction case.
+    /// </summary>
+    /// <remarks>
+    /// Not every caller writes to the operator's log. <c>SparkErrors.Describe</c> scrubs text that lands in
+    /// merchant-facing banners and stored records, where "a Spark SDK log line could not be scrubbed" is both
+    /// the wrong noun and a second sentence nobody asked for next to the failure it accompanies — so the sink
+    /// supplies its own fallback instead of inheriting the log bridge's.
+    /// </remarks>
+    internal static string Scrub(string? line, string fallback)
     {
         if (string.IsNullOrEmpty(line))
             return string.Empty;
@@ -216,7 +228,7 @@ internal static class SparkLogScrubber
         }
         catch (Exception)
         {
-            return $"{Redacted} (a Spark SDK log line could not be scrubbed and was dropped)";
+            return fallback;
         }
     }
 

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkStorageLock.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkStorageLock.cs
@@ -66,11 +66,24 @@ internal sealed class SparkStorageLock : IDisposable
     /// </param>
     /// <returns>The held lock, or null when another process holds it or it could not be taken.</returns>
     public static SparkStorageLock? TryAcquire(string directory, out string? reason)
+        => TryAcquire(directory, out reason, out _);
+
+    /// <summary>
+    /// The same, with the OS's own refusal words surfaced for the operator's log.
+    /// </summary>
+    /// <param name="osDetail">
+    /// The exception type and message from a permission-grounded refusal, for the operator's log only:
+    /// .NET embeds the denied file's absolute path in that message, which is exactly what an operator
+    /// needs to fix ownership and exactly what must never reach the merchant-facing
+    /// <paramref name="reason"/>. Null in every other outcome.
+    /// </param>
+    public static SparkStorageLock? TryAcquire(string directory, out string? reason, out string? osDetail)
     {
         ArgumentException.ThrowIfNullOrEmpty(directory);
 
         var path = System.IO.Path.Combine(directory, FileName);
         reason = null;
+        osDetail = null;
         try
         {
             // Owner-only at creation, matching the storage provider that hardens this same directory: the lock
@@ -122,14 +135,16 @@ internal sealed class SparkStorageLock : IDisposable
                 + "own.";
             return null;
         }
-        catch (UnauthorizedAccessException)
+        catch (UnauthorizedAccessException ex)
         {
             // The platform refused the open on permission grounds. .NET embeds the absolute path
             // of the denied file in this exception's message, and this reason is relayed to
             // whoever is saving the store's settings — a store manager, not necessarily a server
             // operator — so no exception text goes into it, exactly as the IOException branch
-            // above. The caller that logs the refusal logs the storage directory alongside the
-            // reason, which is where that detail belongs.
+            // above. The OS's own words travel separately in osDetail, which the caller logging
+            // the refusal takes with the storage directory: that log is the operator's, and the
+            // denied path plus the exception name are exactly the detail missing from it.
+            osDetail = $"{ex.GetType().Name}: {ex.Message}";
             reason =
                 "This store's Spark wallet storage could not be claimed, so the wallet was not "
                 + "started. The server process cannot open its storage directory for writing; a "

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkStorageLock.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkStorageLock.cs
@@ -122,11 +122,18 @@ internal sealed class SparkStorageLock : IDisposable
                 + "own.";
             return null;
         }
-        catch (UnauthorizedAccessException ex)
+        catch (UnauthorizedAccessException)
         {
+            // The platform refused the open on permission grounds. .NET embeds the absolute path
+            // of the denied file in this exception's message, and this reason is relayed to
+            // whoever is saving the store's settings — a store manager, not necessarily a server
+            // operator — so no exception text goes into it, exactly as the IOException branch
+            // above. The caller that logs the refusal logs the storage directory alongside the
+            // reason, which is where that detail belongs.
             reason =
-                "This store's Spark wallet storage could not be claimed, so the wallet was not started: "
-                + ex.Message;
+                "This store's Spark wallet storage could not be claimed, so the wallet was not "
+                + "started. The server process cannot open its storage directory for writing; a "
+                + "server operator needs to check that directory's ownership and permissions.";
             return null;
         }
     }

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -426,18 +426,20 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
         // in-memory dictionary and therefore per process: two BTCPay instances sharing one data directory each
         // pass it and each connect an SDK instance to the same non-WAL SQLite file. See SparkStorageLock for
         // why that is a corruption hazard rather than merely a duplicate-sweep one.
-        var storageLock = SparkStorageLock.TryAcquire(GetWorkDir(storeId), out var lockReason);
+        var storageLock = SparkStorageLock.TryAcquire(GetWorkDir(storeId), out var lockReason, out var lockDetail);
         if (storageLock is null)
         {
             // The reason is logged as well as returned: an instance holding the claim and a
             // permission refusal arrive here through different exceptions and call for
             // different fixes, and a log line that pre-decided which one it was would
-            // misdirect the operator on half of them.
+            // misdirect the operator on half of them. The OS's own words ride along as a
+            // structured field — this line is the operator's log, the one place the denied
+            // path belongs; the returned reason stays merchant-safe.
             _logger.LogError(
                 "Store {StoreId}: refusing to start its Spark wallet. {LockReason} The storage "
                 + "directory is {StorageDir}; run a single BTCPay instance against this data "
-                + "directory.",
-                storeId, lockReason, GetWorkDir(storeId));
+                + "directory. OS detail: {LockDetail}",
+                storeId, lockReason, GetWorkDir(storeId), lockDetail ?? "none");
             return lockReason;
         }
 

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -429,11 +429,15 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
         var storageLock = SparkStorageLock.TryAcquire(GetWorkDir(storeId), out var lockReason);
         if (storageLock is null)
         {
+            // The reason is logged as well as returned: an instance holding the claim and a
+            // permission refusal arrive here through different exceptions and call for
+            // different fixes, and a log line that pre-decided which one it was would
+            // misdirect the operator on half of them.
             _logger.LogError(
-                "Store {StoreId}: refusing to start its Spark wallet because another process holds the lock on "
-                + "{StorageDir}. Two instances on one storage directory corrupt the wallet's database. Run a "
-                + "single BTCPay instance against this data directory",
-                storeId, GetWorkDir(storeId));
+                "Store {StoreId}: refusing to start its Spark wallet. {LockReason} The storage "
+                + "directory is {StorageDir}; run a single BTCPay instance against this data "
+                + "directory.",
+                storeId, lockReason, GetWorkDir(storeId));
             return lockReason;
         }
 

--- a/BTCPayServer.Plugins.Flint/SparkPlugin.cs
+++ b/BTCPayServer.Plugins.Flint/SparkPlugin.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net.Http;
 using BTCPayServer.Abstractions.Contracts;
 using BTCPayServer.Abstractions.Extensions;
 using BTCPayServer.Abstractions.Models;
@@ -202,6 +203,17 @@ public class SparkPlugin : BaseBTCPayServerPlugin
             client.Timeout = CrossChainCatalog.FetchTimeout;
             client.DefaultRequestHeaders.UserAgent.ParseAdd(
                 $"BTCPayServer.Plugins.Flint/{typeof(SparkPlugin).Assembly.GetName().Version}");
+        })
+        // Redirects are not followed. The catalogue response is parsed into routing decisions a
+        // sweep can spend against, so it is only trusted from the endpoint the plugin itself
+        // named: a 3xx to a different host — a compromised or misconfigured CDN, an open
+        // redirect on the path — would otherwise be answered by whoever it points at, and the
+        // default handler follows up to twenty of them transparently. A redirect is a fetch
+        // failure here, which the catalogue's own cache-and-skip handling already treats as
+        // "no routes this round", not as routes.
+        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+        {
+            AllowAutoRedirect = false
         });
         services.AddSingleton<CrossChainCatalog>();
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ What a server needs to *run* this plugin:
 
 - **BTCPay Server 2.4.1 or newer.** That is the declared support floor, and BTCPay refuses to load the
   plugin on anything older. It is compiled against 2.4.2.
-- **A supported platform.** The Breez Spark SDK ships around 200 MB of native libraries for
-  `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`, `win-x64` and `win-x86`. There is **no**
-  `linux-musl` (Alpine) or `win-arm64` payload, so the plugin will not load on those platforms.
+- **A supported platform.** The plugin's payload carries the Breez Spark SDK's native libraries
+  (around 190 MB) for `linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64` and `win-x64`. There is
+  **no** `linux-musl` (Alpine) or `win-arm64` payload, so the plugin will not load on those platforms.
   Standard BTCPay Docker images (Debian-based) are fine.
 - **Mainnet or regtest.** The SDK offers no testnet or signet, so neither is supported. Stable Balance
   and cross-chain sweeps are mainnet-only even on a supported network.

--- a/docs/building.md
+++ b/docs/building.md
@@ -6,6 +6,7 @@ For development you additionally need:
 
 - .NET SDK 10.0 or later
 - Git with submodule support
+- `jq` (used by `plugin-register.sh` to write the dev settings file)
 - PostgreSQL and the other BTCPay development dependencies (via Docker) for running BTCPay locally
 
 Clone with submodules, or initialise them after the fact:

--- a/docs/ci-and-releases.md
+++ b/docs/ci-and-releases.md
@@ -42,7 +42,10 @@
     sha256 each strip prints) is argued in the script's header, which is also the local pre-release
     recipe: run `dotnet build -c Release`, run the script against the output directory, then
     `PluginPacker` by hand. The step is idempotent and fails the package loudly if an ELF cannot be
-    stripped; the Windows DLLs are not touched at all, because they carry no strippable debug data.
+    stripped; the Windows DLLs are not touched at all, because they carry no strippable debug
+    data. The 32-bit `win-x86` payload is instead pruned at packaging by the step that follows,
+    whose RID-set assertion pins the shipped set to `linux-x64`, `linux-arm64`, `osx-arm64`,
+    `osx-x64` and `win-x64` only.
   - **Artifacts are signed with keyless Sigstore build provenance**
     (`actions/attest-build-provenance`), not a maintainer GPG key: there is no long-lived key for
     anyone to generate, store, lose or leak, and the attestation binds the artifact's digest to this

--- a/plugin-register.sh
+++ b/plugin-register.sh
@@ -11,6 +11,10 @@ source plugin-env.sh
 
 TARGET_PATH="$(dotnet build "$PROJECT/$PROJECT.csproj" -p:Configuration=Debug -getProperty:TargetPath)"
 
-printf '{ "DEBUG_PLUGINS": "%s" }' "$TARGET_PATH" > "btcpayserver/BTCPayServer/appsettings.dev.json"
+# jq rather than a printf: the target path is arbitrary filesystem text, and a path
+# containing a quote or a backslash (any Windows path) would otherwise be interpolated
+# into the file as invalid JSON — which BTCPay's dev host then fails to parse, with an
+# error that does not name this file.
+jq -n --arg p "$TARGET_PATH" '{DEBUG_PLUGINS:$p}' > "btcpayserver/BTCPayServer/appsettings.dev.json"
 
 echo "The plugin will now start when debugging BTCPay Server"

--- a/plugin-register.sh
+++ b/plugin-register.sh
@@ -9,6 +9,11 @@ cd "$(dirname "$0")"
 
 source plugin-env.sh
 
+# Guarded before anything is written: the redirect below truncates its target
+# before jq would fail, and a half-written appsettings.dev.json breaks BTCPay's
+# dev host with an error that does not name this file.
+command -v jq >/dev/null || { echo 'error: plugin-register.sh needs jq (brew install jq / apt install jq)' >&2; exit 1; }
+
 TARGET_PATH="$(dotnet build "$PROJECT/$PROJECT.csproj" -p:Configuration=Debug -getProperty:TargetPath)"
 
 # jq rather than a printf: the target path is arbitrary filesystem text, and a path

--- a/scripts/strip-native-payloads.sh
+++ b/scripts/strip-native-payloads.sh
@@ -272,6 +272,11 @@ strip_macho_llvm() { # $1 = path to .dylib — non-macOS host: llvm-strip + expl
       mode="$(python3 /macho_sig.py flags "/src/$1")"
       case "$mode" in unsigned|adhoc) ;; *) echo "signature state: $mode" >&2; exit 3 ;; esac
       cp "/src/$1" /out/stripped.dylib
+      # The actual strip. The llvm-18 package names its binary llvm-strip-18; probe the
+      # unversioned name as a fallback, mirroring the host path above. Until this line
+      # existed the container only copied and verified, so the docker fallback reported
+      # every dylib as a no-op ("already stripped") and shipped it unstripped.
+      "$(command -v llvm-strip-18 || command -v llvm-strip)" -x /out/stripped.dylib
       python3 /macho_sig.py verify /out/stripped.dylib
       chmod --reference "/src/$1" /out/stripped.dylib
     ' macho "$(basename "$f")"; then

--- a/scripts/strip-native-payloads.sh
+++ b/scripts/strip-native-payloads.sh
@@ -244,6 +244,9 @@ strip_macho_llvm() { # $1 = path to .dylib — non-macOS host: llvm-strip + expl
   if [ -n "$tool" ] && command -v python3 >/dev/null 2>&1; then
     # Strip a copy, verify the copy, only then replace the original: a strip
     # that invalidates the signature must degrade to "skipped", never ship.
+    # Known wart: a $tool that resolves but fails at exec (a broken llvm package,
+    # a 127) is blamed on signature verification by the warn below — the container
+    # path does not share it, its apt install guarantees llvm-18 is present.
     out="$(mktemp "${TMPDIR:-/tmp}/flint-macho.XXXXXX")"
     if cp "$f" "$out" && "$tool" -x "$out" 2>/dev/null && python3 "$MACHO_PY" verify "$out"; then
       if [ "$(fsize "$out")" = "$before" ]; then


### PR DESCRIPTION
## What
The review's low-risk batch (each independently small, each verified; kept as one reviewable batch of mechanical fixes; one commit per concern):
1. **S7** — SDK exception text now goes through `SparkLogScrubber.Scrub` at the `SparkErrors.Describe` choke point, so merchant-visible banners, Greenfield 4xx bodies, `SweepRecord.Error` and `SparkClaimOutcome.Message` can't relay secret-shaped SDK payloads (e.g. session tokens) verbatim.
2. **S8** — the storage lock's `UnauthorizedAccessException` branch returns a fixed merchant reason (no just a path em dash, matching the `IOException` branch), while the detail (the absolute path) moves into the log line — which previously mis-accused a second BTCPay instance for permission failures.
3. **S9** — `SparkController` sets `ResponseCache(NoStore=true, Location=None)` at class level; a rejected import re-renders the submitted recovery phrase from ModelState, and no cache headers were otherwise set anywhere.
4. **Info** — the cross-chain catalog client stops following redirects (`AllowAutoRedirect = false`): a 3xx now surfaces as a fetch failure the catalog already treats as "no routes this round" instead of silently trusting wherever the source redirected.
5. **Tests** — the Postgres test TRUNCATE list gains `InvoicePaymentHashes` (the plugin's 4th table), ending cross-test leakage that could mask a credit-gateway fallback regression.
6. **Packaging+scripts** — the strip script's docker Mach-O fallback actually strips now (`llvm-strip-18 -x` between the cp and the signature verify — previously the fallback only copied+verified and always printed a false "already stripped"); `package.yml` prunes `runtimes/win-x86` (~15 MB dead weight on every host, since BTCPay hosts are linux/win-x64/mac) with an assertion that the remaining RID set is exactly the expected five; `plugin-register.sh` writes its JSON via `jq -n --arg` instead of a raw printf (paths with quotes/backslashes produced invalid JSON).

## Verified
Default suite green (1303 / 1197 / 0); scoped suites green (47/47 scrub+errors, 22/22 storage+startup, 41/41 store-scope); Postgres contract suite green (99/0, on a fresh DB, with the completed truncate list); scripts pass `bash -n`; the RID assertion simulated against an expected set and against a win-x86-present set (fails loudly).
## Independent final review - resolutions

Highlighted commit: `3b3b55d`
- **final-review MUST (P2)** - README and docs/ci-and-releases.md now say win-x86 is pruned at packaging (RIDs: linux-x64, linux-arm64, osx-x64, osx-arm64, win-x64); the release PR's CHANGELOG must record the win-x86 support drop.
- **final-review SHOULDs (P3)** - the scrubber's fail-closed text is parameterised and `Describe` passes "Spark reported an error that could not be shown safely."; the storage lock surfaces the OS error detail (`ex.GetType(): message`) as a structured log field on the existing caller log; a reflection Fact pins the S9 `[ResponseCache]` attributes; `plugin-register.sh` guards jq's availability BEFORE truncating `appsettings.dev.json`; docs/building.md lists jq as a prerequisite; comments note the HeaderCredential end-of-line + Bip39 static-ctor-in-catch trades.