### PR TITLE
Enforce Breez.Sdk.Spark release gating past the Dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,17 @@ updates:
   # NuGet packages referenced directly by the plugin project — except Breez.Sdk.Spark, ignored
   # below: Breez tags and pushes patch versions to NuGet with no GitHub Release and no notes
   # (0.22.1 through 0.22.3 all shipped that way), and a Dependabot PR per push is churn, not
-  # signal. .github/workflows/breez-sdk-update.yml is the release-aware replacement — the same
-  # split as the btcpayserver submodule above, for the same reason — proposing a bump only for
-  # versions upstream has published a release for. A tag-only fix worth shipping early is bumped
-  # by hand.
+  # signal. .github/workflows/breez-sdk-update.yml is the release-aware replacement — proposing a
+  # bump only for versions upstream has published a release for. A tag-only fix worth shipping
+  # early is bumped by hand.
+  #
+  # That split once failed silently in the other direction: the ignore below worked while the pin
+  # was a plain version (no bump proposed between 2026-08-22 and 2026-09-02), and stopped working
+  # as soon as the pin became a bracketed exact-version range (7823e2a changed it on 2026-09-02;
+  # Dependabot proposed a PR for tag-only 0.24.1 on 2026-09-03, PR #65). Two countermeasures
+  # since: `versions: ["*"]` re-routes the ignore through the version-pattern matcher, and
+  # .github/workflows/breez-dependabot-guard.yml closes any Dependabot PR that still names
+  # Breez.Sdk.Spark, so a Dependabot quirk can open nothing but noise that dies without a human.
   #
   # Also note: Dependabot's nuget updater resolves the project's ProjectReference to
   # ../btcpayserver/BTCPayServer/BTCPayServer.csproj, which lives in a git submodule; this is
@@ -28,7 +35,11 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     ignore:
+      # The versions condition is not a statement that some versions may be proposed: it matches
+      # every version, on the strength of the incident described above — make the ignore survive
+      # whatever format the PackageReference pin takes next.
       - dependency-name: "Breez.Sdk.Spark"
+        versions: ["*"]
 
   # Test-project NuGet packages -- xunit.v3, and since the move to Microsoft.Testing.Platform that is the
   # whole list; the VSTest host and adapter it used to name here are gone. Separate entry because

--- a/.github/workflows/breez-dependabot-guard.yml
+++ b/.github/workflows/breez-dependabot-guard.yml
@@ -1,0 +1,55 @@
+name: Breez Dependabot guard
+
+# Dependabot's NuGet ignore rules are not a reliable gate: the name-only ignore for
+# Breez.Sdk.Spark held while the pin was a plain version, and silently stopped working the day
+# the pin became a bracketed exact range (7823e2a, 2026-09-02) — Dependabot proposed a PR for
+# tag-only 0.24.1 the next morning (PR #65, 2026-09-03), defeating the policy that Breez bumps
+# arrive only from .github/workflows/breez-sdk-update.yml, which proposes a version only when
+# upstream has a *published GitHub Release* for it (see the comment on that workflow and on
+# dependabot.yml for why tag-only bumps are deliberate churn).
+#
+# This workflow enforces that policy at the PR layer instead of trusting the ignore: any PR
+# authored by Dependabot that names Breez.Sdk.Spark is closed and its branch deleted. Human
+# PRs (including hand-applied tag-only bumps) are untouched: the guard fires only for
+# dependabot[bot]. If a Dependabot quirk resurrects a PR, this closes it without a human ever
+# having to look at it.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  guard:
+    name: Close Dependabot Breez.Sdk.Spark PR
+    # Fails closed: a PR not authored by dependabot[bot], or already deleted before this job
+    # runs, is a no-op, not an error.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      contains(github.event.pull_request.title, 'Breez.Sdk.Spark')
+    runs-on: ubuntu-latest
+    permissions:
+      # Deleting the guarded PR's branch needs contents; closing + commenting needs PRs.
+      contents: write
+      pull-requests: write
+    steps:
+      # No checkout needed: gh acts on the PR number directly.
+      - name: Close the PR and delete its branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          comment="$(cat <<BODY
+          Closed automatically by \`.github/workflows/breez-dependabot-guard.yml\`.
+
+          Dependabot's ignore for \`Breez.Sdk.Spark\` has a documented hole when the PackageReference
+          pin changes format (name-only ignore defeated by an exact-version bracket), so Breez bump
+          PRs must arrive only from \`.github/workflows/breez-sdk-update.yml\`, which proposes a
+          version only when upstream has a published GitHub Release for it. A tag-only fix worth
+          shipping early is bumped by hand.
+          BODY
+          )"
+          gh pr close "$PR" --comment "$comment" --delete-branch --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/breez-sdk-update.yml
+++ b/.github/workflows/breez-sdk-update.yml
@@ -7,7 +7,10 @@ name: Breez SDK update
 # replaced Dependabot's gitsubmodule ecosystem: weekly plus on-demand, it looks for the newest
 # version breez/spark-sdk has a *published GitHub Release* for (that also exists on NuGet, so
 # the PR can restore), and opens a bump PR only then. Breez.Sdk.Spark is ignored in
-# dependabot.yml so the two do not both propose bumps. A tag-only fix worth shipping early is a
+# dependabot.yml so the two do not both propose bumps; because that ignore proved leaky once the
+# pin format changed (see breez-dependabot-guard.yml), a guard workflow also closes any
+# Dependabot PR that names Breez.Sdk.Spark — the release gate is enforced, not assumed.
+# A tag-only fix worth shipping early is a
 # human decision: bump the PackageReference by hand, exactly as 0.22.2 and 0.22.3 were.
 #
 # Token: default GITHUB_TOKEN, with the same workflow_dispatch re-dispatch trick as


### PR DESCRIPTION
Enforces the policy that Breez SDK bump PRs arrive only from `.github/workflows/breez-sdk-update.yml`, which proposes a version only when upstream has a *published GitHub Release* for it — not from tag-only NuGet pushes.

**Root cause of the churn:** the release-gated updater was never the leaker. Its discovery script queries GitHub Releases (`gh api repos/breez/spark-sdk/releases`), and today correctly reports `changed=false` — 0.23.0 is the newest release, 0.24.0/0.24.1/0.23.1 are tag-only. The leak was Dependabot: its name-only ignore for `Breez.Sdk.Spark` held from 2026-08-22 while the pin was a plain version, and silently stopped working hours after `7823e2a` rewrote the pin to an exact-version bracket — Dependabot proposed a PR for tag-only **0.24.1** on 2026-09-03 (PR #65). This matches documented dependabot-core NuGet ignore bugs ([#12331](https://github.com/dependabot/dependabot-core/issues/12331), [#8182](https://github.com/dependabot/dependabot-core/issues/8182)).

Three layers, so reliability no longer depends on Dependabot internals:

- `dependabot.yml` — ignore hardened with `versions: ["*"]` (re-routes through the version-pattern matcher), incident recorded for the next pin-format change.
- New `.github/workflows/breez-dependabot-guard.yml` — closes and branch-deletes any `dependabot[bot]` PR naming `Breez.Sdk.Spark`; human PRs (including deliberate hand-applied tag-only bumps) are untouched.
- `breez-sdk-update.yml` header comment updated to state the gate is enforced, not assumed.

PR #65 was closed by hand alongside this (0.24.1 shipped no release), so the pin stays on the last release-backed version, 0.23.0.

`actionlint` clean on all three workfiles.
