### PR TITLE
Local Spark regtest e2e suite (cashu-regtest + open-ssp)

### DIFF
--- a/.github/workflows/local-regtest.yml
+++ b/.github/workflows/local-regtest.yml
@@ -1,0 +1,175 @@
+name: Local regtest
+
+# Runs the LocalRegtest suite against a Spark stack this workflow stands up itself:
+# callebtc/cashu-regtest's `--spark` profile — Bitcoin Core, three Spark operators, open-ssp, Electrs,
+# and three LND plus three CLN nodes as external Lightning counterparties.
+#
+# What this covers that ci.yml's `integration-test` and `funded-regtest-test` cannot. Those talk to
+# Lightspark's hosted regtest, where the far side of an invoice is not ours: nothing will pay an invoice
+# the plugin mints, nothing can mine a block on demand, and the whole thing needs a faucet-funded wallet
+# behind a repository secret — which is why the funded suite goes red when an operations event drains it,
+# and why fork PRs cannot run it at all. Here a real LND node pays a Flint invoice and Flint pays LND's,
+# confirmations are a `bitcoin-cli -generate` away, and every credential is a published fixture value. It
+# is the only job that exercises settlement end to end with no third-party service and no secret.
+#
+# COST, and it is not small: the fixture publishes no images, so every run builds the Spark operators
+# (Rust and Go), Electrs, open-ssp and ldk-server from source. Cold, that is around 40 minutes on
+# ubuntu-latest — the number the fixture's own spark-regtest job takes — and GitHub gives each job a clean
+# runner with no Docker layer cache, so it is cold every time. The 90-minute timeout matches the fixture's.
+# FOLLOW-UP: build these images once per pinned SHA and push them to ghcr.io, then have this job pull them.
+# That turns 40 minutes into a few and is the difference between this being a daily signal and a per-PR
+# gate. Doing it now would mean maintaining a publish workflow before the suite has proven its worth.
+
+on:
+  # Daily, for the same reason ci.yml runs daily: the Breez SDK is pre-1.0 and open-ssp moves, so drift in
+  # the protocol between them shows up here on days with no commits.
+  schedule:
+    - cron: "0 6 * * *"  # 06:00 UTC daily, an hour after ci.yml, so the two do not contend for runners
+  pull_request:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: "true"
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+  # write-network.sh and down.sh both need this to find the stack: the fixture's docker-scripts.sh pins
+  # the Compose project name rather than deriving it from the directory, and that name is what every
+  # container and volume is called. Set at workflow level so the diagnostics step has it too.
+  COMPOSE_PROJECT_NAME: cashu
+  # The Spark services are all behind a profile; `docker compose ps`/`logs` skip them without this.
+  COMPOSE_PROFILES: spark
+
+jobs:
+  local-regtest:
+    name: LocalRegtest suite (local Spark stack)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    # ADVISORY ON EVERY TRIGGER FOR NOW, deliberately, and for the reason integration-test's comment gives
+    # for itself: there is no measured flake rate. This suite has a lot of moving parts that are nobody's
+    # product — a source build of six services, a FROST keyshare generation that startup polls for, channel
+    # gossip that has to propagate before a payment can route — and a flaky *fixture* blocking merges would
+    # be worse than the gap it closes. Unlike integration-test the dependency is not a third-party service,
+    # so a red run here is more likely to be our bug, which is the argument for eventually flipping it:
+    #
+    #     continue-on-error: ${{ github.event_name != 'pull_request' }}
+    #
+    # Let the daily schedule accumulate a few weeks of pass/fail first, exactly as `funded-regtest-test`
+    # earned its PR gate. Until then someone has to read the run summary. See docs/ci-and-releases.md.
+    continue-on-error: true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Depth 1 applies to the btcpayserver submodule too (actions/checkout passes the same
+          # fetch-depth through to `git submodule update`), which matters: the submodule is a
+          # large, long-lived repo, and a full clone of it on every run would dominate CI time.
+          submodules: recursive
+          fetch-depth: 1
+
+      # Checked out rather than cloned by up.sh so the fixture's source is fetched with the same cached,
+      # authenticated transport as everything else, and so the pin is visible in this file to a reviewer
+      # and to Dependabot. `ref` MUST stay in step with `CASHU_REGTEST_SHA` in e2e/local-regtest/up.sh —
+      # up.sh verifies the checkout against its own constant and fails the job loudly if they diverge.
+      - name: Check out the cashu-regtest fixture at the pinned SHA
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: callebtc/cashu-regtest
+          ref: 23d5c160e0b5fade7e4a245b7385f9116bf2fc5c
+          path: e2e/local-regtest/cashu-regtest
+          persist-credentials: false
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: "10.0.x"
+
+      # Same key as every job in ci.yml, exact on the csproj hashes with no `restore-keys` prefix
+      # fallback, so a warm cache from a different dependency set is never adopted.
+      - name: Cache NuGet packages
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+
+      - name: Build (plugin + tests)
+        # -m:1 serialises MSBuild project scheduling. Not for speed obviously, but for correctness:
+        # the test project pins StaticWebAssetsEnabled=false on its ProjectReferences, which makes the
+        # btcpayserver closure build a second time under different global properties than the solution's
+        # own entries -- two builds of the same project, one output directory. On the v2.4.1 graph the
+        # two never collided; the v2.4.2 graph re-timed them and every job on the bump PR failed with
+        # "GenerateDepsFile ... deps.json ... being used by another process". The same class of race is
+        # documented for local fresh-worktree builds. Serialising the scheduler removes the collision at
+        # the cost of wall-clock; if that cost ever matters, the real fix is unifying the global
+        # properties, not removing this flag and hoping the timing holds.
+        run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release -m:1
+
+      # Runs the build before the stack on purpose: a compile error should cost two minutes, not forty.
+      - name: Start the local Spark stack
+        env:
+          # Reuse the checkout above instead of letting up.sh clone a second copy. up.sh still verifies
+          # its SHA, so a `ref` that drifts from up.sh's constant fails here rather than silently
+          # testing against a different revision of the fixture.
+          CASHU_REGTEST_DIR: ${{ github.workspace }}/e2e/local-regtest/cashu-regtest
+        run: e2e/local-regtest/up.sh
+
+      - name: Write the network descriptor
+        env:
+          CASHU_REGTEST_DIR: ${{ github.workspace }}/e2e/local-regtest/cashu-regtest
+        run: e2e/local-regtest/write-network.sh
+
+      # --output Detailed is Microsoft.Testing.Platform's equivalent of the VSTest
+      # `--logger "console;verbosity=detailed"` (see the test .csproj). Worth knowing if it is ever edited
+      # back: MTP does not reject the old flag, it takes it as a filter, matches nothing, and exits 5 with
+      # "Zero tests ran" -- red, but red for a reason that reads nothing like a bad command line.
+      #
+      # The suite's collection is declared with DisableParallelization: these tests move one wallet's money
+      # through one SSP, and the SSP serialises coop-exit requests per user.
+      - name: LocalRegtest suite
+        env:
+          SPARK_LOCAL_REGTEST_NETWORK: ${{ github.workspace }}/e2e/local-regtest/network.json
+        run: >
+          dotnet test BTCPayServer.Plugins.Flint.Tests/BTCPayServer.Plugins.Flint.Tests.csproj
+          --configuration Release --no-build --filter "Category=LocalRegtest"
+          --output Detailed
+
+      # A failure in this job is almost never legible from the .NET output alone: the interesting evidence
+      # is which of six services fell over. `ps -a` includes exited containers, which is the common case —
+      # an operator that crashed during keyshare generation looks, from the test's side, like a timeout.
+      - name: Stack failure diagnostics
+        if: failure()
+        working-directory: e2e/local-regtest/cashu-regtest
+        run: |
+          mkdir -p "${{ github.workspace }}/local-regtest-logs"
+          docker compose ps -a | tee "${{ github.workspace }}/local-regtest-logs/ps.txt"
+          for service in bitcoind spark-operator-0 spark-operator-1 spark-operator-2 \
+                         spark-ssp ldk spark-electrs lnd-1; do
+            # `|| true` per service: a service that never got created has no logs, and that must not stop
+            # the loop before it reaches the one that did fail.
+            docker compose logs --tail=400 --no-color "$service" \
+              > "${{ github.workspace }}/local-regtest-logs/$service.log" 2>&1 || true
+          done
+          tail -n 60 "${{ github.workspace }}/local-regtest-logs/"*.log || true
+
+      # Only on failure: on a green run these logs are tens of MB of routine chatter, and unlike
+      # `funded-regtest-test`'s artefact they answer no standing question. Nothing here is secret — every
+      # credential in the stack is a published fixture value and the suite's wallet is random per run and
+      # holds regtest coins — so there is no withholding logic to mirror.
+      - name: Upload the stack logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: local-regtest-stack-logs
+          path: local-regtest-logs/
+          if-no-files-found: warn
+          retention-days: 14
+
+      # always(), so a cancelled or timed-out run does not leave containers holding the runner's disk. On a
+      # hosted runner the runner is discarded anyway; this matters for self-hosted ones and costs seconds.
+      - name: Tear the stack down
+        if: always()
+        env:
+          CASHU_REGTEST_DIR: ${{ github.workspace }}/e2e/local-regtest/cashu-regtest
+        run: e2e/local-regtest/down.sh || true

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ packages/
 .local/
 TESTING.local.md
 *.local.md
+
+# Local Spark stack (e2e/local-regtest): the pinned cashu-regtest checkout, the descriptor
+# write-network.sh generates from the live stack, and up.sh's captured startup log. All three are
+# per-run artifacts of a disposable fixture — the pin itself lives in up.sh and the workflow.
+e2e/local-regtest/cashu-regtest/
+e2e/local-regtest/network.json
+e2e/local-regtest/up.log

--- a/BTCPayServer.Plugins.Flint.Tests/LocalRegtest/LocalRegtestStack.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/LocalRegtest/LocalRegtestStack.cs
@@ -1,0 +1,538 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using System.Threading.Channels;
+using BTCPayServer.Plugins.Flint.Sdk;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using Microsoft.Extensions.Logging.Abstractions;
+using NBitcoin;
+using Xunit;
+using SdkNetwork = Breez.Sdk.Spark.Network;
+
+namespace BTCPayServer.Plugins.Flint.Tests.LocalRegtest;
+
+/// <summary>
+/// One freshly created, funded wallet on a <b>locally hosted</b> Spark network, shared by the whole
+/// local-regtest suite.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What this adds over the funded suite.</b> <see cref="FundedRegtest.FundedRegtestWallet"/> runs against
+/// Lightspark's hosted regtest, which gives real answers but withholds two things the plugin's behaviour
+/// depends on. It has no external Lightning counterparty — a Flint invoice can only be paid by Flint itself,
+/// so the plugin has never been observed settling a payment that came from somebody else's node — and it has
+/// no control of the chain, so a cooperative exit confirms when it confirms. Here the whole stack is local:
+/// three Spark operators, an open-ssp with its own LDK node, an Esplora, bitcoind, and LND and CLN nodes with
+/// balanced channels to the SSP. Blocks are mined on demand and the counterparty is a real Lightning node
+/// that is not this wallet.
+/// </para>
+/// <para>
+/// <b>The wallet is created here, not supplied.</b> The funded suite is gated on a mnemonic held as a CI
+/// secret because its money is real-ish and scarce; nothing about this stack is. A fresh 12-word mnemonic is
+/// generated per run and funded from bitcoind, which is both simpler and safer: there is no long-lived secret
+/// to leak, no shared balance to drain, and every run starts from an empty history. The mnemonic is never
+/// printed — the tests still assert it did not reach the log, because the assertion is about the plugin's
+/// scrubbing rather than about this particular wallet.
+/// </para>
+/// <para>
+/// <b>Gating.</b> Opt-in on <c>SPARK_LOCAL_REGTEST_NETWORK</c> holding the path to the network descriptor
+/// <c>e2e/local-regtest/write-network.sh</c> emits. Absent, every test in the collection skips and this
+/// fixture connects nothing and starts no containers: the stack takes tens of minutes to build, so bringing
+/// it up is a deliberate act and never a side effect of running the test suite.
+/// </para>
+/// <para>
+/// <b>Serialised.</b> One wallet, three tests that each move its money, one chain whose height they all
+/// advance. Hence a collection fixture with parallelisation disabled, as in the funded suite.
+/// </para>
+/// </remarks>
+public sealed class LocalRegtestStack : IAsyncLifetime
+{
+    public const string CollectionName = "Spark local regtest";
+
+    /// <summary>
+    /// What the wallet is funded with, in satoshis.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Sized for the whole suite with headroom — a 5,000-sat receive, a 3,000-sat send, a 30,000-sat
+    /// cooperative exit and every fee involved — and then deliberately kept well under what the SSP holds.
+    /// </para>
+    /// <para>
+    /// <b>The ceiling is the SSP's, and it is not just about the deposit.</b> The fixture seeds open-ssp with
+    /// a single 500,000-sat leaf, and every Spark payment out of this wallet needs the SSP to <em>split</em>
+    /// leaves it can back. Funding this wallet with 200,000 was observed to succeed and then fail the first
+    /// 3,000-sat Lightning send with <c>Tree service error: insufficient funds</c> once the SSP's own
+    /// available balance had fallen below the wallet's — the deposit had eaten it. 150,000 against the SSP's
+    /// 500,000 leaves it several times the wallet's balance, which is what keeps splitting possible.
+    /// </para>
+    /// <para>
+    /// The upper end is also what the sweep test needs: it sizes a cooperative exit off a live fee quote, and
+    /// on a chain whose estimator has drifted up to 100 sat/vB that means sweeping around 100,000 sats to
+    /// keep the fee inside the engine's guards.
+    /// </para>
+    /// </remarks>
+    public const long FundingSats = 150_000;
+
+    /// <summary>How long the fixture waits for the funding deposit to be credited before failing.</summary>
+    /// <remarks>
+    /// Generous because the path is long — bitcoind must mine, Electrs must index, the SDK's chain service
+    /// must see three confirmations, and only then does the claim go to the operators — and because the
+    /// observed spread is wide: on the same stack the credit landed in 7 s on one run and 305 s on the next,
+    /// which is the SDK's own deposit-claim worker choosing when to look rather than anything on the chain.
+    /// The ceiling exists so a genuinely broken stack fails with an explanation instead of hanging until the
+    /// CI job's own timeout kills the process and leaves no failure to read.
+    /// </remarks>
+    private static readonly TimeSpan FundingTimeout = TimeSpan.FromMinutes(10);
+
+    public static string SkipReason =>
+        $"Set {SparkCustomNetworkFile.EnvironmentVariable} to the path of a local Spark regtest network "
+        + "descriptor to run the local-regtest suite. See docs/testing.md and e2e/local-regtest/README.md: "
+        + "bring the stack up with e2e/local-regtest/up.sh, then write the descriptor with "
+        + "e2e/local-regtest/write-network.sh.";
+
+    private static SparkCustomNetwork? TryLoadNetwork()
+    {
+        try
+        {
+            return SparkCustomNetworkFile.TryLoadFromEnvironment();
+        }
+        catch (Exception ex)
+        {
+            // A descriptor that exists but does not parse is a fixture fault, not a reason to skip: skipping
+            // would report the same green run as "the stack is not up", which is how a broken write-network.sh
+            // stays broken.
+            throw new InvalidOperationException(
+                $"{SparkCustomNetworkFile.EnvironmentVariable} is set but the descriptor could not be read: "
+                + ex.Message, ex);
+        }
+    }
+
+    /// <summary>True when the descriptor variable names a file. The gate for the whole suite.</summary>
+    public static bool IsEnabled =>
+        Environment.GetEnvironmentVariable(SparkCustomNetworkFile.EnvironmentVariable) is { } path
+        && !string.IsNullOrWhiteSpace(path);
+
+    /// <summary>
+    /// The deadline for everything this fixture does, including funding.
+    /// </summary>
+    /// <remarks>
+    /// A token of its own rather than <c>TestContext.Current.CancellationToken</c>: the ambient token
+    /// belongs to a test, and fixture setup runs outside one. Bounded anyway, because a fixture that hangs
+    /// reports nothing at all — the CI job's own timeout kills the process and the run has no failure to
+    /// read.
+    /// </remarks>
+    private readonly CancellationTokenSource _setup = new(TimeSpan.FromMinutes(15));
+
+    private string? _mnemonic;
+    private string? _storageDirectory;
+    private string? _logDirectory;
+
+    /// <summary>The connected wallet. Only valid when <see cref="IsEnabled"/>.</summary>
+    public ISparkSdkClient Sdk { get; private set; } = null!;
+
+    /// <summary>bitcoind and LND, over <c>docker exec</c>.</summary>
+    public RegtestControl Control { get; private set; } = null!;
+
+    /// <summary>The network the wallet is connected to, as the descriptor described it.</summary>
+    public SparkCustomNetwork Network { get; private set; } = null!;
+
+    /// <summary>A store id for the plugin-side collaborators. Not a real BTCPay store.</summary>
+    public string StoreId => "local-regtest";
+
+    /// <summary>The payment key the plugin-side collaborators are built with.</summary>
+    public string PaymentKey => "local-regtest-key";
+
+    /// <summary>Everything the SDK's Rust subscriber forwarded through <see cref="SparkLogBridge"/>, scrubbed.</summary>
+    public CapturingLogger<SparkLogBridge> ForwardedLog { get; } = new();
+
+    /// <summary>The wallet's static Bitcoin deposit address.</summary>
+    public string DepositAddress { get; private set; } = null!;
+
+    /// <summary>The balance observed once the funding deposit had been credited.</summary>
+    public long FundedBalanceSats { get; private set; }
+
+    /// <summary>What the SSP charged to claim the funding deposit. Reported, not asserted.</summary>
+    public long DepositClaimFeeSats { get; private set; }
+
+    /// <summary>How long the funding deposit took to be credited, for the record in the run log.</summary>
+    public TimeSpan DepositClaimLatency { get; private set; }
+
+    /// <summary>The seed, for the tests that must prove it was not logged. Never write this anywhere.</summary>
+    public string Mnemonic => _mnemonic
+        ?? throw new InvalidOperationException("The local regtest wallet is not enabled.");
+
+    public async ValueTask InitializeAsync()
+    {
+        if (TryLoadNetwork() is not { } network)
+            return;
+
+        Network = network;
+        Control = new RegtestControl(ReadFixture(
+            Environment.GetEnvironmentVariable(SparkCustomNetworkFile.EnvironmentVariable)!));
+        await Control.InitialiseAsync(_setup.Token);
+
+        // Generated, not configured. See the class remarks: there is no secret to hold, so there is no reason
+        // to hold one, and a fresh wallet per run means no test can be perturbed by an earlier run's history.
+        _mnemonic = new Mnemonic(Wordlist.English, WordCount.Twelve).ToString();
+
+        var root = Path.Combine(Path.GetTempPath(), "spark-local-regtest", Guid.NewGuid().ToString("N"));
+        _storageDirectory = Path.Combine(root, "storage");
+        _logDirectory = Path.Combine(root, "logs");
+        Directory.CreateDirectory(_storageDirectory);
+        Directory.CreateDirectory(_logDirectory);
+
+        // Installed before the connect, because the SDK's subscriber is process-global and one-shot. "debug"
+        // for the same reason the funded suite uses it: that is the level the plugin's log audit was performed
+        // at, so it is the level the receive test's preimage assertion has to hold at. ClampFilter still
+        // refuses trace, where the SSP session token lives.
+        SparkLogging.TryInitialise(_logDirectory, ForwardedLog, "debug");
+
+        var events = Channel.CreateBounded<SparkEventEnvelope>(new BoundedChannelOptions(256));
+        var factory = new SparkSdkClientFactory(
+            new FixedStorageProvider(_storageDirectory),
+            new NBitcoinBolt11Parser(NBitcoin.Network.RegTest, NullLogger<NBitcoinBolt11Parser>.Instance),
+            NullLoggerFactory.Instance);
+
+        Sdk = await factory.ConnectAsync(
+            new SparkConnectOptions(
+                StoreId,
+                _mnemonic,
+                passphrase: null,
+                apiKey: null,
+                SdkNetwork.Regtest,
+                // A ceiling generous enough that the SDK's own background worker claims the funding deposit
+                // without help. The SDK's default of Rate(1 sat/vB) is a cap rather than a bid and strands
+                // deposits, and this suite cannot start until one is credited.
+                //
+                // 1,000 sat/vB rather than the funded suite's 50, because this stack's idea of the fee
+                // market is set by the fixture itself: every funding transaction it sends specifies
+                // fee_rate=100, so the SSP quoted a claim requiring 100 sat/vB (9,900 sats) and refused both
+                // the SDK's auto-claim and an explicit claim at a 50 sat/vB ceiling — the whole suite then
+                // failed at startup with a zero balance. Nothing here is real money, so the ceiling is set
+                // far above anything the fixture can ask for rather than tuned to it.
+                maxDepositClaimFee: new SparkMaxFee.Rate(1_000),
+                stableBalance: null,
+                customNetwork: network),
+            events.Writer);
+
+        DepositAddress = await Sdk.GetBitcoinDepositAddressAsync(_setup.Token);
+        await FundAsync(_setup.Token);
+    }
+
+    /// <summary>
+    /// Puts <see cref="FundingSats"/> into the wallet from bitcoind and waits until the SDK has credited it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The route is the one the Rust reference client uses and the only one that exists: pay the wallet's
+    /// static deposit address on-chain, mine past the SDK's three-confirmation maturity rule, and let the
+    /// wallet claim it. Nothing here talks to the SSP's admin API — a deposit claimed out of band would prove
+    /// nothing about the plugin's own configuration of the SDK.
+    /// </para>
+    /// <para>
+    /// Claiming is expected to happen on the SDK's own background worker, which is why
+    /// <c>maxDepositClaimFee</c> is set. The explicit claim in the loop is a fallback rather than the plan: if
+    /// the worker has not acted by the time a deposit is mature, the suite claims it by outpoint at the same
+    /// ceiling instead of failing. Both routes are the plugin's own code, so either one keeps the test honest;
+    /// which one fired is reported so a change in the SDK's behaviour is visible in the run log rather than
+    /// silently absorbed.
+    /// </para>
+    /// <para>
+    /// A block is mined on every pass, not just at the start. Electrs and the SDK's chain service both follow
+    /// the tip, and on an idle regtest chain nothing else advances it.
+    /// </para>
+    /// </remarks>
+    private async Task FundAsync(CancellationToken cancellationToken)
+    {
+        var started = Stopwatch.StartNew();
+        var amountBtc = FundingSats / 100_000_000m;
+        var txId = await Control.SendToAddressAsync(DepositAddress, amountBtc,
+            cancellationToken: cancellationToken);
+        // Three, because that is the SDK's maturity rule for a deposit; the loop below keeps mining anyway.
+        await Control.MineAsync(3, cancellationToken);
+
+        var vout = await Control.FindVoutAsync(txId, DepositAddress, cancellationToken);
+        var claimedExplicitly = false;
+        var deadline = DateTimeOffset.UtcNow + FundingTimeout;
+        var lastError = "";
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            long balance;
+            try
+            {
+                balance = await SyncBalanceAsync(cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                // The operators and the SSP are all coming up alongside this; a sync that fails while the
+                // chain service catches up is expected, and the deadline is the judge.
+                lastError = $"the last wallet sync failed: {ex.Message}";
+                await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
+                continue;
+            }
+
+            if (balance > 0)
+            {
+                FundedBalanceSats = balance;
+                DepositClaimFeeSats = FundingSats - balance;
+                DepositClaimLatency = started.Elapsed;
+                Console.WriteLine(
+                    $"local-regtest: funded {FundingSats:N0} sats, credited {balance:N0} "
+                    + $"({DepositClaimFeeSats:N0} sats of claim fee) in "
+                    + $"{DepositClaimLatency.TotalSeconds:0.0} s "
+                    + $"({(claimedExplicitly ? "claimed explicitly" : "auto-claimed by the SDK")}); "
+                    + $"deposit {txId}");
+                return;
+            }
+
+            if (!claimedExplicitly && vout is { } outpoint)
+            {
+                try
+                {
+                    var deposits = await Sdk.ListUnclaimedDepositsAsync(cancellationToken);
+                    var mine = deposits.FirstOrDefault(d =>
+                        string.Equals(d.TxId, txId, StringComparison.OrdinalIgnoreCase));
+                    if (mine is { IsMature: true })
+                    {
+                        var claim = await Sdk.ClaimDepositAsync(
+                            txId, outpoint, new SparkMaxFee.Rate(1_000), cancellationToken);
+                        if (claim.Succeeded)
+                            claimedExplicitly = true;
+                        else
+                            lastError = $"the explicit claim was refused: {claim.Error}";
+                    }
+                    else if (mine is null)
+                    {
+                        lastError = "the SDK does not yet know about the funding deposit";
+                    }
+                    else
+                    {
+                        lastError = "the funding deposit is not mature yet";
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lastError = $"the last claim attempt threw: {ex.Message}";
+                }
+            }
+
+            await Control.MineAsync(1, cancellationToken);
+            await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
+        }
+
+        Assert.Fail(
+            $"the local regtest wallet was never funded: {FundingSats:N0} sats were sent to its deposit "
+            + $"address in {txId} (vout {vout?.ToString(CultureInfo.InvariantCulture) ?? "not found"}) and "
+            + $"mined, but the SDK's balance was still 0 after {FundingTimeout.TotalMinutes:0} minutes"
+            + (lastError.Length == 0 ? "." : $"; {lastError}.")
+            + " Check that the stack's Spark operators, open-ssp and Esplora are all healthy — "
+            + "e2e/local-regtest/README.md says how — and that open-ssp reports Spark liquidity, since a "
+            + "deposit is credited out of the SSP's own leaves.");
+    }
+
+    /// <summary>
+    /// Forces a sync and returns the balance.
+    /// </summary>
+    /// <remarks>
+    /// The sync is not optional, for the reason <see cref="ISparkSdkClient.SyncWalletAsync"/> gives: the
+    /// balance was observed lagging settlement by ~20 s on the hosted regtest even through
+    /// <c>GetInfo(ensureSynced: true)</c>. The local stack syncs every two seconds, so the lag is much
+    /// smaller here, but nothing in this suite is measuring that and everything in it needs the current
+    /// number.
+    /// </remarks>
+    public async Task<long> SyncBalanceAsync(CancellationToken cancellationToken = default)
+    {
+        await Sdk.SyncWalletAsync(cancellationToken);
+        var info = await Sdk.GetInfoAsync(ensureSynced: true, cancellationToken);
+        return info.BalanceSats;
+    }
+
+    /// <summary>Fails with an explanation unless the wallet can cover <paramref name="needSats"/>.</summary>
+    /// <remarks>
+    /// Unlike the funded suite's equivalent this is not a runbook step — a drained wallet here means an
+    /// earlier test in the run spent more than it was supposed to, which is a bug in the suite rather than
+    /// something a maintainer tops up.
+    /// </remarks>
+    public async Task RequireBalanceAsync(
+        long needSats, string what, CancellationToken cancellationToken = default)
+    {
+        var balance = await SyncBalanceAsync(cancellationToken);
+        if (balance < needSats)
+        {
+            Assert.Fail(
+                $"{what} needs {needSats:N0} sats and the local regtest wallet holds {balance:N0}. It was "
+                + $"funded with {FundedBalanceSats:N0}, so something in this run spent more than it should "
+                + "have; the amounts in SparkLocalRegtestTests are sized to fit inside the funding together.");
+        }
+    }
+
+    /// <summary>A snapshot of how many lines the bridge has forwarded, to bound a later slice.</summary>
+    public int ForwardedLineCount => ForwardedLog.Lines.Count;
+
+    /// <summary>The lines forwarded since <paramref name="from"/>.</summary>
+    public IReadOnlyList<string> ForwardedSince(int from)
+    {
+        var lines = ForwardedLog.Lines;
+        return from >= lines.Count ? [] : lines.Skip(from).ToList();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_mnemonic is null)
+            return;
+
+        // Before disconnecting, give the money back. See ReturnFundsAsync.
+        await ReturnFundsAsync();
+
+        try
+        {
+            if (Sdk is not null)
+            {
+                // Disconnect then Dispose: after Disconnect alone the instance still serves the network.
+                await Sdk.DisconnectAsync();
+                Sdk.Dispose();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"local-regtest: could not disconnect cleanly: {ex}");
+        }
+
+        TryDeleteStorage();
+        _setup.Dispose();
+    }
+
+    /// <summary>
+    /// Cooperatively exits whatever is left in the wallet back on-chain, best effort.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Why a teardown step spends money.</b> Every run of this suite funds a <em>fresh</em> wallet out of
+    /// the SSP's own Spark leaves, and a wallet that is simply abandoned keeps them: the SSP's available
+    /// balance falls by the funded amount per run and never recovers. Two or three runs against one stack
+    /// were enough to drain the fixture's 500,000-sat seed to the point where the next run's cooperative-exit
+    /// quote failed with <c>Tree service error: insufficient funds</c> — a failure that names this wallet and
+    /// means the SSP. Handing the balance back is what makes the suite re-runnable against a stack that takes
+    /// tens of minutes to build.
+    /// </para>
+    /// <para>
+    /// Best effort, and silent about it beyond a console line: this runs after the tests have their verdicts,
+    /// and a fixture that turned a green run red while tidying up would be worse than a stack that needs a
+    /// top-up. The fixture's own acceptance test ends the same way, for the same reason.
+    /// </para>
+    /// </remarks>
+    private async Task ReturnFundsAsync()
+    {
+        try
+        {
+            var balance = await SyncBalanceAsync();
+            if (balance <= 0)
+                return;
+
+            var destination = await Control.NewAddressAsync("flint-local-regtest-return");
+            var quote = await Sdk.QuoteOnchainSendAsync(destination, balance, feesIncluded: true);
+            if (quote.SlowFeeSats <= 0 || quote.SlowFeeSats >= balance)
+            {
+                Console.WriteLine(
+                    $"local-regtest: leaving {balance:N0} sats in the wallet — the exit fee "
+                    + $"({quote.SlowFeeSats:N0} sats) is not worth paying. The SSP's liquidity will need a "
+                    + "top-up sooner.");
+                return;
+            }
+
+            var send = await Sdk.SendToBitcoinAddressAsync(
+                destination,
+                balance,
+                SparkOnchainSpeed.Slow,
+                feesIncluded: true,
+                Guid.NewGuid().ToString(),
+                approveQuote: _ => null);
+
+            if (send.RejectedReason is null)
+            {
+                // Mined so the SSP's own wallet sees the exit confirm rather than holding it in flight.
+                await Control.MineAsync(3);
+                Console.WriteLine(
+                    $"local-regtest: returned {balance:N0} sats to the chain ({send.Payment?.TxId}), so the "
+                    + "SSP's Spark liquidity comes back for the next run.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"local-regtest: could not return the wallet's balance ({ex.Message}).");
+        }
+    }
+
+    private void TryDeleteStorage()
+    {
+        if (_storageDirectory is null)
+            return;
+        try
+        {
+            // The whole run directory, storage and SDK logs together. Nothing here is an artefact: the
+            // wallet is disposable and its log is asserted on in-process, so leaving either behind would only
+            // leave a directory holding a wallet's storage on a developer's machine.
+            Directory.Delete(Path.GetDirectoryName(_storageDirectory)!, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Reads the descriptor's <c>fixture</c> block — the half the plugin ignores.
+    /// </summary>
+    /// <remarks>
+    /// Read straight from the file rather than through <see cref="SparkCustomNetworkFile"/> on purpose. That
+    /// loader models only what the SDK needs and deliberately ignores this block so a fixture-side change
+    /// cannot break the plugin; keeping the two readers separate is what preserves that.
+    /// </remarks>
+    private static LocalRegtestFixtureInfo ReadFixture(string descriptorPath)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(descriptorPath));
+        if (!document.RootElement.TryGetProperty("fixture", out var fixture))
+        {
+            throw new InvalidOperationException(
+                $"{descriptorPath} has no `fixture` block, so there is no way to reach the stack's bitcoind "
+                + "or its Lightning nodes. It was probably written by hand or by an older "
+                + "write-network.sh; regenerate it with e2e/local-regtest/write-network.sh.");
+        }
+
+        string Required(string name) =>
+            fixture.TryGetProperty(name, out var value) && value.GetString() is { Length: > 0 } text
+                ? text
+                : throw new InvalidOperationException(
+                    $"{descriptorPath}: the fixture block is missing {name}.");
+
+        string? Optional(string name) =>
+            fixture.TryGetProperty(name, out var value) ? value.GetString() : null;
+
+        return new LocalRegtestFixtureInfo(
+            Required("bitcoindContainer"),
+            Required("bitcoindRpcUser"),
+            Required("bitcoindRpcPassword"),
+            Required("lndContainer"),
+            Optional("clnContainer"),
+            Optional("sspContainer"),
+            Optional("sspAdminToken"));
+    }
+
+    private sealed class FixedStorageProvider : ISparkStorageProvider
+    {
+        private readonly string _path;
+
+        public FixedStorageProvider(string path) => _path = path;
+
+        public SparkStorageTarget GetTarget(string storeId) => new SparkStorageTarget.Directory(_path);
+    }
+}
+
+/// <summary>
+/// The collection every local-regtest test joins, so they share one wallet and one chain, one at a time.
+/// </summary>
+[CollectionDefinition(LocalRegtestStack.CollectionName, DisableParallelization = true)]
+public sealed class LocalRegtestCollection : ICollectionFixture<LocalRegtestStack>;

--- a/BTCPayServer.Plugins.Flint.Tests/LocalRegtest/RegtestControl.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/LocalRegtest/RegtestControl.cs
@@ -1,0 +1,564 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+
+namespace BTCPayServer.Plugins.Flint.Tests.LocalRegtest;
+
+/// <summary>
+/// The fixture half of the local-regtest network descriptor: how to drive the stack's bitcoind and its
+/// Lightning counterparties.
+/// </summary>
+/// <remarks>
+/// Deliberately separate from <see cref="Sdk.SparkCustomNetwork"/>, which the plugin reads. Container names
+/// and RPC credentials are the test suite's business and none of the plugin's, so the plugin ignores this
+/// half of the file and it is modelled here instead.
+/// </remarks>
+public sealed record LocalRegtestFixtureInfo(
+    string BitcoindContainer,
+    string BitcoindRpcUser,
+    string BitcoindRpcPassword,
+    string LndContainer,
+    string? ClnContainer,
+    string? SspContainer,
+    string? SspAdminToken);
+
+/// <summary>
+/// Drives the local regtest stack from outside: bitcoind through <c>bitcoin-cli</c> and LND through
+/// <c>lncli</c>, both over <c>docker exec</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why docker exec rather than RPC over the published ports.</b> Both nodes speak to the host — bitcoind's
+/// RPC port and LND's REST port are published — but reaching them needs credentials the fixture only ever
+/// writes inside its own containers: LND's admin macaroon and its self-signed TLS certificate live in a bind
+/// mount whose path is the fixture's business, and the Rust reference client only gets at them because it runs
+/// inside the compose network with those directories mounted. From the host, <c>docker exec</c> is the one
+/// route that needs nothing beyond the container name — and it is exactly what the fixture's own
+/// <c>docker-scripts.sh</c> does (<c>bitcoin-cli-sim</c>, <c>lncli-sim</c>), so the invocations here are the
+/// ones the fixture itself is known to work with.
+/// </para>
+/// <para>
+/// <b>The invocations, and why each flag is there.</b>
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <c>docker exec &lt;bitcoind&gt; bitcoin-cli -regtest -rpcuser=… -rpcpassword=… -rpcwallet=cashu …</c> —
+/// the wallet name is not optional. The fixture creates two wallets (<c>cashu</c> and
+/// <c>ssp-withdrawals</c>), and with more than one loaded bitcoind refuses every wallet call that does not
+/// name one. <c>cashu</c> is the funded, mining wallet.
+/// </description></item>
+/// <item><description>
+/// <c>docker exec &lt;lnd&gt; lncli --network regtest --rpcserver=&lt;hostname&gt;:10009 …</c> — the
+/// rpcserver is required and cannot be <c>localhost</c>: the fixture starts lnd with
+/// <c>--rpclisten=lnd-1:10009</c>, so it is not listening on loopback at all. The hostname is read off the
+/// container at startup rather than assumed, since it is the container's own compose hostname. No macaroon
+/// or TLS flag is needed — lnd's data directory is the image default (<c>/root/.lnd</c>), which is where
+/// lncli looks for <c>tls.cert</c> and <c>data/chain/bitcoin/regtest/admin.macaroon</c>.
+/// </description></item>
+/// </list>
+/// <para>
+/// Every call is bounded by a timeout and every failure carries the exit code and the captured stderr. A
+/// silent hang or a bare "command failed" in the middle of a payment test costs far more to diagnose than
+/// the plumbing costs to write.
+/// </para>
+/// </remarks>
+public sealed class RegtestControl
+{
+    /// <summary>
+    /// The bitcoind wallet the fixture funds and mines with.
+    /// </summary>
+    /// <remarks>
+    /// From <c>docker-scripts.sh</c>'s <c>bitcoin-cli-sim</c>, which pins <c>-rpcwallet=cashu</c> for the same
+    /// reason: <c>cashu-spark-fund-ssp</c> creates an <c>ssp-withdrawals</c> wallet alongside it, and bitcoind
+    /// rejects unqualified wallet calls once two are loaded.
+    /// </remarks>
+    public const string BitcoindWallet = "cashu";
+
+    /// <summary>LND's gRPC port inside the compose network.</summary>
+    private const int LndRpcPort = 10009;
+
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(90);
+
+    private readonly LocalRegtestFixtureInfo _fixture;
+    private string? _lndRpcServer;
+
+    public RegtestControl(LocalRegtestFixtureInfo fixture) => _fixture = fixture;
+
+    /// <summary>
+    /// Proves the stack is reachable and resolves LND's rpcserver address.
+    /// </summary>
+    /// <remarks>
+    /// Called before anything else in the fixture, so that a stack that is not running fails here — naming the
+    /// container and the command — rather than several minutes later as an unexplained funding timeout.
+    /// </remarks>
+    public async Task InitialiseAsync(CancellationToken cancellationToken = default)
+    {
+        var hostname = (await RunAsync(
+            ["docker", "inspect", "-f", "{{.Config.Hostname}}", _fixture.LndContainer],
+            TimeSpan.FromSeconds(30),
+            cancellationToken)).Trim();
+
+        // A compose service gets its service name as its hostname, which is what the fixture's
+        // --rpclisten binds to. An empty or malformed answer would otherwise become an lncli
+        // "connection refused" with no hint about where the address came from.
+        if (string.IsNullOrWhiteSpace(hostname))
+        {
+            throw new InvalidOperationException(
+                $"could not read the compose hostname of the LND container '{_fixture.LndContainer}', so "
+                + "there is no address to point lncli at.");
+        }
+
+        _lndRpcServer = $"{hostname}:{LndRpcPort.ToString(CultureInfo.InvariantCulture)}";
+
+        // Two cheap round trips that fail loudly: one per node, each through the exact invocation the rest of
+        // the suite uses.
+        _ = await BitcoinCliJsonAsync(["getblockchaininfo"], cancellationToken);
+        _ = await LncliJsonAsync(["getinfo"], cancellationToken);
+    }
+
+    #region bitcoind
+
+    /// <summary>Runs <c>bitcoin-cli</c> against the fixture's funded wallet and returns raw stdout.</summary>
+    public Task<string> BitcoinCliAsync(
+        IEnumerable<string> args, CancellationToken cancellationToken = default) =>
+        RunAsync(
+            [
+                "docker", "exec", _fixture.BitcoindContainer, "bitcoin-cli", "-regtest",
+                $"-rpcuser={_fixture.BitcoindRpcUser}",
+                $"-rpcpassword={_fixture.BitcoindRpcPassword}",
+                $"-rpcwallet={BitcoindWallet}",
+                .. args
+            ],
+            DefaultTimeout,
+            cancellationToken);
+
+    /// <summary>Runs <c>bitcoin-cli</c> and parses its answer as JSON.</summary>
+    public async Task<JsonDocument> BitcoinCliJsonAsync(
+        IEnumerable<string> args, CancellationToken cancellationToken = default) =>
+        Parse(await BitcoinCliAsync(args, cancellationToken), "bitcoin-cli");
+
+    /// <summary>A fresh address from the fixture's wallet.</summary>
+    /// <param name="addressType">
+    /// <c>bech32</c> by default. Not <c>bech32m</c>: a sweep destination goes through
+    /// <c>SweepDestinationResolver</c>, and the point of these tests is the sweep, not NBitcoin's taproot
+    /// parsing.
+    /// </param>
+    public async Task<string> NewAddressAsync(
+        string label = "", string addressType = "bech32", CancellationToken cancellationToken = default) =>
+        (await BitcoinCliAsync(["getnewaddress", label, addressType], cancellationToken)).Trim();
+
+    /// <summary>
+    /// Mines <paramref name="blocks"/> blocks to a fresh address of the fixture's wallet.
+    /// </summary>
+    /// <remarks>
+    /// A fresh address rather than <c>-generate</c>'s implicit one purely so the coinbase outputs do not pile
+    /// up on a single key; either would do. The address is minted per call because mining is what this suite
+    /// uses to advance every timelock, so it happens dozens of times per run.
+    /// </remarks>
+    public async Task<int> MineAsync(int blocks, CancellationToken cancellationToken = default)
+    {
+        var address = await NewAddressAsync(cancellationToken: cancellationToken);
+        _ = await BitcoinCliAsync(
+            ["generatetoaddress", blocks.ToString(CultureInfo.InvariantCulture), address],
+            cancellationToken);
+        return await BlockHeightAsync(cancellationToken);
+    }
+
+    public async Task<int> BlockHeightAsync(CancellationToken cancellationToken = default) =>
+        int.Parse(
+            (await BitcoinCliAsync(["getblockcount"], cancellationToken)).Trim(),
+            CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Sends to <paramref name="address"/> and returns the txid.
+    /// </summary>
+    /// <remarks>
+    /// <c>-named</c> with an explicit <c>fee_rate</c>, exactly as the fixture's own funding helpers do: on a
+    /// fresh regtest chain the fee estimator has no data, and an unqualified <c>sendtoaddress</c> fails with
+    /// "Fee estimation failed" rather than picking a floor.
+    /// </remarks>
+    public async Task<string> SendToAddressAsync(
+        string address, decimal amountBtc, int feeRateSatPerVb = 100,
+        CancellationToken cancellationToken = default) =>
+        (await BitcoinCliAsync(
+            [
+                "-named", "sendtoaddress",
+                $"address={address}",
+                $"amount={amountBtc.ToString("0.########", CultureInfo.InvariantCulture)}",
+                $"fee_rate={feeRateSatPerVb.ToString(CultureInfo.InvariantCulture)}"
+            ],
+            cancellationToken)).Trim();
+
+    /// <summary>The index of the output of <paramref name="txId"/> that pays <paramref name="address"/>.</summary>
+    /// <remarks>
+    /// Needed to claim a deposit by hand: the SDK addresses a deposit by outpoint, and a
+    /// <c>sendtoaddress</c> transaction also carries a change output, so the vout is never reliably 0.
+    /// </remarks>
+    public async Task<uint?> FindVoutAsync(
+        string txId, string address, CancellationToken cancellationToken = default)
+    {
+        using var tx = await BitcoinCliJsonAsync(["getrawtransaction", txId, "true"], cancellationToken);
+        if (!tx.RootElement.TryGetProperty("vout", out var outputs))
+            return null;
+
+        foreach (var output in outputs.EnumerateArray())
+        {
+            if (output.TryGetProperty("scriptPubKey", out var script)
+                && script.TryGetProperty("address", out var candidate)
+                && string.Equals(candidate.GetString(), address, StringComparison.Ordinal)
+                && output.TryGetProperty("n", out var n))
+            {
+                return n.GetUInt32();
+            }
+        }
+
+        return null;
+    }
+
+    #endregion
+
+    #region lnd
+
+    /// <summary>Runs <c>lncli</c> inside the fixture's LND container and returns raw stdout.</summary>
+    public Task<string> LncliAsync(IEnumerable<string> args, CancellationToken cancellationToken = default)
+    {
+        var rpcServer = _lndRpcServer
+            ?? throw new InvalidOperationException(
+                $"{nameof(RegtestControl)}.{nameof(InitialiseAsync)} has not run, so LND's rpcserver address "
+                + "is unknown.");
+
+        return RunAsync(
+            [
+                "docker", "exec", _fixture.LndContainer, "lncli",
+                "--network", "regtest", $"--rpcserver={rpcServer}",
+                .. args
+            ],
+            DefaultTimeout,
+            cancellationToken);
+    }
+
+    /// <summary>Runs <c>lncli</c> and parses its answer as JSON.</summary>
+    public async Task<JsonDocument> LncliJsonAsync(
+        IEnumerable<string> args, CancellationToken cancellationToken = default) =>
+        Parse(await LncliAsync(args, cancellationToken), "lncli");
+
+    /// <summary>Mints an invoice on LND, for the plugin to pay.</summary>
+    /// <returns>The BOLT11 request and the payment hash, as lowercase hex.</returns>
+    public async Task<LndInvoice> LndAddInvoiceAsync(
+        long amountSats, string memo, CancellationToken cancellationToken = default)
+    {
+        using var response = await LncliJsonAsync(
+            [
+                "addinvoice",
+                "--amt", amountSats.ToString(CultureInfo.InvariantCulture),
+                "--memo", memo,
+                "--expiry", "900"
+            ],
+            cancellationToken);
+
+        var bolt11 = response.RootElement.GetProperty("payment_request").GetString()
+            ?? throw new InvalidOperationException("lncli addinvoice returned no payment_request.");
+        var hash = HexOf(response.RootElement.GetProperty("r_hash"))
+            ?? throw new InvalidOperationException("lncli addinvoice returned no r_hash.");
+        return new LndInvoice(bolt11, hash);
+    }
+
+    /// <summary>
+    /// Pays a BOLT11 invoice from LND, then reads the settled payment back out of LND's own history.
+    /// </summary>
+    /// <remarks>
+    /// The result is read from <c>listpayments</c> rather than scraped out of <c>payinvoice</c>'s output on
+    /// purpose: <c>payinvoice</c> renders a live-updating table whose shape has changed across lnd releases,
+    /// while <c>listpayments</c> is machine JSON. Passing the hash in means the lookup needs no parsing of the
+    /// payer's progress output at all.
+    /// </remarks>
+    /// <param name="expectedPaymentHash">
+    /// The hash the invoice commits to, used to find the payment afterwards.
+    /// </param>
+    public async Task<LndPayment> LndPayInvoiceAsync(
+        string bolt11,
+        string expectedPaymentHash,
+        long feeLimitSats = 1_000,
+        CancellationToken cancellationToken = default)
+    {
+        // --force skips the interactive confirmation, which would otherwise block forever on a
+        // non-tty stdin. --json asks for machine output where the lnd build supports it; where it
+        // does not, the flag is rejected and the payment is retried without it, since the answer is
+        // read from listpayments either way.
+        string payOutput;
+        try
+        {
+            payOutput = await LncliAsync(
+                [
+                    "payinvoice", "--force", "--json",
+                    "--timeout", "120s",
+                    "--fee_limit", feeLimitSats.ToString(CultureInfo.InvariantCulture),
+                    bolt11
+                ],
+                cancellationToken);
+        }
+        catch (RegtestCommandException ex) when (ex.StdErr.Contains("--json", StringComparison.Ordinal)
+                                                 || ex.StdErr.Contains("flag provided but not defined",
+                                                     StringComparison.Ordinal))
+        {
+            payOutput = await LncliAsync(
+                [
+                    "payinvoice", "--force",
+                    "--timeout", "120s",
+                    "--fee_limit", feeLimitSats.ToString(CultureInfo.InvariantCulture),
+                    bolt11
+                ],
+                cancellationToken);
+        }
+
+        var payment = await FindPaymentAsync(expectedPaymentHash, cancellationToken);
+        if (payment is null)
+        {
+            throw new InvalidOperationException(
+                $"lncli paid {expectedPaymentHash} but no matching payment appeared in listpayments. "
+                + $"payinvoice said:\n{payOutput}");
+        }
+
+        return payment;
+    }
+
+    /// <summary>One payment in LND's history, by hash, or null when LND has no record of it.</summary>
+    public async Task<LndPayment?> FindPaymentAsync(
+        string paymentHash, CancellationToken cancellationToken = default)
+    {
+        // No --reversed flag: lncli rejects it ("flag provided but not defined") because reversed
+        // pagination — newest first — is already the default, which is the order this needs.
+        using var response = await LncliJsonAsync(
+            ["listpayments", "--include_incomplete", "--max_payments", "50"],
+            cancellationToken);
+
+        if (!response.RootElement.TryGetProperty("payments", out var payments))
+            return null;
+
+        foreach (var payment in payments.EnumerateArray())
+        {
+            var hash = payment.TryGetProperty("payment_hash", out var h) ? HexOf(h) : null;
+            if (!string.Equals(hash, paymentHash, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            return new LndPayment(
+                hash!,
+                payment.TryGetProperty("status", out var status) ? status.GetString() ?? "" : "",
+                payment.TryGetProperty("payment_preimage", out var preimage) ? HexOf(preimage) : null,
+                payment.TryGetProperty("value_sat", out var value) ? LongOf(value) : null,
+                payment.TryGetProperty("fee_sat", out var fee) ? LongOf(fee) : null);
+        }
+
+        return null;
+    }
+
+    /// <summary>An invoice's state on LND, by payment hash.</summary>
+    public async Task<LndInvoiceState> LndLookupInvoiceAsync(
+        string paymentHash, CancellationToken cancellationToken = default)
+    {
+        using var response = await LncliJsonAsync(["lookupinvoice", paymentHash], cancellationToken);
+        var root = response.RootElement;
+        var state = root.TryGetProperty("state", out var s) ? s.GetString() ?? "" : "";
+        return new LndInvoiceState(
+            state,
+            root.TryGetProperty("settled", out var settled) && settled.ValueKind == JsonValueKind.True
+                || string.Equals(state, "SETTLED", StringComparison.Ordinal),
+            root.TryGetProperty("r_preimage", out var preimage) ? HexOf(preimage) : null,
+            root.TryGetProperty("amt_paid_sat", out var paid) ? LongOf(paid) : null);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Normalises one of lnd's <c>bytes</c> fields to lowercase hex.
+    /// </summary>
+    /// <remarks>
+    /// lncli renders them as hex and lnd's REST gateway renders the same fields as base64, so both are
+    /// accepted — the Rust reference client's <c>bytes_hex</c> makes the same allowance for the same reason.
+    /// Anything else returns null rather than throwing, so a shape change surfaces as a named assertion in the
+    /// test rather than as a parse error in the plumbing.
+    /// </remarks>
+    internal static string? HexOf(JsonElement element)
+    {
+        if (element.ValueKind != JsonValueKind.String)
+            return null;
+
+        var value = element.GetString();
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (value.Length == 64 && value.All(Uri.IsHexDigit))
+            return value.ToLowerInvariant();
+
+        try
+        {
+            return Convert.ToHexString(Convert.FromBase64String(value)).ToLowerInvariant();
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>lnd renders 64-bit numbers as JSON strings; both forms are read here.</summary>
+    internal static long? LongOf(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.Number => element.GetInt64(),
+        JsonValueKind.String when long.TryParse(
+            element.GetString(), CultureInfo.InvariantCulture, out var parsed) => parsed,
+        _ => null
+    };
+
+    private static JsonDocument Parse(string output, string what)
+    {
+        try
+        {
+            return JsonDocument.Parse(output);
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException(
+                $"{what} did not answer with JSON: {ex.Message}. It said:\n{Trim(output)}", ex);
+        }
+    }
+
+    /// <summary>
+    /// Runs one process to completion, with a timeout, and returns stdout.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ProcessStartInfo.ArgumentList"/> rather than a command string: several arguments here carry
+    /// values from the descriptor and from the tests (memos, addresses, BOLT11 requests), and a shell-quoting
+    /// bug in a test fixture that drives a wallet is not a class of bug worth having. On a timeout the child is
+    /// killed with its whole tree — <c>docker exec</c> otherwise leaves the in-container command running.
+    /// </remarks>
+    private static async Task<string> RunAsync(
+        IReadOnlyList<string> command, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        var info = new ProcessStartInfo(command[0])
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false
+        };
+        foreach (var argument in command.Skip(1))
+            info.ArgumentList.Add(argument);
+
+        using var process = new Process { StartInfo = info };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+                stdout.AppendLine(e.Data);
+        };
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+                stderr.AppendLine(e.Data);
+        };
+
+        if (!process.Start())
+            throw new InvalidOperationException($"could not start {command[0]}.");
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        // Closed immediately: lncli prompts for confirmation on some commands, and a child holding an open
+        // stdin it will never receive anything on is a hang rather than an error.
+        process.StandardInput.Close();
+
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadline.CancelAfter(timeout);
+        try
+        {
+            await process.WaitForExitAsync(deadline.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            TryKill(process);
+            throw new RegtestCommandException(
+                command,
+                exitCode: null,
+                stdout.ToString(),
+                stderr.ToString(),
+                $"timed out after {timeout.TotalSeconds:0} s");
+        }
+        catch (OperationCanceledException)
+        {
+            TryKill(process);
+            throw;
+        }
+
+        if (process.ExitCode != 0)
+        {
+            throw new RegtestCommandException(
+                command, process.ExitCode, stdout.ToString(), stderr.ToString(),
+                $"exited {process.ExitCode.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        return stdout.ToString();
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (InvalidOperationException)
+        {
+        }
+        catch (NotSupportedException)
+        {
+        }
+    }
+
+    private static string Trim(string value) =>
+        value.Length <= 4_000 ? value : value[..4_000] + "\n… (truncated)";
+
+    /// <summary>An invoice minted on LND.</summary>
+    public sealed record LndInvoice(string Bolt11, string PaymentHash);
+
+    /// <summary>An LND invoice's settlement state.</summary>
+    public sealed record LndInvoiceState(string State, bool Settled, string? Preimage, long? AmountPaidSats);
+
+    /// <summary>An outgoing payment as LND recorded it.</summary>
+    public sealed record LndPayment(
+        string PaymentHash, string Status, string? Preimage, long? ValueSats, long? FeeSats)
+    {
+        public bool Succeeded => string.Equals(Status, "SUCCEEDED", StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// A <c>docker exec</c> that failed, carrying everything needed to work out why.
+/// </summary>
+/// <remarks>
+/// The captured stderr is the whole point. bitcoind and lncli both explain themselves there — an unloaded
+/// wallet, a missing macaroon, a wrong rpcserver — and without it every one of those failures reads
+/// identically as a non-zero exit code from a docker command.
+/// </remarks>
+public sealed class RegtestCommandException : Exception
+{
+    public RegtestCommandException(
+        IReadOnlyList<string> command, int? exitCode, string stdOut, string stdErr, string what)
+        : base($"`{string.Join(' ', command)}` {what}."
+               + (string.IsNullOrWhiteSpace(stdErr) ? "" : $"\nstderr:\n{stdErr.TrimEnd()}")
+               + (string.IsNullOrWhiteSpace(stdOut) ? "" : $"\nstdout:\n{stdOut.TrimEnd()}"))
+    {
+        Command = command;
+        ExitCode = exitCode;
+        StdOut = stdOut;
+        StdErr = stdErr;
+    }
+
+    public IReadOnlyList<string> Command { get; }
+
+    public int? ExitCode { get; }
+
+    public string StdOut { get; }
+
+    public string StdErr { get; }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/LocalRegtest/SparkLocalRegtestTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/LocalRegtest/SparkLocalRegtestTests.cs
@@ -1,0 +1,593 @@
+using System.Security.Cryptography;
+using BTCPayServer.Lightning;
+using BTCPayServer.Plugins.Flint.Data;
+using BTCPayServer.Plugins.Flint.Sdk;
+using BTCPayServer.Plugins.Flint.Services;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using BTCPayServer.Plugins.Flint.Tests.FundedRegtest;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Network = NBitcoin.Network;
+
+namespace BTCPayServer.Plugins.Flint.Tests.LocalRegtest;
+
+/// <summary>
+/// The plugin's money paths against a <b>local</b> Spark network, with a real external Lightning
+/// counterparty and a chain this suite mines itself.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What only this suite can answer.</b> The funded suite settles a Lightning receive by paying the
+/// invoice from the same wallet, because Lightspark's regtest offers no second node. That is enough to prove
+/// the reconciler picks the Receive leg, but it leaves the ordinary case — a customer's node pays a
+/// merchant's invoice — never once executed end to end. And a cooperative exit there confirms on somebody
+/// else's schedule, so the sweep engine's Sent → Confirmed transition has only ever been observed as
+/// "eventually". Here LND pays, LND is paid, and blocks appear because this suite mines them.
+/// </para>
+/// <para>
+/// <b>Amounts.</b> Every test in this collection spends from one wallet funded once with
+/// <see cref="LocalRegtestStack.FundingSats"/>, and the tests do not run in a guaranteed order, so each is
+/// sized to leave the others enough: 5,000 in, 3,000 out, 30,000 through a cooperative exit, against
+/// 100,000 of funding. The sweep test caps what it moves through the reserve rather than draining, for exactly that
+/// reason.
+/// </para>
+/// <para>
+/// Gated on <c>SPARK_LOCAL_REGTEST_NETWORK</c>. See <see cref="LocalRegtestStack"/>.
+/// </para>
+/// </remarks>
+[Trait("Category", "LocalRegtest")]
+[Collection(LocalRegtestStack.CollectionName)]
+public class SparkLocalRegtestTests
+{
+    private readonly LocalRegtestStack _stack;
+
+    public SparkLocalRegtestTests(LocalRegtestStack stack) => _stack = stack;
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>What the external node pays the plugin's invoice.</summary>
+    private const long ReceiveAmountSats = 5_000;
+
+    /// <summary>What the plugin pays the external node's invoice.</summary>
+    private const long SendAmountSats = 3_000;
+
+    /// <summary>
+    /// The floor for what a cooperative exit moves; the test may sweep more.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A fixed amount cannot work here. The exit fee does not scale with the amount — that much matches the
+    /// hosted regtest, and is why <c>SweepSettings.MinimumSweepSats</c> exists — but on this stack it scales
+    /// with the <em>chain</em>: the same 30,000-sat exit was quoted at <b>197 sats</b> on a freshly mined
+    /// regtest chain and at <b>19,700 sats</b> an hour later, because every transaction the fixture sends
+    /// specifies <c>fee_rate=100</c> and bitcoind's estimator eventually believes it. At the second figure a
+    /// 30,000-sat sweep delivers 10,300 sats and the fee is 191% of it, which
+    /// <c>SweepSettings.HardMaxFeePercent</c> refuses outright — correctly.
+    /// </para>
+    /// <para>
+    /// So the test quotes the exit first and sizes the sweep off the quote, keeping the fee near a fifth of
+    /// what the destination receives. The guard is then a real assertion rather than a coincidence of the
+    /// fee market the fixture happens to be in.
+    /// </para>
+    /// </remarks>
+    private const long ExitAmountSats = 30_000;
+
+    /// <summary>
+    /// What the sweep leaves untouched, so a test running after this one still has money.
+    /// </summary>
+    private const long ExitMarginSats = 10_000;
+
+    /// <summary>The fee ceiling the sweep is configured with, and sized to stay inside.</summary>
+    /// <remarks>
+    /// Below <see cref="SweepSettings.HardMaxFeePercent"/> so the engine's own hard ceiling is not the thing
+    /// under test; above the ratio the sizing below aims for, so a fee the quote did not predict still fails
+    /// the guard rather than sliding through.
+    /// </remarks>
+    private const double ExitMaxFeePercent = 30.0;
+
+    /// <summary>
+    /// An invoice minted by the plugin and paid by an <b>external</b> Lightning node, settled through the
+    /// plugin's own reconciler, with the SDK's log captured.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the plugin's whole reason to exist — a merchant's invoice paid by a customer — and it has
+    /// never run against a real SDK before, because the hosted regtest has nobody to pay it. The payer is the
+    /// fixture's LND node, which reaches the wallet over its channel to the SSP's LDK node, so the payment
+    /// crosses a real Lightning hop and a real Spark transfer.
+    /// </para>
+    /// <para>
+    /// <b>Three claims, and each is checked against the counterparty rather than against the plugin.</b> The
+    /// payment hash the plugin minted is the one LND paid; the preimage on the settled record is the one LND
+    /// received; and that preimage hashes to that payment hash. A plugin that invented any of the three would
+    /// still pass a single-wallet test.
+    /// </para>
+    /// <para>
+    /// <b>The log assertion.</b> The preimage is read off the settled record — so it is the real one — and
+    /// the forwarded lines are searched for it literally, exactly as the funded suite does. Same for the
+    /// wallet's mnemonic. This is the assertion that would catch <c>SparkLogScrubber</c> letting secret
+    /// material through, and it is worth repeating here because the SDK is talking to a different SSP
+    /// implementation, which logs its own messages.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task An_external_node_pays_a_Flint_invoice_and_it_settles_from_the_receive_leg()
+    {
+        Assert.SkipUnless(LocalRegtestStack.IsEnabled, LocalRegtestStack.SkipReason);
+
+        var store = new InMemoryInvoiceRecordStore();
+        var client = BuildClient(store, out _);
+
+        // Everything the SDK logs from here on belongs to this payment.
+        var logFrom = _stack.ForwardedLineCount;
+
+        var invoice = await client.CreateInvoice(
+            new CreateInvoiceParams(
+                LightMoney.Satoshis(ReceiveAmountSats),
+                "flint local-regtest inbound probe",
+                TimeSpan.FromMinutes(15)),
+            Ct);
+
+        Assert.StartsWith("lnbcrt", invoice.BOLT11);
+        Assert.Equal(LightningInvoiceStatus.Unpaid, invoice.Status);
+
+        var paid = await _stack.Control.LndPayInvoiceAsync(invoice.BOLT11, invoice.PaymentHash, 1_000, Ct);
+        Assert.True(
+            paid.Succeeded,
+            $"the external LND node did not pay the invoice: status {paid.Status}. A failure here is the "
+            + "fixture's Lightning liquidity or the SSP's LDK node, not the plugin — check that open-ssp "
+            + "reports `ldk_mode: live` and that its channel to lnd-1 is active.");
+        Assert.Equal(ReceiveAmountSats, paid.ValueSats);
+
+        // Settlement is driven by polling the reconciler rather than by the event stream, for the reason the
+        // funded suite gives: a completed receive was observed emitting only PaymentPending and never
+        // PaymentSucceeded, with the completion visible from storage alone. SparkReconciliationTask exists
+        // because of that, so this drives the mechanism that has to be right.
+        var settled = await PollAsync(
+            async () =>
+            {
+                var current = await client.GetInvoice(invoice.PaymentHash, Ct);
+                return current.Status is LightningInvoiceStatus.Paid ? current : null;
+            },
+            TimeSpan.FromMinutes(3),
+            "the invoice the external node paid never reached Paid");
+
+        Assert.Equal(LightMoney.Satoshis(ReceiveAmountSats), settled.AmountReceived);
+
+        var record = store.Records[invoice.PaymentHash];
+        Assert.Equal(InvoiceRecordStatus.Paid, record.Status);
+        Assert.NotNull(record.SettledAt);
+        Assert.Equal(ReceiveAmountSats * 1000, record.AmountReceivedMsat);
+
+        // §6.3, and here it is not a stipulation: the only Send leg in existence for this hash is on LND.
+        Assert.NotNull(record.SdkPaymentId);
+        var receiveLeg = await _stack.Sdk.GetPaymentAsync(record.SdkPaymentId!, Ct);
+        Assert.NotNull(receiveLeg);
+        Assert.Equal(SparkPaymentDirection.Receive, receiveLeg!.Direction);
+        Assert.Equal(SparkPaymentStatus.Completed, receiveLeg.Status);
+
+        Assert.False(
+            string.IsNullOrEmpty(record.Preimage),
+            "the settled record carries no preimage, so neither the proof-of-payment assertions nor the log "
+            + "audit below can run. Either the SSP stopped reporting one or SparkPaymentMapper stopped "
+            + "reading it.");
+
+        // The counterparty's view. LND accepted this payment, so the preimage it holds is the one the
+        // network settled on; a record carrying anything else would be the plugin reporting a payment that
+        // did not happen the way it says.
+        Assert.Equal(paid.Preimage, record.Preimage!.ToLowerInvariant());
+        Assert.Equal(
+            invoice.PaymentHash.ToLowerInvariant(),
+            Sha256Hex(record.Preimage!));
+
+        var forwarded = string.Join('\n', _stack.ForwardedSince(logFrom));
+
+        Assert.False(
+            FundedRegtestWallet.CountOccurrences(forwarded, record.Preimage!) > 0,
+            "the payment preimage reached BTCPay's logger through SparkLogBridge. SparkLogScrubber did not "
+            + "redact it. Preimage fingerprint: "
+            + $"`{FundedRegtestWallet.Fingerprint(record.Preimage!)}` (SHA-256 prefix; not reversible) — "
+            + "the fingerprint rather than the value, because this assertion lands in a public job log.");
+
+        Assert.False(
+            FundedRegtestWallet.SeedAppearsIn(forwarded, _stack.Mnemonic),
+            "the wallet's BIP39 mnemonic reached BTCPay's logger. The wallet itself is disposable — it is "
+            + "generated per run and funded from regtest — but the scrubber hole this proves is not.");
+    }
+
+    /// <summary>
+    /// An invoice minted by an <b>external</b> Lightning node and paid through
+    /// <c>SparkLightningClient.Pay</c>, confirmed settled on the payee.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The plugin's payout path, end to end, against a payee that is not itself. What the funded suite cannot
+    /// check is the part that happens after the SDK returns: that the invoice on the other node is actually
+    /// settled, and that the preimage BTCPay was handed is the one that settled it. A payout marked Completed
+    /// against an unsettled invoice is the failure mode that matters, and it is invisible from inside one
+    /// wallet.
+    /// </para>
+    /// <para>
+    /// <c>Pay</c> is called through the plugin's own client rather than the SDK, so the outgoing record, the
+    /// duplicate-claim guard and the fee guard all run — this is the path BTCPay's payout processor takes.
+    /// </para>
+    /// <para>
+    /// <b>The send timeout is not decoration.</b> <c>SparkLightningClient</c> passes
+    /// <c>PayInvoiceParams.SendTimeout</c> straight through as the SDK's <c>completionTimeoutSecs</c>, and
+    /// with none set the SDK does not wait: against this SSP the send returned a <em>Pending</em> payment
+    /// which the plugin correctly maps to <c>PayResult.Unknown</c> — while LND, checked afterwards, showed
+    /// the invoice SETTLED. That is the plugin behaving as designed (BTCPay marks such a payout InProgress
+    /// and its pending listener resolves it later), but it is not what this test is about, so a timeout is
+    /// passed and <c>Ok</c> is required.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task Flint_pays_an_external_invoice_and_the_payee_sees_it_settled()
+    {
+        Assert.SkipUnless(LocalRegtestStack.IsEnabled, LocalRegtestStack.SkipReason);
+        await _stack.RequireBalanceAsync(SendAmountSats + 2_000, "an outbound Lightning payment", Ct);
+
+        var store = new InMemoryInvoiceRecordStore();
+        var client = BuildClient(store, out var log);
+
+        var invoice = await _stack.Control.LndAddInvoiceAsync(
+            SendAmountSats, $"flint local-regtest outbound {Guid.NewGuid():N}", Ct);
+
+        var before = await _stack.Control.LndLookupInvoiceAsync(invoice.PaymentHash, Ct);
+        Assert.False(before.Settled, "the invoice LND just minted is already settled");
+
+        var response = await client.Pay(
+            invoice.Bolt11,
+            new PayInvoiceParams { SendTimeout = TimeSpan.FromSeconds(60) },
+            Ct);
+
+        Assert.True(
+            response.Result is PayResult.Ok,
+            $"the payout was reported as {response.Result}: {response.ErrorDetail}\n"
+            + $"what the client logged:\n{log.AllText}");
+        Assert.NotNull(response.Details);
+        Assert.Equal(
+            invoice.PaymentHash.ToLowerInvariant(),
+            response.Details!.PaymentHash?.ToString()?.ToLowerInvariant());
+
+        // The payee's own view, which is the only authority on whether this invoice was paid.
+        var after = await PollAsync(
+            async () =>
+            {
+                var state = await _stack.Control.LndLookupInvoiceAsync(invoice.PaymentHash, Ct);
+                return state.Settled ? state : null;
+            },
+            TimeSpan.FromMinutes(2),
+            $"LND never reported invoice {invoice.PaymentHash} as settled, although the plugin returned "
+            + $"{response.Result}. A payout reported Ok against an unsettled invoice is the failure this "
+            + "test exists for");
+
+        Assert.Equal("SETTLED", after.State);
+        Assert.Equal(SendAmountSats, after.AmountPaidSats);
+        Assert.NotNull(after.Preimage);
+        // The payee's preimage really is this invoice's, so it is a usable yardstick for the plugin's.
+        Assert.Equal(invoice.PaymentHash.ToLowerInvariant(), Sha256Hex(after.Preimage!));
+
+        // The path BTCPay takes when a PayResponse arrives without a preimage — LightningAutomatedPayoutProcessor
+        // resolves the payout by hash — and the path that carries proof of payment to the merchant. Polled
+        // rather than read once: the send returns as soon as the SSP says Completed, and the payment record it
+        // wrote may not carry everything yet.
+        var settledPayment = await PollAsync(
+            async () =>
+            {
+                var payment = await client.GetPayment(invoice.PaymentHash, Ct);
+                return payment is { Status: LightningPaymentStatus.Complete } ? payment : null;
+            },
+            TimeSpan.FromMinutes(2),
+            $"the plugin never resolved its own send of {invoice.PaymentHash} to Complete, so a payout "
+            + "waiting on it would be cancelled by BTCPay's pending listener");
+
+        Assert.Equal(invoice.PaymentHash.ToLowerInvariant(), settledPayment.PaymentHash?.ToLowerInvariant());
+        Assert.Equal(LightMoney.Satoshis(SendAmountSats), settledPayment.Amount);
+
+        // <b>Every preimage the plugin reports must be the payee's.</b> Asserted wherever one appears — on
+        // the PayResponse and on the resolved payment — rather than asserted to appear: against this SSP a
+        // completed send was observed carrying no preimage at all on either surface, which costs the merchant
+        // proof of payment but settles the payout correctly, and is the SSP's behaviour rather than the
+        // plugin's. A *wrong* preimage would be the plugin's, and this is what would catch it.
+        var reported = new (string Surface, string? Value)[]
+        {
+            ("the PayResponse", response.Details.Preimage?.ToString()),
+            ("the resolved payment", settledPayment.Preimage)
+        };
+        foreach (var (surface, value) in reported)
+        {
+            if (!string.IsNullOrEmpty(value))
+                Assert.Equal(after.Preimage, value.ToLowerInvariant());
+        }
+
+        Console.WriteLine(
+            $"local-regtest: paid {SendAmountSats:N0} sats to LND ({invoice.PaymentHash}); "
+            + $"fee {settledPayment.Fee}; preimage reported on "
+            + $"[{string.Join(", ", reported.Where(r => !string.IsNullOrEmpty(r.Value)).Select(r => r.Surface))}]"
+            + $"{(reported.All(r => string.IsNullOrEmpty(r.Value)) ? "nothing — the SSP reported none" : "")}");
+    }
+
+    /// <summary>
+    /// A cooperative exit driven by the sweep engine, followed to <see cref="SweepRecordStatus.Confirmed"/>
+    /// with this suite mining the blocks that confirm it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The same shape as the funded suite's engine test, with the one thing that suite cannot have: control
+    /// of the chain. There, Confirmed arrives when the hosted regtest happens to mine; here blocks are mined
+    /// between polls, so reaching Confirmed is bounded in blocks rather than in luck, and a sweep that
+    /// <em>never</em> confirms is distinguishable from one that is merely waiting.
+    /// </para>
+    /// <para>
+    /// The destination is a fresh bitcoind address rather than the wallet's own deposit address. The funded
+    /// suite sends to itself so the principal comes back to a scarce wallet; nothing is scarce here, and a
+    /// third-party destination is both the realistic case and one where the exit's output can be inspected
+    /// on-chain.
+    /// </para>
+    /// <para>
+    /// Confirmation is driven by re-running the engine, because that is the only thing that advances a
+    /// record: <c>RunAsync</c> resolves the store's unresolved rows before it considers a new sweep, and
+    /// there is no separate confirm entry point. The reserve is set so the second pass finds nothing
+    /// sweepable and merely resolves.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task A_cooperative_exit_sweep_reaches_Confirmed_once_its_transaction_is_mined()
+    {
+        Assert.SkipUnless(LocalRegtestStack.IsEnabled, LocalRegtestStack.SkipReason);
+        await _stack.RequireBalanceAsync(ExitAmountSats + ExitMarginSats, "a cooperative-exit sweep", Ct);
+        var balance = await _stack.SyncBalanceAsync(Ct);
+
+        var destination = await _stack.Control.NewAddressAsync("flint-local-regtest-sweep",
+            cancellationToken: Ct);
+
+        // Quoted through the plugin's own read-only quote, at the floor amount, purely to learn what this
+        // stack's fee market currently charges. The engine re-quotes for itself when it sends — a prepare is
+        // only good for about a minute — so this is an estimate used for sizing and nothing else.
+        SparkOnchainFeeQuote quoted;
+        try
+        {
+            quoted = await _stack.Sdk.QuoteOnchainSendAsync(destination, ExitAmountSats, feesIncluded: true, Ct);
+        }
+        catch (Exception ex) when (SparkErrors.IsInsufficientFunds(ex))
+        {
+            // The wallet's own balance was checked above, so this is the SSP's: a cooperative exit needs it
+            // to split leaves it can back, and it reports that shortfall as the wallet's. Worth naming,
+            // because the message the SDK gives — "Tree service error: insufficient funds" — reads as though
+            // this wallet were empty when it is not.
+            var balanceNow = await _stack.SyncBalanceAsync(Ct);
+            Assert.Fail(
+                $"quoting a cooperative exit failed with \"{ex.Message}\" although the wallet holds "
+                + $"{balanceNow:N0} sats, which means the service provider is out of Spark liquidity rather "
+                + "than the wallet. Each run of this suite funds a fresh wallet out of the SSP's leaves, so a "
+                + "stack that has run it several times needs topping up: POST "
+                + "/admin/spark/deposit-address on the SSP with its admin token, pay the address from "
+                + "bitcoind, mine 3, then POST /admin/spark/claim-deposit — which is what the fixture's own "
+                + "cashu-spark-fund-ssp does. e2e/local-regtest/README.md has the commands.");
+            throw;
+        }
+        var slowFee = quoted.SlowFeeSats;
+        Assert.True(slowFee > 0, $"the SSP quoted a Slow cooperative-exit fee of {slowFee} sats");
+
+        // Five times the fee, so the fee lands near 20% of what the destination receives — inside both
+        // ExitMaxFeePercent and the engine's hard 50% ceiling with room for the re-quote to move.
+        var amount = Math.Max(ExitAmountSats, slowFee * 5);
+        if (amount > balance - ExitMarginSats)
+        {
+            Assert.Fail(
+                $"this stack quotes {slowFee:N0} sats for a cooperative exit, so a sweep would have to move "
+                + $"{amount:N0} sats to stay inside the engine's fee guards, and the wallet holds only "
+                + $"{balance:N0}. Raise LocalRegtestStack.FundingSats — but check first that the SSP has "
+                + "several times that in Spark liquidity, since it has to back the leaf splitting.");
+        }
+
+        var records = new InMemorySweepRecordStore();
+        var engine = BuildEngine(records, new SweepSettings
+        {
+            Enabled = true,
+            DestinationMode = SweepDestinationMode.StaticAddress,
+            StaticAddress = destination,
+            // Everything above the reserve is swept, so the reserve is how the amount is chosen — and how
+            // the rest of the suite keeps its money.
+            ReserveSats = balance - amount,
+            BalanceThresholdSats = amount,
+            MinimumSweepSats = amount / 2,
+            DrainWhenSweeping = true,
+            ConfirmationSpeed = SweepConfirmationSpeed.Slow,
+            MaxFeePercent = ExitMaxFeePercent
+        });
+
+        var run = await engine.RunAsync(_stack.StoreId, SweepTrigger.Manual, Ct);
+        Assert.True(
+            run.Kind is SweepOutcomeKind.Swept,
+            $"the sweep did not go out: {run.Kind} — {run.Reason}");
+
+        var sent = Assert.Single(records.Records).Value;
+        Assert.Equal(destination, sent.DestinationAddress);
+        Assert.True(
+            sent.Status is SweepRecordStatus.Sent or SweepRecordStatus.Confirmed,
+            $"a sweep that reported Swept left its record at {sent.Status}");
+        // Present from the first Sent write — the only handle an operator has on funds in flight.
+        Assert.False(string.IsNullOrEmpty(sent.TxId), "the cooperative exit recorded no txid");
+
+        // The engine's economics assume a flat fee that does not scale with the amount. Pinned here against
+        // the local SSP as well as the hosted one, because this is a different SSP implementation quoting its
+        // own fees and a change in them is exactly what MinimumSweepSats exists to survive.
+        Assert.True(
+            sent.QuotedFeeSats > 0 && sent.QuotedFeeSats < amount / 2,
+            $"an exit fee of {sent.QuotedFeeSats} sats on a {amount} sat sweep is not a fee this engine's "
+            + "economics were designed around (the guard that would refuse it is "
+            + $"SweepSettings.HardMaxFeePercent at {SweepSettings.HardMaxFeePercent}%). The quote taken "
+            + $"moments earlier said {slowFee} sats for the Slow tier.");
+
+        // The exit's transaction must be in bitcoind's view before mining can confirm it. Asserted rather
+        // than assumed: a txid the SSP reported but never broadcast would otherwise look identical to a
+        // slow confirmation for the whole timeout.
+        await PollAsync(
+            async () =>
+            {
+                using var tx = await _stack.Control.BitcoinCliJsonAsync(
+                    ["getrawtransaction", sent.TxId!, "true"], Ct);
+                return tx.RootElement.TryGetProperty("txid", out _) ? sent.TxId : null;
+            },
+            TimeSpan.FromMinutes(2),
+            $"the cooperative exit's transaction {sent.TxId} never appeared in bitcoind, so the SSP "
+            + "reported a txid it did not broadcast");
+
+        var minedBlocks = 0;
+        var confirmed = await PollAsync(
+            async () =>
+            {
+                // Three at a time, matching the fixture's own funding helpers: enough to move a transaction
+                // out of the mempool and past the confirmation counts the SDK cares about without minting a
+                // hundred blocks per poll.
+                minedBlocks += 3;
+                await _stack.Control.MineAsync(3, Ct);
+                await engine.RunAsync(_stack.StoreId, SweepTrigger.Automatic, Ct);
+                var current = await records.GetAsync(_stack.StoreId, sent.IdempotencyKey, Ct);
+                return current?.Status is SweepRecordStatus.Confirmed ? current : null;
+            },
+            TimeSpan.FromMinutes(5),
+            $"the sweep never reached Confirmed (txid {sent.TxId}) even after mining");
+
+        Assert.Equal(SweepRecordStatus.Confirmed, confirmed.Status);
+        Assert.NotNull(confirmed.CompletedAt);
+        // The txid survives the Sent -> Confirmed resolution. A SweepResolution's nulls mean "nothing new to
+        // say", not "clear it", and that is what keeps the handle.
+        Assert.Equal(sent.TxId, confirmed.TxId);
+        Assert.Null(confirmed.Error);
+
+        // The destination actually received the money, on-chain. This is the assertion no amount of SDK
+        // bookkeeping can substitute for: a Confirmed record whose output never landed is the worst possible
+        // outcome for a sweep, and it is only visible from bitcoind.
+        using var mined = await _stack.Control.BitcoinCliJsonAsync(
+            ["getrawtransaction", sent.TxId!, "true"], Ct);
+        var paidToDestination = mined.RootElement.GetProperty("vout").EnumerateArray()
+            .Where(v => v.TryGetProperty("scriptPubKey", out var script)
+                        && script.TryGetProperty("address", out var address)
+                        && string.Equals(address.GetString(), destination, StringComparison.Ordinal))
+            .Select(v => v.GetProperty("value").GetDecimal())
+            .Sum();
+        Assert.True(
+            paidToDestination > 0m,
+            $"the confirmed exit transaction {sent.TxId} pays nothing to {destination}");
+        // Fees included, so the destination receives amount - fee. Compared loosely: the record's own
+        // arithmetic is unit-tested, and what this asserts is that the two views agree on the same payment.
+        var expectedSats = sent.AmountSats - sent.QuotedFeeSats;
+        Assert.Equal(expectedSats, (long)decimal.Round(paidToDestination * 100_000_000m));
+
+        Console.WriteLine(
+            $"local-regtest: cooperative exit of {sent.AmountSats:N0} sats confirmed after "
+            + $"{minedBlocks} mined blocks; quoted fee {sent.QuotedFeeSats:N0} sats, "
+            + $"{expectedSats:N0} sats paid to {destination} in {sent.TxId}");
+    }
+
+    /// <summary>
+    /// The plugin's Lightning client over the real wallet, wired as <c>SparkService</c> wires it.
+    /// </summary>
+    /// <remarks>
+    /// A fresh store per test, because the invoice and outgoing records are per-store state and nothing here
+    /// is testing what happens when two tests share them. The credit gateway is empty: there is no BTCPay
+    /// here, so there is no invoice to credit, and the settlement path stays whole without it.
+    /// </remarks>
+    private SparkLightningClient BuildClient(
+        InMemoryInvoiceRecordStore store, out CapturingLogger<SparkLightningClient> log)
+    {
+        log = new CapturingLogger<SparkLightningClient>();
+        var broadcaster = new SparkSettlementBroadcaster(NullLogger<SparkSettlementBroadcaster>.Instance);
+        var reconciler = new SparkSettlementReconciler(
+            store,
+            broadcaster,
+            new SparkInvoiceCreditor(
+                new FakeInvoiceCreditGateway(), store, NullLogger<SparkInvoiceCreditor>.Instance),
+            NullLogger<SparkSettlementReconciler>.Instance);
+
+        return new SparkLightningClient(
+            _stack.StoreId,
+            _stack.PaymentKey,
+            _stack.Sdk,
+            store,
+            new InMemoryOutgoingPaymentStore(),
+            reconciler,
+            broadcaster,
+            new NBitcoinBolt11Parser(Network.RegTest, NullLogger<NBitcoinBolt11Parser>.Instance),
+            log);
+    }
+
+    /// <summary>
+    /// The sweep engine, wired the way <c>SparkService</c> wires it, over the real wallet.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TimeProvider.System"/> rather than the stub the unit tests use: the engine's grace and
+    /// resolution windows are read off it, and against a real service they have to mean real time.
+    /// </remarks>
+    private SparkSweepEngine BuildEngine(InMemorySweepRecordStore records, SweepSettings sweep)
+    {
+        var settings = new FakeSparkStoreSettingsStore();
+        settings.Settings[_stack.StoreId] = new SparkSettings
+        {
+            ProtectedMnemonic = "not-read-by-the-engine",
+            PaymentKey = _stack.PaymentKey,
+            Sweep = sweep
+        };
+
+        var runtime = new FakeSparkStoreRuntime();
+        runtime.Clients[_stack.StoreId] = _stack.Sdk;
+
+        return new SparkSweepEngine(
+            settings,
+            runtime,
+            records,
+            new SweepDestinationResolver(
+                new FakeSweepAddressSource(),
+                Network.RegTest,
+                NullLogger<SweepDestinationResolver>.Instance),
+            new CrossChainRouteResolver(NullLogger<CrossChainRouteResolver>.Instance),
+            new FakeCrossChainValueOracle(),
+            new FakeSweepTransactionLabeler(),
+            TimeProvider.System,
+            NullLogger<SparkSweepEngine>.Instance);
+    }
+
+    private static string Sha256Hex(string hex) =>
+        Convert.ToHexString(SHA256.HashData(Convert.FromHexString(hex))).ToLowerInvariant();
+
+    /// <summary>
+    /// Polls until <paramref name="attempt"/> produces a value, then fails with <paramref name="timeoutMessage"/>.
+    /// </summary>
+    /// <remarks>
+    /// Same shape as the funded suite's, and generous for the same reason: nothing here measures latency, it
+    /// measures whether a state is ever reached, and a tight deadline against a stack that is still settling
+    /// turns a working plugin into a red CI run.
+    /// </remarks>
+    private static async Task<T> PollAsync<T>(
+        Func<Task<T?>> attempt,
+        TimeSpan timeout,
+        string timeoutMessage) where T : class
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        Exception? last = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            try
+            {
+                if (await attempt() is { } value)
+                    return value;
+                last = null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // A transient failure from the stack mid-poll is not the answer; the deadline is.
+                last = ex;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(3), Ct);
+        }
+
+        Assert.Fail(last is null
+            ? $"{timeoutMessage} within {timeout.TotalMinutes:0} minutes."
+            : $"{timeoutMessage} within {timeout.TotalMinutes:0} minutes; the last attempt threw {last}");
+        throw new InvalidOperationException("unreachable");
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/SparkCustomNetworkTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkCustomNetworkTests.cs
@@ -1,0 +1,470 @@
+using Breez.Sdk.Spark;
+using BTCPayServer.Plugins.Flint.Sdk;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The local-regtest network descriptor and the SDK config it produces.
+/// </summary>
+/// <remarks>
+/// Both halves are asserted against real values rather than shapes. A descriptor that parses into a
+/// half-formed signing set, or a config whose sparkConfig was built and then not applied, produces a connect
+/// that succeeds and goes on talking to Lightspark's hosted regtest — which is the failure mode these tests
+/// exist to make impossible, because a green local-regtest run against the hosted network proves nothing.
+/// </remarks>
+public class SparkCustomNetworkTests
+{
+    private const string FirstIdentifier =
+        "0000000000000000000000000000000000000000000000000000000000000001";
+
+    private const string SecondIdentifier =
+        "0000000000000000000000000000000000000000000000000000000000000002";
+
+    private const string CaCertPem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n";
+
+    private const string SspIdentityPublicKey =
+        "0322ca18fc0f26c1a1e6e0f7a4a8f6f4c0e2c1a5b6d7e8f9a0b1c2d3e4f5a6b7c8";
+
+    [Fact]
+    public void A_descriptor_parses_into_the_network_it_describes()
+    {
+        var network = SparkCustomNetworkFile.Parse(Descriptor());
+
+        Assert.Equal(FirstIdentifier, network.CoordinatorIdentifier);
+        Assert.Equal(2u, network.Threshold);
+        Assert.Equal("http://127.0.0.1:30000", network.EsploraUrl);
+        Assert.Equal("http://127.0.0.1:5000", network.Ssp.BaseUrl);
+        Assert.Equal(SspIdentityPublicKey, network.Ssp.IdentityPublicKey);
+        Assert.Equal("graphql/spark/rc", network.Ssp.SchemaEndpoint);
+
+        Assert.Collection(
+            network.Operators,
+            first =>
+            {
+                Assert.Equal(0u, first.Id);
+                Assert.Equal(FirstIdentifier, first.Identifier);
+                Assert.Equal("https://localhost:8535", first.Address);
+                Assert.Equal(CaCertPem, first.CaCertPem);
+            },
+            second =>
+            {
+                Assert.Equal(1u, second.Id);
+                Assert.Equal(SecondIdentifier, second.Identifier);
+                Assert.Equal("https://localhost:8536", second.Address);
+                // Absent rather than empty: null is what tells the SDK to use the machine trust store.
+                Assert.Null(second.CaCertPem);
+            });
+    }
+
+    /// <summary>
+    /// The <c>fixture</c> object is the test suite's half of the file, and is ignored rather than rejected.
+    /// </summary>
+    /// <remarks>
+    /// Stated as its own test because the two halves evolve independently: the fixture scripts grow
+    /// container names and credentials as the stack does, and none of that may make the plugin refuse a file
+    /// it can otherwise read.
+    /// </remarks>
+    [Fact]
+    public void Fixture_details_and_unknown_properties_are_ignored()
+    {
+        var json = Descriptor(extra: "\"somethingTheFixtureAddedLater\": { \"nested\": [1, 2, 3] },");
+
+        var network = SparkCustomNetworkFile.Parse(json);
+
+        Assert.Equal(2, network.Operators.Count);
+    }
+
+    [Fact]
+    public void A_missing_coordinator_identifier_is_named()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(coordinator: null)));
+
+        Assert.Contains("missing coordinatorIdentifier", error.Message);
+    }
+
+    /// <summary>
+    /// Identifiers must be 64 hex characters.
+    /// </summary>
+    /// <remarks>
+    /// The SDK parses them as 32-byte keys, so a short or non-hex one is a signing failure several seconds
+    /// into a connect that names neither the operator nor the field.
+    /// </remarks>
+    [Fact]
+    public void A_coordinator_identifier_that_is_not_64_hex_is_rejected()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(coordinator: "00")));
+
+        Assert.Contains("coordinatorIdentifier", error.Message);
+        Assert.Contains("64 hex characters", error.Message);
+    }
+
+    [Fact]
+    public void An_operator_identifier_that_is_not_64_hex_names_its_index()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(secondIdentifier: "not-hex")));
+
+        Assert.Contains("operator 1's identifier", error.Message);
+        Assert.Contains("64 hex characters", error.Message);
+    }
+
+    /// <summary>
+    /// A threshold above the size of the signing set can never be met.
+    /// </summary>
+    /// <remarks>
+    /// Checked here because the SDK does not check it, and what it produces instead is a wallet that
+    /// connects and then fails every signing operation.
+    /// </remarks>
+    [Fact]
+    public void A_threshold_above_the_operator_count_is_rejected()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(threshold: "4")));
+
+        Assert.Contains("threshold (4)", error.Message);
+        Assert.Contains("2 operator(s)", error.Message);
+    }
+
+    [Fact]
+    public void A_zero_or_missing_threshold_is_rejected()
+    {
+        foreach (var threshold in new[] { "0", "null" })
+        {
+            var error = Assert.Throws<FormatException>(
+                () => SparkCustomNetworkFile.Parse(Descriptor(threshold: threshold)));
+
+            Assert.Contains("at least 1", error.Message);
+        }
+    }
+
+    [Fact]
+    public void An_empty_operator_list_is_rejected()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(operators: "[]")));
+
+        Assert.Contains("no operators", error.Message);
+    }
+
+    /// <summary>
+    /// Operator addresses must be https.
+    /// </summary>
+    /// <remarks>
+    /// The SDK speaks gRPC over TLS to them and nothing else, so a plain-http address is not a weaker
+    /// configuration, it is a connect that never completes.
+    /// </remarks>
+    [Fact]
+    public void A_plain_http_operator_address_is_rejected()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(secondAddress: "http://localhost:8536")));
+
+        Assert.Contains("operator 1's address", error.Message);
+        Assert.Contains("https URL", error.Message);
+    }
+
+    [Fact]
+    public void A_missing_operator_address_names_its_index()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(secondAddress: "")));
+
+        Assert.Contains("operator 1's address", error.Message);
+    }
+
+    [Fact]
+    public void An_ssp_without_an_identity_key_is_rejected()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(sspIdentityPublicKey: "")));
+
+        Assert.Contains("ssp identityPublicKey", error.Message);
+    }
+
+    [Fact]
+    public void An_ssp_without_a_base_url_is_rejected()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(sspBaseUrl: "")));
+
+        Assert.Contains("ssp baseUrl", error.Message);
+    }
+
+    [Fact]
+    public void A_relative_esplora_url_is_rejected()
+    {
+        var error = Assert.Throws<FormatException>(
+            () => SparkCustomNetworkFile.Parse(Descriptor(esploraUrl: "127.0.0.1:30000")));
+
+        Assert.Contains("esploraUrl", error.Message);
+        Assert.Contains("absolute http(s) URL", error.Message);
+    }
+
+    [Fact]
+    public void An_optional_schema_endpoint_may_be_absent()
+    {
+        var network = SparkCustomNetworkFile.Parse(Descriptor(sspSchemaEndpoint: null));
+
+        // Null, not empty: an empty schema endpoint is a 404 on every SSP call, where null is the SDK's own.
+        Assert.Null(network.Ssp.SchemaEndpoint);
+    }
+
+    [Fact]
+    public void Malformed_json_is_reported_as_such()
+    {
+        var error = Assert.Throws<FormatException>(() => SparkCustomNetworkFile.Parse("{ not json"));
+
+        Assert.Contains("not valid JSON", error.Message);
+    }
+
+    [Fact]
+    public void Load_round_trips_a_descriptor_from_disk_and_names_a_bad_one()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"spark-network-{Guid.NewGuid():N}.json");
+        try
+        {
+            File.WriteAllText(path, Descriptor());
+            Assert.Equal(FirstIdentifier, SparkCustomNetworkFile.Load(path).CoordinatorIdentifier);
+
+            // The path is the only part of a descriptor failure the caller did not supply, and in CI it is
+            // the difference between "the descriptor is wrong" and "a stale descriptor is being read".
+            File.WriteAllText(path, Descriptor(threshold: "9"));
+            var error = Assert.Throws<FormatException>(() => SparkCustomNetworkFile.Load(path));
+            Assert.Contains(path, error.Message);
+            Assert.Contains("2 operator(s)", error.Message);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// An unset variable reads as "no local stack", which is what the opt-in suite skips on.
+    /// </summary>
+    /// <remarks>
+    /// Blank counts as unset. A shell that exports the variable empty — which is what an unsubstituted
+    /// workflow expression produces — would otherwise fail the whole suite on a missing file rather than
+    /// skipping it, and a skip is the honest outcome when no stack was started.
+    /// </remarks>
+    [Fact]
+    public void An_unset_environment_variable_yields_no_network()
+    {
+        var original = Environment.GetEnvironmentVariable(SparkCustomNetworkFile.EnvironmentVariable);
+        try
+        {
+            Environment.SetEnvironmentVariable(SparkCustomNetworkFile.EnvironmentVariable, null);
+            Assert.Null(SparkCustomNetworkFile.TryLoadFromEnvironment());
+
+            Environment.SetEnvironmentVariable(SparkCustomNetworkFile.EnvironmentVariable, "   ");
+            Assert.Null(SparkCustomNetworkFile.TryLoadFromEnvironment());
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(SparkCustomNetworkFile.EnvironmentVariable, original);
+        }
+    }
+
+    [Fact]
+    public void The_custom_network_replaces_the_signing_set_and_the_SSP()
+    {
+        var network = SparkCustomNetworkFile.Parse(Descriptor());
+
+        var applied = SparkSdkClientFactory.ApplyCustomNetwork(
+            BreezSdkSparkMethods.DefaultConfig(Network.Regtest), Options(network), NullLogger.Instance);
+
+        var sparkConfig = applied.sparkConfig;
+        Assert.NotNull(sparkConfig);
+        Assert.Equal(FirstIdentifier, sparkConfig.coordinatorIdentifier);
+        Assert.Equal(2u, sparkConfig.threshold);
+        Assert.Equal("http://127.0.0.1:5000", sparkConfig.sspConfig?.baseUrl);
+        Assert.Equal(SspIdentityPublicKey, sparkConfig.sspConfig?.identityPublicKey);
+        Assert.Equal("graphql/spark/rc", sparkConfig.sspConfig?.schemaEndpoint);
+
+        Assert.Collection(
+            sparkConfig.signingOperators,
+            first =>
+            {
+                Assert.Equal(0u, first.id);
+                Assert.Equal("https://localhost:8535", first.address);
+                Assert.Equal(CaCertPem, first.caCertPem);
+            },
+            second =>
+            {
+                Assert.Equal(1u, second.id);
+                Assert.Equal("https://localhost:8536", second.address);
+                Assert.Null(second.caCertPem);
+            });
+
+        // Not one operator of the hosted network survives. Asserted separately because a partially replaced
+        // signing set is the failure that still connects.
+        Assert.DoesNotContain(
+            sparkConfig.signingOperators,
+            op => op.address.Contains("lightspark.com") || op.address.Contains("breez.technology"));
+    }
+
+    [Fact]
+    public void The_withdraw_parameters_of_the_default_config_are_preserved()
+    {
+        var defaults = BreezSdkSparkMethods.DefaultConfig(Network.Regtest);
+        var expected = defaults.sparkConfig;
+        Assert.NotNull(expected);
+
+        var applied = SparkSdkClientFactory.ApplyCustomNetwork(
+            defaults, Options(SparkCustomNetworkFile.Parse(Descriptor())), NullLogger.Instance);
+
+        // A cooperative exit quoted against the wrong bond is rejected by the operators, so these are the
+        // fields a from-scratch sparkConfig would silently get wrong.
+        var sparkConfig = applied.sparkConfig;
+        Assert.NotNull(sparkConfig);
+        Assert.Equal(expected.expectedWithdrawBondSats, sparkConfig.expectedWithdrawBondSats);
+        Assert.Equal(
+            expected.expectedWithdrawRelativeBlockLocktime,
+            sparkConfig.expectedWithdrawRelativeBlockLocktime);
+        Assert.Equal(expected.maxTokenTransactionInputs, sparkConfig.maxTokenTransactionInputs);
+        Assert.Equal(defaults.maxConcurrentClaims, applied.maxConcurrentClaims);
+        Assert.Equal(defaults.maxDepositClaimFee, applied.maxDepositClaimFee);
+    }
+
+    [Fact]
+    public void Every_hosted_Breez_service_is_switched_off()
+    {
+        var defaults = BreezSdkSparkMethods.DefaultConfig(Network.Regtest);
+
+        // Guards the assertions below: were a future SDK to ship these already off, they would pass without
+        // the code under test having done anything.
+        Assert.NotNull(defaults.realTimeSyncServerUrl);
+        Assert.True(defaults.useDefaultExternalInputParsers);
+        Assert.Equal(60u, defaults.syncIntervalSecs);
+
+        var applied = SparkSdkClientFactory.ApplyCustomNetwork(
+            defaults,
+            Options(SparkCustomNetworkFile.Parse(Descriptor()), apiKey: "a-hosted-key"),
+            NullLogger.Instance);
+
+        Assert.Null(applied.realTimeSyncServerUrl);
+        Assert.Null(applied.apiKey);
+        Assert.Null(applied.lnurlDomain);
+        Assert.False(applied.useDefaultExternalInputParsers);
+        Assert.False(applied.preferSparkOverLightning);
+        Assert.True(applied.privateEnabledDefault);
+        Assert.Equal(SparkSdkClientFactory.CustomNetworkSyncIntervalSecs, applied.syncIntervalSecs);
+
+        var leafOptimization = applied.leafOptimizationConfig;
+        var tokenOptimization = applied.tokenOptimizationConfig;
+        Assert.NotNull(leafOptimization);
+        Assert.NotNull(tokenOptimization);
+        Assert.False(leafOptimization.autoEnabled);
+        Assert.False(tokenOptimization.autoEnabled);
+
+        // Patched, not replaced: the thresholds stay whatever this SDK version ships.
+        var defaultTokenOptimization = defaults.tokenOptimizationConfig;
+        Assert.NotNull(defaultTokenOptimization);
+        Assert.Equal(defaultTokenOptimization.minOutputsThreshold, tokenOptimization.minOutputsThreshold);
+        Assert.Equal(defaultTokenOptimization.targetOutputCount, tokenOptimization.targetOutputCount);
+
+        // The one toggle where this plugin departs from the reference client: the settlement path is the
+        // in-process event stream the background tasks feed, so a run with them off would exercise a wallet
+        // that is not the one the plugin ships.
+        Assert.True(applied.backgroundTasksEnabled);
+    }
+
+    [Fact]
+    public void A_connect_without_a_custom_network_is_untouched()
+    {
+        var defaults = BreezSdkSparkMethods.DefaultConfig(Network.Regtest);
+
+        var applied = SparkSdkClientFactory.ApplyCustomNetwork(
+            defaults,
+            new SparkConnectOptions("store", "mnemonic", null, "key", Network.Regtest),
+            NullLogger.Instance);
+
+        Assert.Equal(defaults, applied);
+    }
+
+    /// <summary>
+    /// A custom signing set on mainnet stops the connect rather than being ignored.
+    /// </summary>
+    /// <remarks>
+    /// What it guards against is not a misconfiguration but the shape of a wallet takeover: an arbitrary
+    /// signing set holding real funds. Dropping the network silently would be the worse of the two outcomes,
+    /// because the wallet would then come up looking correct.
+    /// </remarks>
+    [Fact]
+    public void A_custom_network_on_mainnet_is_refused()
+    {
+        var network = SparkCustomNetworkFile.Parse(Descriptor());
+
+        var error = Assert.Throws<ArgumentException>(() => SparkSdkClientFactory.ApplyCustomNetwork(
+            BreezSdkSparkMethods.DefaultConfig(Network.Mainnet),
+            Options(network, Network.Mainnet),
+            NullLogger.Instance));
+
+        Assert.Contains("only supported on Regtest", error.Message);
+    }
+
+    private static SparkConnectOptions Options(
+        SparkCustomNetwork network, Network sdkNetwork = Network.Regtest, string? apiKey = null) =>
+        new("store", "mnemonic", null, apiKey, sdkNetwork, customNetwork: network);
+
+    /// <summary>
+    /// A descriptor in the shape write-network.sh emits, <c>fixture</c> object included, with one field at a
+    /// time swapped out for an invalid one.
+    /// </summary>
+    private static string Descriptor(
+        string? coordinator = FirstIdentifier,
+        string threshold = "2",
+        string? operators = null,
+        string secondIdentifier = SecondIdentifier,
+        string secondAddress = "https://localhost:8536",
+        string sspBaseUrl = "http://127.0.0.1:5000",
+        string sspIdentityPublicKey = SspIdentityPublicKey,
+        string? sspSchemaEndpoint = "graphql/spark/rc",
+        string esploraUrl = "http://127.0.0.1:30000",
+        string extra = "") =>
+        $$"""
+        {
+          "coordinatorIdentifier": {{Text(coordinator)}},
+          "threshold": {{threshold}},
+          "operators": {{operators ?? $$"""
+          [
+            {
+              "id": 0,
+              "identifier": "{{FirstIdentifier}}",
+              "address": "https://localhost:8535",
+              "identityPublicKey": "03dfbdff4b6332c220f8fa2ba8ed496c698ceada563fa01b67d9983bfc5c95e763",
+              "caCertPem": "{{CaCertPem.Replace("\n", "\\n")}}"
+            },
+            {
+              "id": 1,
+              "identifier": "{{secondIdentifier}}",
+              "address": "{{secondAddress}}",
+              "identityPublicKey": "03e625e9768651c9be268e287245cc33f96a68ce9141b0b4769205db027ee8ed77"
+            }
+          ]
+          """}},
+          "ssp": {
+            "baseUrl": "{{sspBaseUrl}}",
+            "identityPublicKey": "{{sspIdentityPublicKey}}",
+            "schemaEndpoint": {{Text(sspSchemaEndpoint)}}
+          },
+          "esploraUrl": "{{esploraUrl}}",
+          {{extra}}
+          "fixture": {
+            "bitcoindContainer": "bitcoind-1",
+            "bitcoindRpcUser": "cashu",
+            "bitcoindRpcPassword": "cashu",
+            "lndContainer": "lnd-1",
+            "clnContainer": "clightning-1",
+            "sspAdminToken": "regtest-spark-admin-token",
+            "sspContainer": "spark-ssp"
+          }
+        }
+        """;
+
+    private static string Text(string? value) => value is null ? "null" : $"\"{value}\"";
+}

--- a/BTCPayServer.Plugins.Flint/Sdk/ISparkSdkClientFactory.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/ISparkSdkClientFactory.cs
@@ -22,7 +22,8 @@ public sealed class SparkConnectOptions
         string? apiKey,
         SdkNetwork network,
         SparkMaxFee? maxDepositClaimFee = null,
-        SparkStableBalanceConfiguration? stableBalance = null)
+        SparkStableBalanceConfiguration? stableBalance = null,
+        SparkCustomNetwork? customNetwork = null)
     {
         StoreId = storeId;
         Mnemonic = mnemonic;
@@ -31,6 +32,7 @@ public sealed class SparkConnectOptions
         Network = network;
         MaxDepositClaimFee = maxDepositClaimFee;
         StableBalance = stableBalance;
+        CustomNetwork = customNetwork;
     }
 
     public string StoreId { get; }
@@ -64,6 +66,17 @@ public sealed class SparkConnectOptions
     /// work once and then silently stop.
     /// </remarks>
     public SparkStableBalanceConfiguration? StableBalance { get; }
+
+    /// <summary>
+    /// A privately hosted Spark network to connect to instead of the one the SDK ships, or null for the
+    /// SDK's own. Legal only with <see cref="SdkNetwork.Regtest"/>.
+    /// </summary>
+    /// <remarks>
+    /// Exists for the local-regtest test suite, and has no merchant-facing path into it — see
+    /// <see cref="SparkCustomNetwork"/> for why that matters. Setting it replaces the whole signing set,
+    /// so a wallet created against one network cannot be read on another.
+    /// </remarks>
+    public SparkCustomNetwork? CustomNetwork { get; }
 
     /// <summary>Deliberately says nothing: this object holds seed material.</summary>
     public override string ToString() => $"{nameof(SparkConnectOptions)}({StoreId}, {Network})";

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkCustomNetwork.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkCustomNetwork.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BTCPayServer.Plugins.Flint.Sdk;
+
+/// <summary>
+/// One Spark signing operator of a privately hosted Spark network.
+/// </summary>
+/// <param name="Id">
+/// The operator's index in the signing set. It is not decorative: the SDK addresses operators by id, so an
+/// id that disagrees with the network's own numbering produces signing failures rather than a config error.
+/// </param>
+/// <param name="Identifier">
+/// The 64-hex operator identifier. On the reference regtest stack these are the hex of <c>id + 1</c>, but
+/// nothing here assumes that — only that it is 64 hex characters, which is what the SDK will parse.
+/// </param>
+/// <param name="CaCertPem">
+/// The PEM of the CA that signed this operator's TLS certificate, or null to use the machine trust store.
+/// A locally generated stack signs its own certificates, so leaving this null there fails the handshake.
+/// </param>
+public sealed record SparkCustomNetworkOperator(
+    uint Id,
+    string Identifier,
+    string Address,
+    string IdentityPublicKey,
+    string? CaCertPem);
+
+/// <summary>
+/// The Spark Service Provider of a privately hosted Spark network.
+/// </summary>
+/// <param name="SchemaEndpoint">
+/// The GraphQL path the SSP serves, or null for the SDK's own default. It differs between SSP builds, and a
+/// wrong one is a 404 on every SSP call rather than a startup error.
+/// </param>
+public sealed record SparkCustomNetworkSsp(
+    string BaseUrl,
+    string IdentityPublicKey,
+    string? SchemaEndpoint);
+
+/// <summary>
+/// A complete description of a privately hosted Spark network: its signing set, its SSP and its chain source.
+/// </summary>
+/// <remarks>
+/// This exists for one reason — running the plugin's real-SDK tests against a local stack instead of the
+/// hosted Lightspark regtest. It is deliberately not reachable from any merchant-facing setting: a merchant
+/// who could point the wallet at an arbitrary signing set could be pointed at somebody else's.
+/// </remarks>
+public sealed record SparkCustomNetwork(
+    string CoordinatorIdentifier,
+    uint Threshold,
+    IReadOnlyList<SparkCustomNetworkOperator> Operators,
+    SparkCustomNetworkSsp Ssp,
+    string EsploraUrl);
+
+/// <summary>
+/// Reads a <see cref="SparkCustomNetwork"/> from the JSON descriptor a local stack's fixture scripts emit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The descriptor is written by <c>e2e/local-regtest/write-network.sh</c> once the stack is up, because most
+/// of it cannot be known ahead of time: the SSP's identity pubkey is generated on first boot and the
+/// operators' certificates are generated per stack.
+/// </para>
+/// <para>
+/// The file carries a <c>fixture</c> object as well — container names, RPC credentials, the SSP admin token —
+/// which the test suite uses to drive bitcoind and the Lightning counterparties over <c>docker exec</c>.
+/// That half is none of the plugin's business and is ignored here rather than modelled, so a fixture-side
+/// change cannot break the loader.
+/// </para>
+/// <para>
+/// Everything is validated up front. The alternative is handing a half-formed signing set to the SDK, which
+/// reports it as a TLS or signing failure several seconds into a connect, naming nothing.
+/// </para>
+/// </remarks>
+public static class SparkCustomNetworkFile
+{
+    /// <summary>Environment variable holding the path to the descriptor.</summary>
+    public const string EnvironmentVariable = "SPARK_LOCAL_REGTEST_NETWORK";
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        // Unknown members are ignored (the default) on purpose: `fixture` is one, and so is anything the
+        // fixture scripts start emitting for the test suite before the plugin knows about it.
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    /// <summary>Reads and validates the descriptor at <paramref name="path"/>.</summary>
+    /// <exception cref="FormatException">The file is not a valid descriptor.</exception>
+    public static SparkCustomNetwork Load(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var json = File.ReadAllText(path);
+        try
+        {
+            return Parse(json);
+        }
+        catch (FormatException ex)
+        {
+            // The path is the only part of the failure the caller did not already supply, and in CI it is
+            // the difference between "the descriptor is wrong" and "a stale descriptor is being read".
+            throw new FormatException($"{path}: {ex.Message}", ex);
+        }
+    }
+
+    /// <summary>Validates the descriptor named by <see cref="EnvironmentVariable"/>, or null if unset.</summary>
+    /// <remarks>
+    /// Returns null for an unset *or blank* variable, so that a shell that exports the variable empty reads
+    /// the same as one that never set it. This is what the test suites skip on.
+    /// </remarks>
+    public static SparkCustomNetwork? TryLoadFromEnvironment()
+    {
+        var path = Environment.GetEnvironmentVariable(EnvironmentVariable);
+        return string.IsNullOrWhiteSpace(path) ? null : Load(path);
+    }
+
+    /// <summary>Parses and validates a descriptor.</summary>
+    /// <exception cref="FormatException">The JSON is malformed, or a required field is missing or invalid.</exception>
+    public static SparkCustomNetwork Parse(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        Descriptor? descriptor;
+        try
+        {
+            descriptor = JsonSerializer.Deserialize<Descriptor>(json, SerializerOptions);
+        }
+        catch (JsonException ex)
+        {
+            throw new FormatException($"the Spark network descriptor is not valid JSON: {ex.Message}", ex);
+        }
+
+        if (descriptor is null)
+        {
+            throw new FormatException("the Spark network descriptor is empty.");
+        }
+
+        var coordinator = Hex64(descriptor.CoordinatorIdentifier, "coordinatorIdentifier");
+
+        if (descriptor.Operators is not { Count: > 0 } operators)
+        {
+            throw new FormatException("the Spark network descriptor lists no operators.");
+        }
+
+        if (descriptor.Threshold is not { } threshold || threshold == 0)
+        {
+            throw new FormatException("the Spark network descriptor's threshold must be at least 1.");
+        }
+
+        // A threshold above the signing-set size can never be met, so every signing operation would fail.
+        // Caught here because the SDK does not check it and the resulting failures name neither number.
+        if (threshold > operators.Count)
+        {
+            throw new FormatException(
+                $"the Spark network descriptor's threshold ({threshold}) exceeds its "
+                + $"{operators.Count} operator(s).");
+        }
+
+        var parsed = new List<SparkCustomNetworkOperator>(operators.Count);
+        for (var index = 0; index < operators.Count; index++)
+        {
+            var op = operators[index]
+                ?? throw new FormatException($"operator {index} of the Spark network descriptor is null.");
+
+            if (op.Id is not { } id)
+            {
+                throw new FormatException($"operator {index} of the Spark network descriptor has no id.");
+            }
+
+            parsed.Add(new SparkCustomNetworkOperator(
+                id,
+                Hex64(op.Identifier, $"operator {index}'s identifier"),
+                HttpsAddress(op.Address, $"operator {index}'s address"),
+                Required(op.IdentityPublicKey, $"operator {index}'s identityPublicKey"),
+                string.IsNullOrWhiteSpace(op.CaCertPem) ? null : op.CaCertPem));
+        }
+
+        if (descriptor.Ssp is not { } ssp)
+        {
+            throw new FormatException("the Spark network descriptor has no ssp section.");
+        }
+
+        var sspConfig = new SparkCustomNetworkSsp(
+            AbsoluteUrl(ssp.BaseUrl, "the ssp baseUrl"),
+            Required(ssp.IdentityPublicKey, "the ssp identityPublicKey"),
+            string.IsNullOrWhiteSpace(ssp.SchemaEndpoint) ? null : ssp.SchemaEndpoint);
+
+        return new SparkCustomNetwork(
+            coordinator,
+            threshold,
+            parsed,
+            sspConfig,
+            AbsoluteUrl(descriptor.EsploraUrl, "the esploraUrl"));
+    }
+
+    private static string Required(string? value, string field) =>
+        string.IsNullOrWhiteSpace(value)
+            ? throw new FormatException($"the Spark network descriptor is missing {field}.")
+            : value.Trim();
+
+    private static string Hex64(string? value, string field)
+    {
+        var candidate = Required(value, field);
+        if (candidate.Length != 64 || !IsHex(candidate))
+        {
+            throw new FormatException(
+                $"the Spark network descriptor's {field} must be 64 hex characters, not \"{candidate}\".");
+        }
+
+        return candidate;
+    }
+
+    /// <summary>
+    /// Operator addresses must be https: the SDK talks gRPC-over-TLS to them and nothing else, so a plain
+    /// http address is not a weaker configuration, it is a connect that never completes.
+    /// </summary>
+    private static string HttpsAddress(string? value, string field)
+    {
+        var candidate = AbsoluteUrl(value, field);
+        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new FormatException(
+                $"the Spark network descriptor's {field} must be an https URL, not \"{candidate}\".");
+        }
+
+        return candidate;
+    }
+
+    private static string AbsoluteUrl(string? value, string field)
+    {
+        var candidate = Required(value, field);
+        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new FormatException(
+                $"the Spark network descriptor's {field} must be an absolute http(s) URL, "
+                + $"not \"{candidate}\".");
+        }
+
+        return candidate;
+    }
+
+    private static bool IsHex(string value)
+    {
+        foreach (var c in value)
+        {
+            if (!Uri.IsHexDigit(c))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// The wire shape. Every member is nullable so that a missing field is reported by name below rather
+    /// than as a deserialization error that says only which JSON path failed.
+    /// </summary>
+    private sealed record Descriptor
+    {
+        [JsonPropertyName("coordinatorIdentifier")]
+        public string? CoordinatorIdentifier { get; init; }
+
+        [JsonPropertyName("threshold")]
+        public uint? Threshold { get; init; }
+
+        [JsonPropertyName("operators")]
+        public IReadOnlyList<OperatorDescriptor?>? Operators { get; init; }
+
+        [JsonPropertyName("ssp")]
+        public SspDescriptor? Ssp { get; init; }
+
+        [JsonPropertyName("esploraUrl")]
+        public string? EsploraUrl { get; init; }
+    }
+
+    private sealed record OperatorDescriptor
+    {
+        [JsonPropertyName("id")]
+        public uint? Id { get; init; }
+
+        [JsonPropertyName("identifier")]
+        public string? Identifier { get; init; }
+
+        [JsonPropertyName("address")]
+        public string? Address { get; init; }
+
+        [JsonPropertyName("identityPublicKey")]
+        public string? IdentityPublicKey { get; init; }
+
+        [JsonPropertyName("caCertPem")]
+        public string? CaCertPem { get; init; }
+    }
+
+    private sealed record SspDescriptor
+    {
+        [JsonPropertyName("baseUrl")]
+        public string? BaseUrl { get; init; }
+
+        [JsonPropertyName("identityPublicKey")]
+        public string? IdentityPublicKey { get; init; }
+
+        [JsonPropertyName("schemaEndpoint")]
+        public string? SchemaEndpoint { get; init; }
+    }
+}

--- a/BTCPayServer.Plugins.Flint/Sdk/SparkSdkClientFactory.cs
+++ b/BTCPayServer.Plugins.Flint/Sdk/SparkSdkClientFactory.cs
@@ -48,6 +48,7 @@ public class SparkSdkClientFactory : ISparkSdkClientFactory
         // backgroundTasksEnabled = false, which disables the in-process event stream this plugin's
         // settlement path is built on, and hard-fails on Stable Balance config.
         config = ApplyPostMvpConfig(config, options, _logger);
+        config = ApplyCustomNetwork(config, options, _logger);
 
         var seed = new Seed.Mnemonic(options.Mnemonic, options.Passphrase);
 
@@ -55,6 +56,16 @@ public class SparkSdkClientFactory : ISparkSdkClientFactory
         var builder = new SdkBuilder(config, seed);
         try
         {
+            // A private network has no Lightspark chain API in front of it, so the chain source has to be
+            // named explicitly — and before Build(), which is the only point the builder still accepts it.
+            // Credentials are null because the fixture's Esplora is unauthenticated.
+            if (options.CustomNetwork is { } customNetwork)
+            {
+                await builder
+                    .WithRestChainService(customNetwork.EsploraUrl, ChainApiType.Esplora, null)
+                    .ConfigureAwait(false);
+            }
+
             switch (_storageProvider.GetTarget(options.StoreId))
             {
                 case SparkStorageTarget.Directory directory:
@@ -194,6 +205,130 @@ public class SparkSdkClientFactory : ISparkSdkClientFactory
                     defaultTargetOverpayBps: null)
             };
         }
+
+        return config;
+    }
+
+    /// <summary>
+    /// How often a wallet on a private network polls. Seconds rather than the SDK's 60, because a local
+    /// stack mines on demand: a test that waits a minute for the next sync is a test that times out.
+    /// </summary>
+    internal const uint CustomNetworkSyncIntervalSecs = 2;
+
+    /// <summary>
+    /// Repoints the config at a privately hosted Spark network, or returns it untouched.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Internal and static for the same reason as <see cref="ApplyPostMvpConfig"/>: these are the settings
+    /// that decide whether a connect talks to the local stack or quietly keeps talking to Lightspark's, and
+    /// that distinction is invisible from a connected client.
+    /// </para>
+    /// <para>
+    /// Mirrors the Spark reference regtest client. The toggles are not tuning — each of them names a hosted
+    /// service that does not exist on a private network, and every one left at its default is a background
+    /// task retrying against the internet for the life of the wallet.
+    /// </para>
+    /// </remarks>
+    internal static Config ApplyCustomNetwork(Config config, SparkConnectOptions options, ILogger logger)
+    {
+        if (options.CustomNetwork is not { } network)
+        {
+            return config;
+        }
+
+        // Refused rather than ignored on mainnet. A custom signing set is exactly the shape of a wallet
+        // takeover — real funds, somebody else's operators — so the mismatch has to stop the connect.
+        if (options.Network is not Network.Regtest)
+        {
+            throw new ArgumentException(
+                $"A custom Spark network is only supported on {Network.Regtest}, not {options.Network}.",
+                nameof(options));
+        }
+
+        // DefaultConfig carries a sparkConfig on both networks today; asserted rather than assumed, because
+        // the fields kept below are withdraw parameters, and inventing values for those would be worse than
+        // failing to start.
+        if (config.sparkConfig is not { } sparkConfig)
+        {
+            throw new InvalidOperationException(
+                "The Spark SDK's default config has no sparkConfig to base a custom network on.");
+        }
+
+        var operators = new SparkSigningOperator[network.Operators.Count];
+        for (var index = 0; index < operators.Length; index++)
+        {
+            var op = network.Operators[index];
+            operators[index] = new SparkSigningOperator(
+                op.Id, op.Identifier, op.Address, op.IdentityPublicKey, op.CaCertPem);
+        }
+
+        config = config with
+        {
+            // Patched rather than constructed: expectedWithdrawBondSats and
+            // expectedWithdrawRelativeBlockLocktime are protocol parameters the local stack shares with the
+            // hosted one, and a cooperative exit quoted against the wrong bond is rejected by the operators.
+            sparkConfig = sparkConfig with
+            {
+                coordinatorIdentifier = network.CoordinatorIdentifier,
+                threshold = network.Threshold,
+                signingOperators = operators,
+                sspConfig = new SparkSspConfig(
+                    network.Ssp.BaseUrl, network.Ssp.IdentityPublicKey, network.Ssp.SchemaEndpoint)
+            },
+
+            // Every hosted Breez service is switched off by name.
+            //
+            // apiKey and lnurlDomain address Breez infrastructure that knows nothing about this wallet, so a
+            // key here is at best inert. realTimeSyncServerUrl is the one that matters: left at its default
+            // the wallet keeps pushing its state to Breez's datasync server — a real endpoint, reachable from
+            // CI — which is both an outbound leak from a supposedly private network and a source of sync
+            // failures that look like local-stack faults. useDefaultExternalInputParsers pulls its parser
+            // list over the network at connect time, from a service the stack does not have.
+            apiKey = null,
+            lnurlDomain = null,
+            realTimeSyncServerUrl = null,
+            useDefaultExternalInputParsers = false,
+
+            // Routing and privacy defaults, pinned so the tests assert the SDK's behaviour and not the
+            // release's choice of default: sends go over Lightning (which is what the fixture's LND and CLN
+            // nodes are there to exercise), and transfers stay private.
+            preferSparkOverLightning = false,
+            privateEnabledDefault = true,
+
+            syncIntervalSecs = CustomNetworkSyncIntervalSecs
+        };
+
+        // Leaf and token optimization run as background tasks that talk to the SSP on a timer. On a stack
+        // that is torn down minutes after it is built they buy nothing, and their traffic interleaves with
+        // whatever a test is asserting. Patched rather than replaced so that the multiplicity and output
+        // thresholds stay whatever the SDK version ships.
+        if (config.leafOptimizationConfig is { } leafOptimization)
+        {
+            config = config with
+            {
+                leafOptimizationConfig = leafOptimization with { autoEnabled = false }
+            };
+        }
+
+        if (config.tokenOptimizationConfig is { } tokenOptimization)
+        {
+            config = config with
+            {
+                tokenOptimizationConfig = tokenOptimization with { autoEnabled = false }
+            };
+        }
+
+        // backgroundTasksEnabled is deliberately left alone: the plugin's whole settlement path is the
+        // in-process event stream those tasks feed, so a local-regtest run with them off would exercise a
+        // wallet the plugin never ships. maxDepositClaimFee is likewise left as ApplyPostMvpConfig set it —
+        // the reference client disables automatic claiming and claims by hand, which is the opposite of what
+        // these tests exist to cover.
+
+        logger.LogDebug(
+            "Store {StoreId}: using a custom Spark network with {OperatorCount} operator(s) "
+            + "(threshold {Threshold}), SSP {SspBaseUrl}, chain source {EsploraUrl}",
+            options.StoreId, operators.Length, network.Threshold, network.Ssp.BaseUrl, network.EsploraUrl);
 
         return config;
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,8 +28,9 @@ Everything about the plugin beyond "what is it and how do I install it". Start a
 
 - **[Building](building.md)** — prerequisites, the submodule pin, packaging a `.btcpay`, and why the
   built-against version and the support floor are separate numbers.
-- **[Tests](testing.md)** — the default run, the opt-in Postgres and regtest suites, and the runbook for
-  the funded regtest wallet CI uses.
+- **[Tests](testing.md)** — the default run, the opt-in Postgres and regtest suites, the runbook for
+  the funded regtest wallet CI uses, and the local Spark stack that settles real payments against real
+  LND counterparties.
 - **[Local development](development.md)** — side-loading the plugin into a local BTCPay, and authoring EF
   migrations.
 - **[CI, releases & upstream updates](ci-and-releases.md)** — what each workflow does, which jobs gate a

--- a/docs/ci-and-releases.md
+++ b/docs/ci-and-releases.md
@@ -16,6 +16,24 @@
   error-string re-wording, or a preimage reaching the log, shows as a failed job inside a green
   scheduled run. A drained wallet failing a PR is answered by funding the wallet and re-running, not by
   reading it as a code failure.
+- **`.github/workflows/local-regtest.yml`** runs the `LocalRegtest` suite against a Spark stack it
+  stands up itself — [callebtc/cashu-regtest](https://github.com/callebtc/cashu-regtest)'s `--spark`
+  profile, pinned by SHA in both the workflow and `e2e/local-regtest/up.sh`. It is the only job that
+  covers settlement end to end with **no third-party service and no secret**: real LND nodes on both
+  sides of an invoice, and blocks mined on demand. Daily, on PRs, and on manual dispatch.
+
+  | job | gates a merge? | why |
+  |---|---|---|
+  | `local-regtest` | no — `continue-on-error` | no measured flake rate yet, and the fixture is six services built from source with keyshare generation and channel gossip to wait on; a flaky fixture blocking merges would cost more than the gap it closes. Unlike `integration-test` the dependency is not a third-party service, so red here is likelier to be our bug — which is the argument for eventually gating it on PRs, once the daily schedule has accumulated a pass/fail record, exactly as `funded-regtest-test` earned its gate |
+
+  It is also the slowest job in the repository by a wide margin: the fixture publishes no images, so
+  every run builds the Spark operators, Electrs, `open-ssp` and `ldk-server` from Rust and Go source
+  on a cache-less runner — around **40 minutes**, against a 90-minute timeout. Publishing those images
+  to `ghcr.io` once per pinned SHA is the noted follow-up, and is what would make the job cheap enough
+  to gate. On failure it uploads a `local-regtest-stack-logs` artifact with `docker compose ps -a` and
+  the tail of each service's log, because a failure here is usually "which of six services fell over"
+  rather than anything the .NET output shows. See
+  ["Against a local Spark stack"](testing.md#against-a-local-spark-stack).
 - **`.github/workflows/spark-regtest-wallet.yml`** is manual-only. It prints the CI regtest wallet's
   static deposit address and balance so a maintainer can fund it — see
   ["A funded regtest wallet for CI"](testing.md#a-funded-regtest-wallet-for-ci). It never prints the seed, and
@@ -77,4 +95,5 @@
   (`integration-test` intentionally *not* required, since it is `continue-on-error` by design), plus
   "Require branches to be up to date before merging". `funded-regtest-test` blocks PRs since it is
   no longer `continue-on-error` there; requiring it in branch protection as well is a choice —
-  doing so means a drained CI wallet holds every merge until someone funds it.
+  doing so means a drained CI wallet holds every merge until someone funds it. `local-regtest` is
+  `continue-on-error` on every trigger and should not be required either, for now.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,7 @@ The default run covers the plugin's own logic — invoice-record state transitio
 connection-string handling, listener safety, settlement fan-out, the sweep engine's economics, guards and
 crash recovery, and the whole `ILightningClient` surface driven through a fake SDK. It needs no Docker, no
 database and no network, and finishes in a couple of seconds. It does **not** cover the EF store or the SDK
-itself; those need the two opt-in suites below.
+itself; those need the opt-in suites below.
 
 The fake SDK deliberately models the real one's hazards rather than an idealised SDK: a cooperative-exit
 quote that does not check the balance, quotes that expire, the script-type dust floor, a send that returns
@@ -147,3 +147,49 @@ context: a preimage next to a name the scrubber knows is handled; one with no na
 scrubber's remarks left open, and since it lives in `sdk.log` the fix is a log-level or file-permissions
 question rather than a regex. Either way, **record the answer in `Sdk/SparkLogScrubber.cs` and delete the
 stated gap.** That is what the artifact is for; it only needs reading once.
+
+## Against a local Spark stack
+
+Both regtest suites above run against Lightspark's hosted service, where everything on the far side of an
+invoice is somebody else's: **no counterparty will pay an invoice the plugin mints**, no one can mine a
+block on demand, and the funded suite needs a faucet-filled wallet behind a repository secret — which is
+why it goes red when the wallet drains, and why a fork cannot run it at all.
+
+A local stack removes all three constraints. [`e2e/local-regtest/`](../e2e/local-regtest/) stands up
+[callebtc/cashu-regtest](https://github.com/callebtc/cashu-regtest)'s `--spark` profile: Bitcoin Core in
+regtest, three Spark operators signing 2-of-3, an `open-ssp` service provider backed by an LDK node,
+Electrs serving an Esplora API, and three LND plus three CLN nodes in a funded channel topology. Those
+Lightning nodes are the point — `lnd-1` pays a Flint invoice and Flint pays `lnd-1`'s, so a **settlement**
+is observable from both sides, with the payment hash checked against what the payer recorded. Deposits
+confirm because a test mines them, a cooperative exit reaches `Confirmed` in seconds rather than whenever
+a block arrives, and there is no secret and no balance to keep topped up.
+
+```bash
+e2e/local-regtest/up.sh                     # clone at the pinned SHA, then ./start.sh --spark
+e2e/local-regtest/write-network.sh          # discover the live stack, write network.json
+
+SPARK_LOCAL_REGTEST_NETWORK=$PWD/e2e/local-regtest/network.json \
+  dotnet test --filter "Category=LocalRegtest"
+
+e2e/local-regtest/down.sh
+```
+
+`SPARK_LOCAL_REGTEST_NETWORK` points at a **network descriptor**: a JSON file naming the three operators
+with their addresses, identity keys and TLS certificates, the SSP's base URL and identity key, and the
+Esplora URL. The plugin's `SparkCustomNetwork` loader reads it and rewrites the SDK's regtest config from
+it; the test fixture additionally reads the container names it needs to drive `bitcoin-cli` and `lncli`.
+It has to be generated rather than committed, because the SSP's identity key and the operators'
+certificates are created fresh by every `start.sh` — so **re-run `write-network.sh` after every
+`up.sh`**. Absent the variable the suite skips itself, as the Postgres and integration suites do.
+
+The cost is time: the fixture publishes no images, so a cold run builds six services from Rust and Go
+source and takes **tens of minutes** (a few minutes once the layers are cached). On Docker Desktop for macOS
+the fixture's Core Lightning nodes cannot write their SQLite database on a bind mount, so `up.sh` gives them
+named volumes through a compose override there; see the
+[fixture README](../e2e/local-regtest/README.md#on-macos). Do not mine or start the suite while `up.sh` is
+still running — the fixture's init waits for every node to reach one exact height, and outside mining
+makes that wait time out with the SSP unfunded.
+
+Everything the stack holds — the `cashu`/`cashu` RPC credentials, the `regtest-spark-admin-token`, the
+operator keyshares — is a public fixture value, and the suite's wallet is random per run. Details, and how
+to bump the pin, are in [`e2e/local-regtest/README.md`](../e2e/local-regtest/README.md).

--- a/e2e/local-regtest/README.md
+++ b/e2e/local-regtest/README.md
@@ -1,0 +1,83 @@
+# The local Spark stack
+
+[callebtc/cashu-regtest](https://github.com/callebtc/cashu-regtest) with its `--spark` profile: Bitcoin
+Core in regtest, three Spark operators signing 2-of-3, an
+[`open-ssp`](https://github.com/benthecarman/open-ssp) service provider backed by an LDK node, Electrs serving
+an Esplora API, and three LND plus three CLN nodes wired into a funded channel topology.
+
+Those Lightning nodes are why this exists. The plugin's other regtest suite talks to Lightspark's
+hosted SSP, where nothing on the far side of an invoice is under our control: no counterparty will
+pay one, and no one can mine. Here `lnd-1` pays a Flint invoice and Flint pays `lnd-1`'s, block
+production is a command, and every credential is a published fixture value. See
+[docs/testing.md](../../docs/testing.md#against-a-local-spark-stack).
+
+## Running it
+
+```bash
+e2e/local-regtest/up.sh                     # clone at the pin, then ./start.sh --spark
+e2e/local-regtest/write-network.sh          # discover the live stack, write network.json
+
+SPARK_LOCAL_REGTEST_NETWORK=$PWD/e2e/local-regtest/network.json \
+  dotnet test --filter "Category=LocalRegtest"
+
+e2e/local-regtest/down.sh                   # compose down --volumes, all profiles
+```
+
+`write-network.sh` prints the `export` line for the descriptor path when it finishes. Absent that
+variable the suite skips itself, exactly as the Postgres and Lightspark suites do.
+
+## What it costs
+
+The fixture builds the Spark operators (Rust and Go), Electrs, `open-ssp` and `ldk-server` **from
+source** — there are no published images. A cold first run is **tens of minutes** (the fixture's own
+CI allows 90, and its Spark job takes around 40) and wants several GB of disk for the image layers
+and build caches. Subsequent runs reuse those layers and come up in a few minutes.
+
+`up.sh` is idempotent about the *checkout*, not the *state*: the fixture's `start.sh` begins with
+`docker compose down --volumes`, so every run resets the chain, the operator databases, the SSP
+mnemonic and the generated TLS certificates. The descriptor is therefore only valid for the run
+that produced it — re-run `write-network.sh` after every `up.sh`. `down.sh` deletes the stale
+`network.json` for that reason.
+
+Host dependencies are `docker`, `git`, `jq`, `curl` and `openssl`.
+
+### On macOS
+
+Docker Desktop for macOS cannot host lightningd's SQLite database on a bind mount: the three core Core
+Lightning nodes die seconds after starting with `**BROKEN** lightningd: ... attempt to write a readonly
+database`, `start.sh` times out in `wait-for-clightning-sync`, and the Spark init that funds the SSP never
+runs. The fixture's own `clightning-4`, which sits on a named volume, starts fine on the same host — so on
+Darwin `up.sh` writes a `docker-compose.override.yml` into the checkout that gives `clightning-1..3` (and
+the REST sidecar that shares `clightning-2`'s directory) named volumes too. Compose merges `volumes` by
+container target path, so the override replaces the bind mounts without touching the pinned compose file,
+and Linux keeps the fixture's own layout. The override is only written if the checkout has none.
+
+One consequence: with named volumes the host-side `data/clightning-*` directories stay empty, so the
+fixture's CLN REST credentials are not on the host. No LocalRegtest test uses them — `lnd-1` is the
+counterparty on both sides — and `write-network.sh` treats `clightning-1` as optional for that reason.
+
+Do not mine or run the suite while `up.sh` is still running. The fixture's init waits for all seven
+Lightning nodes to sit at one exact block height, and a block mined from outside during that wait makes
+the loop time out; the stack then looks up but the SSP is unfunded.
+
+## What is pinned, and how to bump it
+
+`up.sh` holds `CASHU_REGTEST_SHA`, and verifies the checkout matches it on every run — including a
+checkout you point at with `CASHU_REGTEST_DIR`. The pin covers more than the compose topology: the
+operators' identity public keys, the loopback ports `8535`/`8536`/`8537`, the Esplora port `30000`,
+the SSP's port `5000`, the `cashu` Compose project name that gives every container its name, and
+the `regtest-spark-admin-token`. `write-network.sh` reads what it can from the pinned checkout's own
+`spark/operators.json` rather than duplicating it, and asserts what it cannot — that each
+certificate carries a `DNS:localhost` SAN, that `/identity` returned a compressed pubkey.
+
+To bump: update `CASHU_REGTEST_SHA` here **and** the `ref:` in
+[`.github/workflows/local-regtest.yml`](../../.github/workflows/local-regtest.yml), delete the local
+checkout, and run the flow above. Read the fixture's diff for moved ports or changed operator keys
+while you are at it; the assertions above will catch some of that, but not a port that moved.
+
+## Credentials
+
+Every secret in this stack is a public regtest fixture value, committed in the upstream repository:
+the `cashu`/`cashu` Bitcoin Core RPC credentials, the `regtest-spark-admin-token`, the operator
+signing keyshares. The wallet the suite connects is generated from random entropy per run and holds
+regtest coins. **Never point any of this at real funds.**

--- a/e2e/local-regtest/down.sh
+++ b/e2e/local-regtest/down.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Tear the local Spark stack down and reclaim its disk.
+#
+# This runs the fixture's own `cashu-regtest-stop`, which is `docker compose --profile "*" down
+# --volumes` followed by deleting and recreating the bind-mounted Lightning node data directories.
+# The profile wildcard matters: the Spark services are all behind a profile, and a plain
+# `docker compose down` leaves every one of them running. The `--volumes` matters too — the
+# operators' Postgres databases, the SSP's mnemonic and the generated TLS certificates all live in
+# named volumes, and a half-reset stack (fresh chain, stale keyshares) fails in ways that look like
+# Spark bugs. Recreating the data directories afterwards is what keeps the next start from failing
+# on permissions.
+#
+# It does not remove the checkout, and it does not remove the built images: those are the tens of
+# minutes of Rust and Go compilation, and keeping them is what makes a second run fast. Delete
+# e2e/local-regtest/cashu-regtest by hand if you want the source gone as well.
+#
+# Environment:
+#   CASHU_REGTEST_DIR  the fixture checkout to stop (default: the one alongside this script)
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+checkout="${CASHU_REGTEST_DIR:-$script_dir/cashu-regtest}"
+
+if [ ! -d "$checkout" ]; then
+  echo "No fixture checkout at $checkout; nothing to stop."
+  exit 0
+fi
+
+# docker-scripts.sh only resolves its own relative sources (bark/, ldk/, fees/ scripts) from the
+# checkout root, and it is also what exports COMPOSE_PROJECT_NAME=cashu — the project name the
+# stack was created under. Sourcing it from anywhere else stops nothing.
+cd "$checkout"
+# shellcheck disable=SC1091  # a file in the pinned foreign checkout, not in this repository
+. ./docker-scripts.sh
+
+echo "==> cashu-regtest-stop (compose down --volumes across all profiles)"
+cashu-regtest-stop
+
+# The descriptor names container IDs and holds certificates that no longer exist; leaving it in
+# place would let a later `dotnet test` run point the SDK at a dead stack and fail on a connection
+# error rather than saying the stack is down.
+if [ -f "$script_dir/network.json" ]; then
+  echo "==> removing the stale $script_dir/network.json"
+  rm -f "$script_dir/network.json"
+fi
+
+echo "==> stack is down. Built images are kept; delete $checkout to remove the source too."

--- a/e2e/local-regtest/up.sh
+++ b/e2e/local-regtest/up.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Bring up the local Spark stack the LocalRegtest suite runs against.
+#
+# The stack is callebtc/cashu-regtest with its `--spark` profile: Bitcoin Core in regtest, three
+# Spark operators (2-of-3 FROST), an `open-ssp` service provider backed by an LDK node, Electrs
+# serving an Esplora API, and three LND plus three CLN nodes wired into a real channel topology.
+# Those Lightning nodes are the point: they are external counterparties the plugin's SSP has to
+# actually route to and from, which is the one thing Lightspark's hosted regtest cannot give us
+# (see docs/testing.md).
+#
+# Idempotent by design: run it twice and the second run reuses the existing checkout. It is NOT
+# incremental past that — `start.sh` itself begins with `docker compose down --volumes`, so every
+# run resets the chain, the operators' databases and every node identity. That is the fixture's
+# model, not ours; treat the stack as disposable.
+#
+# Environment:
+#   CASHU_REGTEST_DIR  where the fixture checkout lives. Defaults to a clone this script manages.
+#                      CI sets it to the path actions/checkout already wrote, so the workflow does
+#                      not clone twice.
+set -euo pipefail
+
+# Pinned so the descriptor write-network.sh emits, the operator keys it reads out of
+# spark/operators.json, and the published host ports all stay in agreement. The fixture is a
+# regtest playground and reorganises its compose file freely; an unpinned clone would move the
+# ports or the keys out from under the tests with no signal. To bump it, see
+# e2e/local-regtest/README.md — the bump is a reviewed change, not a `git pull`.
+CASHU_REGTEST_SHA="23d5c160e0b5fade7e4a245b7385f9116bf2fc5c"
+CASHU_REGTEST_REPO="https://github.com/callebtc/cashu-regtest.git"
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+checkout="${CASHU_REGTEST_DIR:-$script_dir/cashu-regtest}"
+log="$script_dir/up.log"
+
+if [ ! -d "$checkout" ]; then
+  echo "==> cloning $CASHU_REGTEST_REPO into $checkout"
+  # A full clone, deliberately: the pinned SHA is not a tag and not necessarily reachable from the
+  # default branch's tip in a shallow fetch, and the repository is small.
+  git clone --quiet "$CASHU_REGTEST_REPO" "$checkout"
+  git -C "$checkout" checkout --quiet "$CASHU_REGTEST_SHA"
+fi
+
+# Verify rather than trust, on every run and not just after a fresh clone: the common failure is a
+# checkout somebody updated by hand, or a CASHU_REGTEST_DIR pointing at their own working copy — and
+# CI sets that variable to a path actions/checkout wrote from its own `ref`, so this is also what
+# catches that ref drifting from the constant above. A stack built from a different revision fails
+# later, deep inside a test, with an error that says nothing about the cause. Anything that does not
+# resolve to a 40-hex commit is reported as "not a git checkout" rather than passed through: a plain
+# directory or an extracted tarball makes `rev-parse` fail, and an empty repository makes it
+# succeed-ish by echoing back "HEAD".
+head_sha="$(git -C "$checkout" rev-parse HEAD 2>/dev/null || true)"
+if ! printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+  head_sha="not a git checkout"
+fi
+if [ "$head_sha" != "$CASHU_REGTEST_SHA" ]; then
+  echo "error: $checkout is at $head_sha, expected the pinned $CASHU_REGTEST_SHA" >&2
+  echo "       Check it out at the pin, or delete the directory and let this script clone it." >&2
+  exit 1
+fi
+
+# What the fixture's own CI does before `start.sh` (.github/workflows/ci.yml, spark-regtest job),
+# and it is load-bearing rather than cargo cult: the compose file bind-mounts ./data and ./spark
+# into containers that run as assorted non-root uids — lightningd, lnd, the operators — and those
+# containers write into the mounts. Without world-writable modes the node data directories fail to
+# initialise and the stack dies during startup with permission errors that look like node bugs.
+# It is safe here because everything under the checkout is disposable regtest fixture data.
+# Docker Desktop for macOS cannot host lightningd's SQLite database on a bind mount: every Core Lightning
+# node dies seconds after start with "attempt to write a readonly database", start.sh times out in
+# wait-for-clightning-sync, and the Spark init that funds the SSP never runs. The fixture's own
+# clightning-4 — on a named volume — starts fine on the same host, so the fix is to give the three core
+# CLN nodes named volumes too. Compose merges `volumes` by container target path, so an override file
+# replaces the bind mounts without editing the pinned compose file. Linux keeps the fixture's own
+# layout; the override is written only where it is needed, and only if the checkout has none of its own.
+if [ "$(uname -s)" = "Darwin" ] && [ ! -f "$checkout/docker-compose.override.yml" ]; then
+  echo "==> macOS: writing docker-compose.override.yml (named volumes for the CLN nodes' SQLite)"
+  cat > "$checkout/docker-compose.override.yml" <<'OVERRIDE'
+# Written by Flint's e2e/local-regtest/up.sh on macOS. See that script for why.
+services:
+  clightning-1:
+    volumes:
+      - cln1-data:/root/.lightning/
+  clightning-2:
+    volumes:
+      - cln2-data:/root/.lightning/
+  clightning-2-rest:
+    volumes:
+      - cln2-data:/root/.lightning/
+  clightning-3:
+    volumes:
+      - cln3-data:/root/.lightning/
+volumes:
+  cln1-data:
+  cln2-data:
+  cln3-data:
+OVERRIDE
+fi
+
+echo "==> chmod -R 777 $checkout (the fixture's containers write into its bind mounts as several uids)"
+chmod -R 777 "$checkout"
+
+echo "==> ./start.sh --spark  (first run builds the Rust and Go images from source: tens of minutes)"
+echo "    full output is also being written to $log"
+# `start.sh` sources docker-scripts.sh with relative paths, so it only works from its own directory.
+# `set -e` is suspended around the pipeline so the tail-of-log diagnostic below actually runs; the
+# exit status comes from PIPESTATUS[0] rather than the pipeline, so `tee` cannot mask a failure.
+set +e
+( cd "$checkout" && ./start.sh --spark ) 2>&1 | tee "$log"
+start_status="${PIPESTATUS[0]}"
+set -e
+
+if [ "$start_status" -ne 0 ]; then
+  echo "" >&2
+  echo "error: the fixture's ./start.sh --spark failed (exit $start_status)." >&2
+  echo "       Last 80 lines; start.sh's own EXIT trap has already dumped container logs above." >&2
+  echo "---------------------------------------------------------------------------" >&2
+  tail -n 80 "$log" >&2
+  echo "---------------------------------------------------------------------------" >&2
+  exit "$start_status"
+fi
+
+echo ""
+echo "==> stack is up and the fixture's own acceptance tests passed."
+echo "    Next: $script_dir/write-network.sh"

--- a/e2e/local-regtest/write-network.sh
+++ b/e2e/local-regtest/write-network.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Write the network descriptor the LocalRegtest suite and the plugin's custom-network loader read.
+#
+# Everything in the descriptor is discovered from the running stack rather than hardcoded here,
+# because the two pieces that matter most cannot be known ahead of time: the SSP's identity public
+# key and the operators' TLS certificates are generated fresh on every `start.sh`, which begins by
+# destroying the volumes that held the previous ones. The parts that ARE fixed by the pin — operator
+# identity keys, published host ports, the admin token — are read out of the pinned checkout's own
+# files where possible, so a bump that changes them shows up here instead of silently disagreeing.
+#
+# Usage:  write-network.sh [output-path]
+# Environment:
+#   CASHU_REGTEST_DIR      the fixture checkout (default: the one up.sh manages, alongside this script)
+#   COMPOSE_PROJECT_NAME   defaults to `cashu`, which is what the fixture's docker-scripts.sh exports
+#                          and therefore what named its containers and volumes
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+checkout="${CASHU_REGTEST_DIR:-$script_dir/cashu-regtest}"
+output="${1:-$script_dir/network.json}"
+
+# The fixture pins its compose project name in docker-scripts.sh (`export COMPOSE_PROJECT_NAME=cashu`)
+# rather than letting Compose derive it from the directory name. That is what makes the containers
+# `cashu-bitcoind-1`, `cashu-lnd-1-1`, `cashu-spark-ssp-1` and so on, and the volumes `cashu_*` —
+# and it means resolving anything with `docker compose` from a differently-named directory finds
+# nothing unless the same value is exported here.
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-cashu}"
+# The Spark services are all behind the `spark` profile; `docker compose ps -q` ignores services
+# whose profile is not active, and would return empty for every one of them without this.
+export COMPOSE_PROFILES="${COMPOSE_PROFILES:-spark}"
+
+for tool in docker jq curl openssl; do
+  command -v "$tool" >/dev/null || { echo "error: $tool is required" >&2; exit 1; }
+done
+[ -d "$checkout" ] || { echo "error: no fixture checkout at $checkout; run up.sh first" >&2; exit 1; }
+cd "$checkout"
+
+# Resolve a service's container name through Compose rather than assuming the `cashu-<svc>-1`
+# pattern. The pattern is what the pin produces today, but the descriptor is consumed by
+# `docker exec` calls in the test fixture, and a wrong name there fails as an unhelpful "No such
+# container" in the middle of a payment test.
+#
+# `ps -aq`, not `ps -q`: a name is a name whether or not the container is currently running, and
+# resolving it is separate from asserting it is up (which the second argument does). Getting an
+# exited container's name into the descriptor is useful — `docker logs` on it is the first thing
+# anyone reads.
+#
+#   container_name <service> required   — absent or exited is a hard failure
+#   container_name <service> optional   — absent or exited warns and yields the empty string
+container_name() {
+  local service="$1" requirement="$2" id state
+  id="$(docker compose ps -aq "$service" || true)"
+  if [ -n "$id" ]; then
+    state="$(docker inspect -f '{{.State.Status}}' "$id")"
+    if [ "$state" = "running" ]; then
+      docker inspect -f '{{.Name}}' "$id" | sed 's|^/||'
+      return 0
+    fi
+  fi
+
+  local detail="is not running (state: ${state:-no such container})"
+  if [ "$requirement" = optional ]; then
+    echo "warning: service '$service' $detail; recording it as empty in the descriptor." >&2
+    if [ -n "$id" ]; then docker inspect -f '{{.Name}}' "$id" | sed 's|^/||'; fi
+    return 0
+  fi
+  echo "error: service '$service' $detail (COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME," >&2
+  echo "       COMPOSE_PROFILES=$COMPOSE_PROFILES). Run up.sh first, and read its output." >&2
+  return 1
+}
+
+echo "==> resolving containers"
+bitcoind_container="$(container_name bitcoind required)"
+lnd_container="$(container_name lnd-1 required)"
+ssp_container="$(container_name spark-ssp required)"
+for id in 0 1 2; do
+  # Not recorded in the descriptor — the operators are reached over their published ports, not
+  # `docker exec` — but asserted, because an operator that fell over during keyshare generation is
+  # the single most common way this stack comes up half-working, and the resulting SDK failure says
+  # only that a signing round timed out.
+  container_name "spark-operator-$id" required >/dev/null
+done
+# Optional, and deliberately so: no LocalRegtest test drives Core Lightning — `lnd-1` is the
+# counterparty on both sides of the Lightning tests — so a CLN node that is down should cost a warning,
+# not the descriptor. (On macOS the CLN nodes only run at all because up.sh moves their SQLite onto named
+# volumes; see the README.)
+cln_container="$(container_name clightning-1 optional)"
+
+echo "==> reading the SSP identity from http://127.0.0.1:5000/identity"
+# Generated per run from a mnemonic the SSP writes into its own volume, so there is nothing to pin.
+# The fixture's wait-for-spark-ssp already blocked until this endpoint agrees with the SSP's
+# internal /status view, so by the time up.sh returned this is the settled value.
+ssp_identity="$(curl --fail --silent --max-time 15 http://127.0.0.1:5000/identity | jq -er '.identityPublicKey')"
+if ! printf '%s' "$ssp_identity" | grep -Eq '^0[23][0-9a-f]{64}$'; then
+  echo "error: /identity returned '$ssp_identity', which is not a 33-byte compressed pubkey" >&2
+  exit 1
+fi
+echo "    SSP identity $ssp_identity"
+
+echo "==> reading operator certificates out of the ${COMPOSE_PROJECT_NAME}_spark-tls-certs volume"
+# spark-cert-init generates these on first start into a named volume that `start.sh --spark` wipes
+# every run, so they must be read live. Preferred route is `docker exec` into the operator that
+# actually mounts the volume: it needs no extra image and it proves the operator can see the same
+# bytes the client will pin. The `docker run` fallback covers an operator that has exited (a
+# post-mortem descriptor is still useful) by mounting the volume directly.
+read_operator_cert() {
+  local id="$1" cid
+  cid="$(docker compose ps -q "spark-operator-$id" || true)"
+  if [ -n "$cid" ] && docker exec "$cid" cat "/opt/spark/tls/server_$id.crt" 2>/dev/null; then
+    return 0
+  fi
+  docker run --rm -v "${COMPOSE_PROJECT_NAME}_spark-tls-certs:/tls:ro" alpine:3.20 \
+    cat "/tls/server_$id.crt"
+}
+
+operators_json="$(jq -n '[]')"
+for id in 0 1 2; do
+  # Command substitution strips trailing newlines; PEM readers want the last line terminated, and
+  # the Rust reference client hands the SDK the file's bytes verbatim, so restore it.
+  cert="$(read_operator_cert "$id")"$'\n'
+  printf '%s' "$cert" | grep -q 'BEGIN CERTIFICATE' \
+    || { echo "error: server_$id.crt does not look like a PEM certificate" >&2; exit 1; }
+
+  # The client connects to https://localhost:<port> from the host, so `localhost` has to be a name
+  # the certificate covers or the SDK's TLS handshake fails on hostname verification — and the
+  # certificate is the only thing pinned, since there is no CA to fall back on. spark-cert-init
+  # issues each cert with `subjectAltName = DNS:spark-operator-<i>,DNS:spark-operator-<i>.minikube
+  # .local,DNS:localhost`, so it does; this asserts it rather than assuming, because that SAN list
+  # is a line in the fixture's compose file and a bump could drop the localhost entry.
+  if ! printf '%s' "$cert" | openssl x509 -noout -ext subjectAltName 2>/dev/null | grep -q 'DNS:localhost'; then
+    echo "error: server_$id.crt has no DNS:localhost SAN, so a host client cannot verify it." >&2
+    echo "       Check spark-cert-init's -addext subjectAltName in the fixture's docker-compose.yml." >&2
+    exit 1
+  fi
+
+  # Operator identity keys are fixed by the pin — they are the public halves of the committed
+  # keyshares in spark/keys — so they come from the pinned checkout's own operators.json rather
+  # than from a constant duplicated here.
+  identity_public_key="$(jq -er --argjson id "$id" '.[] | select(.id == $id) | .identity_public_key' spark/operators.json)"
+
+  # Identifiers are the FROST participant identifiers: 64 hex digits of (id + 1). The addresses are
+  # the loopback ports the compose file publishes — every operator listens on 8535 inside the
+  # network, mapped to 8535/8536/8537 on the host.
+  operators_json="$(jq \
+    --argjson id "$id" \
+    --arg identifier "$(printf '%064x' $((id + 1)))" \
+    --arg address "https://localhost:$((8535 + id))" \
+    --arg identityPublicKey "$identity_public_key" \
+    --arg caCertPem "$cert" \
+    '. + [{id: $id, identifier: $identifier, address: $address,
+           identityPublicKey: $identityPublicKey, caCertPem: $caCertPem}]' \
+    <<<"$operators_json")"
+done
+
+echo "==> writing $output"
+mkdir -p "$(dirname -- "$output")"
+# jq builds the document so the PEM blocks are escaped correctly; hand-assembled JSON with embedded
+# newlines is the classic way this file ends up unparseable.
+jq -n \
+  --argjson operators "$operators_json" \
+  --arg sspIdentityPublicKey "$ssp_identity" \
+  --arg bitcoindContainer "$bitcoind_container" \
+  --arg lndContainer "$lnd_container" \
+  --arg clnContainer "$cln_container" \
+  --arg sspContainer "$ssp_container" \
+  '{
+    coordinatorIdentifier: "0000000000000000000000000000000000000000000000000000000000000001",
+    threshold: 2,
+    operators: $operators,
+    ssp: {
+      baseUrl: "http://127.0.0.1:5000",
+      identityPublicKey: $sspIdentityPublicKey,
+      schemaEndpoint: "graphql/spark/rc"
+    },
+    esploraUrl: "http://127.0.0.1:30000",
+    fixture: {
+      bitcoindContainer: $bitcoindContainer,
+      bitcoindRpcUser: "cashu",
+      bitcoindRpcPassword: "cashu",
+      lndContainer: $lndContainer,
+      clnContainer: $clnContainer,
+      sspAdminToken: "regtest-spark-admin-token",
+      sspContainer: $sspContainer
+    }
+  }' > "$output"
+
+output_abs="$(cd -- "$(dirname -- "$output")" && pwd)/$(basename -- "$output")"
+echo ""
+echo "Descriptor written. Point the suite at it with:"
+echo ""
+echo "  export SPARK_LOCAL_REGTEST_NETWORK=$output_abs"
+echo ""


### PR DESCRIPTION
## What

A local, fully-owned Spark stack for real-SDK tests, and the plugin seam to point the Breez SDK at it.

- **`e2e/local-regtest/`** — `up.sh` clones [callebtc/cashu-regtest](https://github.com/callebtc/cashu-regtest) at a pinned SHA and starts its `--spark` profile (bitcoind, three Spark operators, [open-ssp](https://github.com/benthecarman/open-ssp), Electrs, ldk-server, plus LND and CLN counterparties); `write-network.sh` discovers the live SSP identity, operator certs and container names into a JSON descriptor; `down.sh` tears down. On macOS `up.sh` writes a compose override so the CLN nodes' SQLite lives on named volumes (Docker Desktop bind mounts refuse lightningd's writes).
- **`Sdk/SparkCustomNetwork.cs`** and `SparkConnectOptions.CustomNetwork` — regtest-only override of the SDK's signing set, SSP and chain source, with every hosted Breez service switched off by name. Refused on mainnet. No merchant-facing path into it.
- **`Tests/LocalRegtest`** (`Category=LocalRegtest`, gated on `SPARK_LOCAL_REGTEST_NETWORK`) — three things Lightspark's hosted regtest cannot exercise: an external LND node pays a Flint invoice and it settles from the Receive leg with no preimage in the scrubbed log; Flint pays an LND invoice and LND shows it settled; a cooperative exit through the sweep engine reaches Confirmed with the exact net amount landing on-chain.
- **`.github/workflows/local-regtest.yml`** — daily, on PRs, on dispatch. Advisory for now: no flake data yet, and cold runs are ~40 min because the fixture builds its images from source each time.

## Why

Both existing live suites talk to Lightspark's hosted regtest, where nothing will pay an invoice the plugin mints, nothing mines on demand, and the funded suite needs a faucet-filled wallet behind a repository secret. This stack has real counterparties on both sides, deterministic mining, and no secrets. The hosted daily job stays: it is the only thing that catches drift in the SSP real merchants use.

## Verified

| check | result |
|---|---|
| default unit suite | 1250 passed, 0 failed (22 new) |
| full `down → up → write-network → dotnet test` cycle from a fresh clone, Apple Silicon | 3/3 LocalRegtest in 19 s |
| fixture's own acceptance tests during that start | all passed |

## Observed against open-ssp (differs from Lightspark)

- Exit and claim fees track the chain estimator, which the fixture drives to ~100 sat/vB; the sweep test quotes first and sizes from the quote.
- A send with no timeout returns Pending → `PayResult.Unknown`; a completed send carries no preimage on the response, only via `GetPayment`.
- SSP Spark liquidity (one 500,000-sat leaf) is the real budget; the fixture returns funds on teardown.

## Follow-ups (in progress on a stacked branch)

1. Prebuild the four source-built images to ghcr once per pin so the job drops to minutes.
2. Make this suite a hard pre-release gate.
3. Stage 2: BTCPay in Docker with the plugin, Greenfield creates the invoice, LND pays it, assert Settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
