### PR TITLE
Release gate on the local Spark stack, prebuilt fixture images, BTCPay e2e layer

### DIFF
--- a/.github/workflows/local-regtest-images.yml
+++ b/.github/workflows/local-regtest-images.yml
@@ -1,0 +1,195 @@
+name: Local regtest images
+
+# Builds the four images the local Spark stack would otherwise compile from source on every run, and
+# pushes them to this repository's GitHub Container Registry namespace so
+# .github/workflows/local-regtest.yml (and a developer running e2e/local-regtest/up.sh) can pull them
+# instead.
+#
+# WHY this workflow exists at all. callebtc/cashu-regtest publishes no images: its compose file carries
+# `build:` sections for the Spark operators (Rust), open-ssp (Go), Electrs (Rust) and ldk-server (Rust),
+# and a hosted runner gets a clean machine with no Docker layer cache, so `local-regtest.yml` paid that
+# compile — around 40 minutes — on every single run. That cost is the whole reason that job was advisory
+# rather than a gate. Building once per pinned fixture SHA and pulling thereafter is what makes it cheap
+# enough for package.yml to block a release on (see docs/ci-and-releases.md).
+#
+# ONE SOURCE OF TRUTH for the fixture revision: `CASHU_REGTEST_SHA` in e2e/local-regtest/up.sh. This
+# workflow greps it out of that file rather than carrying its own copy, so the images can only ever be
+# built from the revision up.sh will verify its checkout against. (local-regtest.yml's own `ref:` is the
+# third copy, and up.sh fails loudly when it drifts — that is the check that keeps all three honest.)
+#
+# ONE SOURCE OF TRUTH for the image set: `docker compose --profile spark config`. The services that need
+# building, and the exact local image name each one expects, are read out of the pinned compose file
+# rather than hardcoded here, because that is also how up.sh decides what to pull and what to tag it as.
+# Hardcoding either side would let the two disagree silently — compose would just rebuild, and the only
+# symptom would be a 40-minute "fast" run. Services are deduplicated by image: `ldk` and `ldk-fee` share
+# one image, as do the three operators, so four targets cover seven services.
+#
+# linux/amd64 ONLY, deliberately. Hosted runners are amd64 and that is what CI needs. An arm64 variant
+# would have to cross-build several large Rust projects under QEMU, which takes hours rather than
+# minutes; arm64 developers (Apple silicon) build locally once and keep the layers, which is the same
+# trade the fixture itself makes. up.sh skips the pull entirely on a non-amd64 host for this reason —
+# pulling an amd64 operator onto arm64 would "work" and then run the whole stack under emulation.
+#
+# The packages must be PUBLIC for a fork's `local-regtest.yml` to pull them without credentials. GitHub
+# creates a package private-by-default on its first push; making it public is a one-time repository
+# settings change (Packages → the package → Package settings → Change visibility). up.sh degrades to
+# building from source when a pull fails, so a private package is slow, not broken.
+
+on:
+  # The normal trigger. Publishing is a deliberate act tied to a pin bump, not something that should
+  # happen on unrelated pushes.
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      # up.sh is where the pin lives, so a merged pin bump republishes the set for the new SHA. The
+      # workflow itself is here so a change to how images are built is exercised on merge.
+      - .github/workflows/local-regtest-images.yml
+      - e2e/local-regtest/up.sh
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build & push the fixture images
+    runs-on: ubuntu-latest
+    # Cold, this compiles four Rust/Go projects on one runner. The fixture's own CI allows 90 minutes
+    # for a build plus a full stack run; this does only the build half, but with no layer cache on a
+    # first run for a new pin, so it gets the same allowance.
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write  # the only job in this repository that writes to the registry
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # No submodules and no .NET here: this job never builds the plugin. The btcpayserver
+          # submodule is the single largest thing this repository checks out, and skipping it is
+          # worth minutes.
+          fetch-depth: 1
+
+      # Grepped rather than duplicated. Anchored on the exact assignment so a renamed variable or a
+      # short SHA fails here instead of checking out something unintended: `actions/checkout` accepts
+      # almost anything as a `ref`, including a branch name that happens to look like a prefix.
+      - name: Read the pinned fixture SHA out of up.sh
+        id: pin
+        run: |
+          set -euo pipefail
+          sha="$(sed -n 's/^CASHU_REGTEST_SHA="\([0-9a-f]\{40\}\)"$/\1/p' e2e/local-regtest/up.sh)"
+          if [ -z "$sha" ]; then
+            echo "error: could not read a 40-hex CASHU_REGTEST_SHA out of e2e/local-regtest/up.sh." >&2
+            echo "       That assignment is this workflow's only input; fix the grep or the script." >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Fixture pin: $sha"
+
+      - name: Check out the cashu-regtest fixture at the pinned SHA
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: callebtc/cashu-regtest
+          ref: ${{ steps.pin.outputs.sha }}
+          path: cashu-regtest
+          persist-credentials: false
+
+      # Produces a buildx bake override file next to the compose file. Bake reads the compose file's
+      # `build:` sections natively — contexts, build args, and the inline Dockerfile `ldk` uses, which
+      # no `docker/build-push-action` invocation could express — and this override only replaces each
+      # target's tags and adds the platform and cache settings.
+      #
+      # The cache scope is per image name rather than shared: one scope for four unrelated Rust/Go
+      # builds would have them evicting each other out of a 10 GB repository cache budget.
+      - name: Derive the bake targets from the pinned compose file
+        id: targets
+        working-directory: cashu-regtest
+        env:
+          # Lowercased: a GHCR path segment must be lowercase, and `github.repository_owner` preserves
+          # whatever case the account was created with.
+          OWNER: ${{ github.repository_owner }}
+          PIN: ${{ steps.pin.outputs.sha }}
+          # The Spark services are behind a compose profile; `config` omits them without this.
+          COMPOSE_PROFILES: spark
+          COMPOSE_PROJECT_NAME: cashu
+        run: |
+          set -euo pipefail
+          prefix="ghcr.io/$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')/flint-regtest"
+          docker compose config --format json \
+            | jq --arg prefix "$prefix" --arg pin "$PIN" '
+                # One target per distinct local image: ldk/ldk-fee share one, the three operators
+                # share one. Building a target twice would only hit cache, but pushing the same ref
+                # twice from two targets is a race nobody needs.
+                [ .services | to_entries[] | select(.value.build != null) ]
+                | group_by(.value.image) | map(.[0]) as $targets
+                | {
+                    target: ( $targets | map({
+                        (.key): {
+                          tags: [ $prefix + "/" + (.value.image | split(":")[0]) + ":" + $pin ],
+                          platforms: [ "linux/amd64" ],
+                          "cache-from": [ "type=gha,scope=" + (.value.image | split(":")[0]) ],
+                          "cache-to": [ "type=gha,mode=max,scope=" + (.value.image | split(":")[0]) ]
+                        }
+                      }) | add ),
+                    _names: ( $targets | map(.key) )
+                  }' > bake-override.json
+          jq -e '._names | length == 4' bake-override.json > /dev/null || {
+            echo "error: expected exactly four buildable images in the spark profile; got:" >&2
+            jq -r '._names[]' bake-override.json >&2
+            echo "       The fixture's compose file changed shape. Re-read it, then update this" >&2
+            echo "       assertion and e2e/local-regtest/up.sh's pull list together." >&2
+            exit 1
+          }
+          # `_names` is not a bake key, so it has to come out before bake reads the file.
+          names="$(jq -r '._names | join(" ")' bake-override.json)"
+          jq 'del(._names)' bake-override.json > bake-override.tmp
+          mv bake-override.tmp bake-override.json
+          echo "names=$names" >> "$GITHUB_OUTPUT"
+          echo "Targets: $names"
+          jq -r '.target | to_entries[] | "  \(.key) -> \(.value.tags[0])"' bake-override.json
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      # GITHUB_TOKEN with `packages: write` is enough; there is no registry secret to hold.
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # bake-action rather than build-push-action: the compose file is the build definition (one target
+      # uses an inline Dockerfile and a git-URL context), and bake is the only front end that consumes
+      # it. It is also what exports the GitHub Actions cache credentials the `type=gha` backend needs —
+      # a bare `docker buildx bake` in a `run:` step cannot see them.
+      - name: Build and push
+        uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
+        with:
+          workdir: cashu-regtest
+          files: |
+            docker-compose.yml
+            bake-override.json
+          targets: ${{ steps.targets.outputs.names }}
+          push: true
+
+      - name: Summarise what was published
+        working-directory: cashu-regtest
+        env:
+          PIN: ${{ steps.pin.outputs.sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "### Fixture images published"
+            echo ""
+            echo "Fixture pin: \`$PIN\`"
+            echo ""
+            jq -r '.target | to_entries[] | "- `" + .value.tags[0] + "`  (compose service `" + .key + "`)"' \
+              bake-override.json
+            echo ""
+            echo "\`e2e/local-regtest/up.sh\` pulls these and retags them to the local names the"
+            echo "pinned compose file expects, which is what makes it skip the source build."
+            echo ""
+            echo "If a fork cannot pull them, the packages are still private:"
+            echo "make each one public under the repository's Packages settings."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/local-regtest.yml
+++ b/.github/workflows/local-regtest.yml
@@ -131,11 +131,18 @@ jobs:
 
       # Same key as every job in ci.yml, exact on the csproj hashes with no `restore-keys` prefix
       # fallback, so a warm cache from a different dependency set is never adopted.
+      #
+      # `!e2e/**` is not in ci.yml's key and does not change it: e2e/ holds no csproj, so the hashed file
+      # set is identical. It is here because hashFiles is evaluated TWICE — once at restore, once in the
+      # action's post step at the end of the job — and by then e2e/ contains the fixture checkout and
+      # the BTCPay data directory, with files the containers wrote as root that the runner user cannot
+      # read. Walking into them made the post-step hash fail ("Fail to hash files under directory") on
+      # this workflow's first green run, which lost the cache save and put a red step on a passing job.
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '!e2e/**') }}
 
       - name: Build (plugin + tests)
         # -m:1 serialises MSBuild project scheduling. Not for speed obviously, but for correctness:

--- a/.github/workflows/local-regtest.yml
+++ b/.github/workflows/local-regtest.yml
@@ -1,6 +1,6 @@
 name: Local regtest
 
-# Runs the LocalRegtest suite against a Spark stack this workflow stands up itself:
+# Runs the LocalRegtest and BtcpayE2E suites against a Spark stack this workflow stands up itself:
 # callebtc/cashu-regtest's `--spark` profile — Bitcoin Core, three Spark operators, open-ssp, Electrs,
 # and three LND plus three CLN nodes as external Lightning counterparties.
 #
@@ -12,13 +12,20 @@ name: Local regtest
 # confirmations are a `bitcoin-cli -generate` away, and every credential is a published fixture value. It
 # is the only job that exercises settlement end to end with no third-party service and no secret.
 #
-# COST, and it is not small: the fixture publishes no images, so every run builds the Spark operators
-# (Rust and Go), Electrs, open-ssp and ldk-server from source. Cold, that is around 40 minutes on
-# ubuntu-latest — the number the fixture's own spark-regtest job takes — and GitHub gives each job a clean
-# runner with no Docker layer cache, so it is cold every time. The 90-minute timeout matches the fixture's.
-# FOLLOW-UP: build these images once per pinned SHA and push them to ghcr.io, then have this job pull them.
-# That turns 40 minutes into a few and is the difference between this being a daily signal and a per-PR
-# gate. Doing it now would mean maintaining a publish workflow before the suite has proven its worth.
+# It runs the suites in two layers against the same stack. `LocalRegtest` drives the Breez SDK directly,
+# so a failure there is the plugin's SDK wiring. `BtcpayE2E` then stands up a real BTCPay Server in Docker
+# with this plugin side-loaded and drives it over the Greenfield API, so a failure there is the plugin as
+# BTCPay actually hosts it — store Lightning method, invoice lifecycle, the sweep endpoint. The second
+# layer is the one that catches a plugin which loads in a test host but not in the product.
+#
+# COST. The fixture publishes no images, so compose would build the Spark operators (Rust and Go), Electrs,
+# open-ssp and ldk-server from source: around 40 minutes on ubuntu-latest, cold every time, because GitHub
+# gives each job a clean runner with no Docker layer cache. .github/workflows/local-regtest-images.yml now
+# builds that set once per pinned fixture SHA and pushes it to ghcr.io, and up.sh pulls and retags it so
+# compose skips the build — which is what took this from a ~40-minute daily signal to a ~10-15-minute job
+# cheap enough for package.yml to block a release on. up.sh falls back to building when a pull fails (a
+# fork whose packages are private, an arm64 host), so the 90-minute timeout still has to cover the cold
+# case.
 
 on:
   # Daily, for the same reason ci.yml runs daily: the Breez SDK is pre-1.0 and open-ssp moves, so drift in
@@ -27,6 +34,21 @@ on:
     - cron: "0 6 * * *"  # 06:00 UTC daily, an hour after ci.yml, so the two do not contend for runners
   pull_request:
   workflow_dispatch: {}
+  # Called by .github/workflows/package.yml on a `v*` tag, so a release cannot be packaged over a red
+  # stack. See docs/ci-and-releases.md for the gating rule this and the job below encode.
+  #
+  # `blocking` exists because `github.event_name` CANNOT be used to detect being called: inside a reusable
+  # workflow it reports the *caller's* triggering event ("push", for a tag build), never "workflow_call".
+  # An input is the only honest signal, and defaulting it to true means a caller has to opt out of the
+  # gate rather than remember to opt in. On every other trigger the `inputs` context is empty, so
+  # `inputs.blocking` reads as null — falsy — which is exactly the advisory behaviour those triggers want.
+  workflow_call:
+    inputs:
+      blocking:
+        description: "Fail the calling workflow if the stack or either suite fails."
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -44,21 +66,42 @@ env:
 
 jobs:
   local-regtest:
-    name: LocalRegtest suite (local Spark stack)
+    name: LocalRegtest + BtcpayE2E suites (local Spark stack)
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    # ADVISORY ON EVERY TRIGGER FOR NOW, deliberately, and for the reason integration-test's comment gives
-    # for itself: there is no measured flake rate. This suite has a lot of moving parts that are nobody's
-    # product — a source build of six services, a FROST keyshare generation that startup polls for, channel
-    # gossip that has to propagate before a payment can route — and a flaky *fixture* blocking merges would
-    # be worse than the gap it closes. Unlike integration-test the dependency is not a third-party service,
-    # so a red run here is more likely to be our bug, which is the argument for eventually flipping it:
+    # BLOCKING on the two paths where a red stack must stop something, ADVISORY everywhere else.
     #
-    #     continue-on-error: ${{ github.event_name != 'pull_request' }}
+    # Blocking when `inputs.blocking` is true, which is the release path: package.yml calls this workflow
+    # on a `v*` tag and takes the default (true), so a failure here fails that job, and `package` never
+    # runs. Cutting a release over a stack that cannot settle a payment is the one case where carrying on
+    # is indefensible — and a release is also the moment a human is definitely present to re-run a
+    # transient failure.
+    #
+    # Blocking on a `release/*` head branch, which is the same gate one step earlier: this repository
+    # releases by merging a `release/vX.Y.Z` branch through a PR (see git log), so the release PR is where
+    # a maintainer would rather learn about a broken stack than at tag time. `github.head_ref` is only set
+    # on `pull_request`, and casts to '' elsewhere, so this term is inert on schedule and dispatch.
+    #
+    # Advisory everywhere else — ordinary PRs, the daily schedule, manual dispatch — for the reason
+    # integration-test's comment gives for itself: there is no measured flake rate. This has a lot of
+    # moving parts that are nobody's product (six services, a FROST keyshare generation startup polls for,
+    # channel gossip that must propagate before a payment can route, and now a BTCPay container on top),
+    # and a flaky *fixture* blocking every merge would be worse than the gap it closes. Unlike
+    # integration-test the dependency is not a third-party service, so a red run here is likelier to be our
+    # bug — which is the argument for eventually promoting the ordinary-PR case too:
+    #
+    #     continue-on-error: ${{ !(inputs.blocking || github.event_name == 'pull_request') }}
     #
     # Let the daily schedule accumulate a few weeks of pass/fail first, exactly as `funded-regtest-test`
     # earned its PR gate. Until then someone has to read the run summary. See docs/ci-and-releases.md.
-    continue-on-error: true
+    continue-on-error: ${{ !(inputs.blocking || startsWith(github.head_ref, 'release/')) }}
+    # `packages: read` is only for pulling the prebuilt fixture images from this repository's GHCR
+    # namespace while those packages are still private (they are private on first push, and making them
+    # public is a one-time settings change). Declared at job level because a job in a workflow called by
+    # package.yml takes its permissions from the calling job, not from this file — see package.yml.
+    permissions:
+      contents: read
+      packages: read
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -106,7 +149,26 @@ jobs:
         # properties, not removing this flag and hoping the timing holds.
         run: dotnet build BTCPayServer.Plugins.Flint.slnx --configuration Release -m:1
 
+      # Lets up.sh pull the prebuilt fixture images while those GHCR packages are private. Public
+      # packages need no credentials at all, and a fork PR gets a token that cannot read this
+      # repository's packages either way — in both of those cases up.sh falls back to building from
+      # source, which is slow but correct, so this step is a cost optimisation and never a dependency.
+      - name: Log in to GHCR (for the prebuilt fixture images)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Runs the build before the stack on purpose: a compile error should cost two minutes, not forty.
+      #
+      # up.sh pulls the four prebuilt images from ghcr.io and retags them to the local names the pinned
+      # compose file expects, so compose skips the source build; it warns and builds when a pull fails.
+      # Then it runs the fixture's init chain minus the fee-hub wait (not its `start.sh`, which also runs the
+      # fixture's own acceptance suites and would rebuild its Rust test client here) and asserts the
+      # three things the suites depend on: a live SSP with Spark liquidity, six ready LDK channels, and
+      # every Lightning node at bitcoind's tip.
       - name: Start the local Spark stack
         env:
           # Reuse the checkout above instead of letting up.sh clone a second copy. up.sh still verifies
@@ -135,6 +197,28 @@ jobs:
           --configuration Release --no-build --filter "Category=LocalRegtest"
           --output Detailed
 
+      # Stage 2 starts here: the same stack, now with the product on top of it. e2e/btcpay/up.sh builds
+      # the plugin, starts BTCPay Server + NBXplorer + Postgres joined to the fixture's own docker network
+      # (so NBXplorer talks to the fixture's bitcoind), side-loads the plugin, provisions an admin, a store
+      # and an API key through Greenfield, points the store's Lightning method at Flint, funds the wallet,
+      # and writes e2e/btcpay/btcpay.json describing all of it.
+      #
+      # Separate from the stack step rather than folded into up.sh: this half is worth failing on its own,
+      # and a BTCPay that will not start is a different diagnosis from a Spark stack that will not.
+      - name: Start BTCPay Server against the local Spark stack
+        run: e2e/btcpay/up.sh
+
+      # Greenfield-level coverage: an invoice lnd-1 pays and BTCPay reports Settled, a payment BTCPay
+      # makes to lnd-1, and the store's sweep endpoint reaching Confirmed after a block. Same
+      # --output Detailed and same sequential-collection reasoning as the suite above.
+      - name: BtcpayE2E suite
+        env:
+          FLINT_BTCPAY_E2E: ${{ github.workspace }}/e2e/btcpay/btcpay.json
+        run: >
+          dotnet test BTCPayServer.Plugins.Flint.Tests/BTCPayServer.Plugins.Flint.Tests.csproj
+          --configuration Release --no-build --filter "Category=BtcpayE2E"
+          --output Detailed
+
       # A failure in this job is almost never legible from the .NET output alone: the interesting evidence
       # is which of six services fell over. `ps -a` includes exited containers, which is the common case —
       # an operator that crashed during keyshare generation looks, from the test's side, like a timeout.
@@ -151,6 +235,17 @@ jobs:
             docker compose logs --tail=400 --no-color "$service" \
               > "${{ github.workspace }}/local-regtest-logs/$service.log" 2>&1 || true
           done
+          # The stage-2 containers belong to a different Compose project, and this step is inside the
+          # fixture's, so they are matched by container name rather than by service: `docker logs` needs
+          # no project context, and matching by name keeps working if e2e/btcpay renames its project.
+          # A plugin that failed to load says so in BTCPay's own startup log and nowhere else, which is
+          # the single most valuable thing in this whole artefact when stage 2 is what went red.
+          docker ps -a --format '{{.Names}}' \
+            | grep -E 'btcpay|nbxplorer' \
+            | while IFS= read -r container; do
+                docker logs --tail=400 "$container" \
+                  > "${{ github.workspace }}/local-regtest-logs/$container.log" 2>&1 || true
+              done || true
           tail -n 60 "${{ github.workspace }}/local-regtest-logs/"*.log || true
 
       # Only on failure: on a green run these logs are tens of MB of routine chatter, and unlike
@@ -165,6 +260,13 @@ jobs:
           path: local-regtest-logs/
           if-no-files-found: warn
           retention-days: 14
+
+      # Before the fixture's teardown, always: these containers are attached to the fixture's docker
+      # network, and `compose down` on the fixture cannot remove a network something else is still joined
+      # to — it fails, leaves the network behind, and the next run on a self-hosted runner inherits it.
+      - name: Tear BTCPay Server down
+        if: always()
+        run: e2e/btcpay/down.sh || true
 
       # always(), so a cancelled or timed-out run does not leave containers holding the runner's disk. On a
       # hosted runner the runner is discarded anyway; this matters for self-hosted ones and costs seconds.

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,6 +10,23 @@ name: Package
 # cutting a release (e.g. to sanity-check packaging changes before tagging).
 #
 # ---------------------------------------------------------------------------------------------
+# Release gate: a `v*` tag runs the whole local Spark stack first.
+#
+# `local-regtest` below calls .github/workflows/local-regtest.yml, which stands up the cashu-regtest
+# `--spark` fixture, runs the LocalRegtest suite against the Breez SDK and the BtcpayE2E suite against
+# a real BTCPay Server with this plugin side-loaded, and — because it is called with its `blocking`
+# input at the default of true — fails rather than reporting advisory-green. `package` needs it, so a
+# tag cannot produce a signed release over a plugin that cannot settle a payment. That gate is only
+# affordable because the fixture's images are prebuilt and pulled
+# (.github/workflows/local-regtest-images.yml): ~10-15 minutes, against ~40+ if a pull falls back to
+# building from source.
+#
+# It is deliberately scoped to tags. workflow_dispatch exists to inspect a packaged artifact quickly,
+# and making every dispatch pay a quarter-hour of Docker would defeat the reason it exists — so the
+# gate job skips off-tag, and `package` accepts a skipped need explicitly. It refuses to accept a
+# failed or cancelled one.
+#
+# ---------------------------------------------------------------------------------------------
 # Signing: keyless build provenance, not a maintainer GPG key.
 #
 # The obvious precedent is the Boltz BTCPay plugin, which GPG-signs SHA256SUMS in CI with a
@@ -82,9 +99,33 @@ env:
   PROJECT_PATH: BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj
 
 jobs:
+  # The release gate. See the note at the top of this file for the scoping argument.
+  local-regtest:
+    name: Local regtest gate
+    # Tags only. A `refs/tags/v*` push is the release path; a workflow_dispatch is an inspection build.
+    if: startsWith(github.ref, 'refs/tags/v')
+    uses: ./.github/workflows/local-regtest.yml
+    # A job that calls a reusable workflow takes its permissions from HERE, not from the called file's
+    # own `permissions:` block, which is ignored. contents: read to check out; packages: read so up.sh can
+    # pull the prebuilt fixture images while those GHCR packages are private. Deliberately none of this
+    # workflow's write scopes: nothing in that stack should be able to attest or publish anything.
+    permissions:
+      contents: read
+      packages: read
+    # No `secrets: inherit`: every credential in the fixture is a published regtest value, and the suites
+    # generate their own wallets. Passing the release job's secrets into a stack that runs six
+    # third-party container images would be handing them out for nothing.
+
   package:
     name: Build & package plugin
     runs-on: ubuntu-latest
+    needs: [local-regtest]
+    # `always()` is what lets the gate be tag-scoped: without it a skipped `local-regtest` (every
+    # workflow_dispatch) would skip `package` too, since a skipped need is not a satisfied one. The
+    # explicit result check is the actual gate — 'failure' and 'cancelled' both stop the release, and
+    # listing the two acceptable results rather than negating the unacceptable ones means a result GitHub
+    # adds later fails closed.
+    if: always() && (needs.local-regtest.result == 'success' || needs.local-regtest.result == 'skipped')
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ TESTING.local.md
 e2e/local-regtest/cashu-regtest/
 e2e/local-regtest/network.json
 e2e/local-regtest/up.log
+
+# Local BTCPay e2e stack (e2e/btcpay): the handoff file the up.sh script writes (it holds a live
+# API key), the staged plugin copy and the in-network Spark descriptor it mounts into the
+# container, and the --docker descriptor write-network.sh emits. All per-run artifacts of a
+# fixture down.sh destroys.
+e2e/local-regtest/network.docker.json
+e2e/btcpay/btcpay.json
+e2e/btcpay/data/

--- a/BTCPayServer.Plugins.Flint.Tests/BtcpayE2E/BtcpayE2EStack.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/BtcpayE2E/BtcpayE2EStack.cs
@@ -1,0 +1,346 @@
+using System.Globalization;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using BTCPayServer.Plugins.Flint.Tests.LocalRegtest;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests.BtcpayE2E;
+
+/// <summary>
+/// A live BTCPay Server running the Flint plugin against the local Spark stack, shared by the whole
+/// <c>BtcpayE2E</c> suite and driven only over Greenfield.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>What this adds over the LocalRegtest suite.</b> That suite builds the plugin's collaborators by hand
+/// and connects an SDK instance of its own, which is enough to prove the money paths and the reconciler but
+/// leaves out everything that only exists inside a host: BTCPay's invoice lifecycle and the transition to
+/// <c>Settled</c>, the Lightning payment-method wiring the provisioner writes, the Greenfield surface's own
+/// authorisation and store scoping, the reconciliation and sweep tasks running as hosted services on
+/// BTCPay's schedule, and the plugin loading at all — as a directory under the data dir, out of the official
+/// image, with Breez's native library resolved by BTCPay's own plugin load context. A green LocalRegtest run
+/// says nothing about any of those.
+/// </para>
+/// <para>
+/// <b>Nothing here reaches inside.</b> Every assertion is made through an HTTP call an operator could make,
+/// or against the fixture's own bitcoind and LND. There is no in-process handle on the plugin: the point is
+/// to observe it the way a host does.
+/// </para>
+/// <para>
+/// <b>Gating.</b> Opt-in on <c>FLINT_BTCPAY_E2E</c> holding the path to the <c>btcpay.json</c> that
+/// <c>e2e/btcpay/up.sh</c> writes. Absent, every test in the collection skips and this fixture starts
+/// nothing: the stack takes minutes to bring up and needs the Spark fixture under it, so it is a deliberate
+/// act and never a side effect of running the unit suite.
+/// </para>
+/// <para>
+/// <b>Serialised.</b> One store, one wallet, three tests that each move its money, and one chain whose
+/// height they all advance — hence a collection fixture with parallelisation disabled.
+/// </para>
+/// </remarks>
+public sealed class BtcpayE2EStack : IAsyncLifetime
+{
+    public const string CollectionName = "Flint on a live BTCPay Server";
+
+    /// <summary>Environment variable holding the path to <c>e2e/btcpay/btcpay.json</c>.</summary>
+    public const string EnvironmentVariable = "FLINT_BTCPAY_E2E";
+
+    /// <summary>
+    /// The balance every test leaves behind for the others, in satoshis.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The tests do not run in a guaranteed order, so the sweep sizes itself to leave this much rather than
+    /// draining — the same reasoning as the LocalRegtest suite's exit margin, and the reason
+    /// <c>up.sh</c> configures the store with <c>enabled: false</c>: an automatic pass firing between two
+    /// tests would move money nobody asked it to.
+    /// </para>
+    /// <para>
+    /// <b>Small on purpose, and this number has a running cost.</b> It covers a 2,000-sat receive and a
+    /// 3,000-sat send with room for their Lightning fees, and nothing more, because whatever is left when
+    /// the containers go is <em>stranded</em>: a cooperative exit on this fixture costs around 20,000 sats,
+    /// so a remainder under roughly 60,000 is refused by the fee guard — correctly — and stays in a wallet
+    /// whose storage <c>down.sh</c> destroys. That leftover comes out of the SSP's own leaves. Measured: a
+    /// 60,000-sat reserve took the fixture's SSP from 500,000 to 382,000 across two runs, which is about a
+    /// dozen runs before its liquidity needs topping up. At 15,000 it is nearer forty.
+    /// </para>
+    /// </remarks>
+    public const long ReserveForOtherTestsSats = 15_000;
+
+    public static string SkipReason =>
+        $"Set {EnvironmentVariable} to the path of the btcpay.json that e2e/btcpay/up.sh writes to run the "
+        + "BTCPay end-to-end suite. See docs/testing.md: bring the Spark stack up with "
+        + "e2e/local-regtest/up.sh, then e2e/btcpay/up.sh.";
+
+    /// <summary>True when the variable names a file. The gate for the whole suite.</summary>
+    public static bool IsEnabled =>
+        Environment.GetEnvironmentVariable(EnvironmentVariable) is { } path
+        && !string.IsNullOrWhiteSpace(path);
+
+    private readonly CancellationTokenSource _setup = new(TimeSpan.FromMinutes(5));
+    private HttpClient? _http;
+
+    /// <summary>Greenfield, with the store's API key already attached. Only valid when enabled.</summary>
+    public BtcpayGreenfield Api { get; private set; } = null!;
+
+    /// <summary>bitcoind and LND, over <c>docker exec</c> — the same helper the LocalRegtest suite uses.</summary>
+    public RegtestControl Control { get; private set; } = null!;
+
+    /// <summary>The store <c>up.sh</c> provisioned.</summary>
+    public string StoreId { get; private set; } = null!;
+
+    /// <summary>The balance the store held when the suite started, for the run log.</summary>
+    public long StartingBalanceSats { get; private set; }
+
+    public async ValueTask InitializeAsync()
+    {
+        if (Environment.GetEnvironmentVariable(EnvironmentVariable) is not { } path
+            || string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(path, _setup.Token));
+        var root = document.RootElement;
+
+        string Required(string name) =>
+            root.TryGetProperty(name, out var value) && value.GetString() is { Length: > 0 } text
+                ? text
+                : throw new InvalidOperationException(
+                    $"{path} is missing `{name}`. It was probably written by an older e2e/btcpay/up.sh; "
+                    + "re-run e2e/btcpay/down.sh then e2e/btcpay/up.sh.");
+
+        var baseUrl = Required("baseUrl");
+        var apiKey = Required("apiKey");
+        StoreId = Required("storeId");
+
+        _http = new HttpClient { BaseAddress = new Uri(baseUrl), Timeout = TimeSpan.FromMinutes(3) };
+        // `token <key>`, BTCPay's own scheme for an API key. Not Bearer, and not Basic: the key is not a
+        // password and BTCPay rejects it as one.
+        _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("token", apiKey);
+        Api = new BtcpayGreenfield(_http, StoreId);
+
+        Control = new RegtestControl(ReadFixture(path, root));
+        await Control.InitialiseAsync(_setup.Token);
+
+        // Both halves proved before any test runs, because the two failures need different fixes and neither
+        // is legible from a payment test that simply times out.
+        using var health = await Api.GetAsync("/api/v1/health", _setup.Token);
+        Assert.True(
+            health.RootElement.TryGetProperty("synchronized", out _)
+            || health.RootElement.ValueKind is JsonValueKind.Object,
+            $"{baseUrl}/api/v1/health did not answer with a health document.");
+
+        using var status = await Api.GetStoreAsync("/spark", _setup.Token);
+        var configured = status.RootElement.GetProperty("configured").GetBoolean();
+        var running = status.RootElement.GetProperty("walletRunning").GetBoolean();
+        if (!configured || !running)
+        {
+            Assert.Fail(
+                $"store {StoreId} on {baseUrl} does not have a running Flint wallet (configured: "
+                + $"{configured}, walletRunning: {running}, walletError: "
+                + $"{Text(status.RootElement, "walletError") ?? "none"}). Re-run e2e/btcpay/up.sh, and read "
+                + "`docker compose -f e2e/btcpay/docker-compose.yml logs flint-e2e-btcpay`.");
+        }
+
+        StartingBalanceSats = status.RootElement.TryGetProperty("balanceSats", out var balance)
+                              && balance.ValueKind is JsonValueKind.Number
+            ? balance.GetInt64()
+            : 0;
+
+        Console.WriteLine(
+            $"btcpay-e2e: store {StoreId} on {baseUrl}, wallet running, balance "
+            + $"{StartingBalanceSats.ToString("N0", CultureInfo.InvariantCulture)} sats, Lightning wiring "
+            + $"{Text(status.RootElement, "lightningWiring") ?? "unknown"}");
+    }
+
+    /// <summary>Fails with an explanation unless the store's balance can cover <paramref name="needSats"/>.</summary>
+    /// <remarks>
+    /// A drained wallet here means an earlier test in the run spent more than it was sized for, which is a
+    /// bug in this suite rather than something a maintainer tops up — so it is an assertion and not a runbook
+    /// step. The balance is read from the plugin's own status endpoint, which
+    /// <c>docs/greenfield-api.md</c> warns is indicative: it lags settlement by around 20 s. That is
+    /// tolerable for a floor check and is why nothing else in this suite reconciles against it.
+    /// </remarks>
+    public async Task RequireBalanceAsync(long needSats, string what, CancellationToken cancellationToken)
+    {
+        using var status = await Api.GetStoreAsync("/spark", cancellationToken);
+        var balance = status.RootElement.TryGetProperty("balanceSats", out var value)
+                      && value.ValueKind is JsonValueKind.Number
+            ? value.GetInt64()
+            : 0;
+
+        if (balance < needSats)
+        {
+            Assert.Fail(
+                $"{what} needs {needSats:N0} sats and the store holds {balance:N0}. It started this run with "
+                + $"{StartingBalanceSats:N0}, so something in this run spent more than it should have; the "
+                + $"amounts in {nameof(BtcpayE2ETests)} are sized to fit inside the funding together, and the "
+                + $"sweep leaves {ReserveForOtherTestsSats:N0} behind on purpose.");
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        // Nothing to give back. Unlike the LocalRegtest fixture, this suite's wallet is not created per run:
+        // it belongs to the store e2e/btcpay/up.sh provisioned, and e2e/btcpay/down.sh is what returns the
+        // SSP's liquidity — by destroying the wallet's storage along with the containers. Sweeping here
+        // instead would spend a cooperative-exit fee on every run for no gain.
+        _http?.Dispose();
+        _setup.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    private static string? Text(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind is JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    /// <summary>
+    /// Reads the <c>fixture</c> block, which <c>up.sh</c> copies verbatim out of the Spark descriptor.
+    /// </summary>
+    /// <remarks>
+    /// The same shape <c>network.json</c> carries and the same reader shape the LocalRegtest fixture uses, so
+    /// <see cref="RegtestControl"/> is reused unchanged rather than reimplemented against a second contract.
+    /// </remarks>
+    private static LocalRegtestFixtureInfo ReadFixture(string path, JsonElement root)
+    {
+        if (!root.TryGetProperty("fixture", out var fixture))
+        {
+            throw new InvalidOperationException(
+                $"{path} has no `fixture` block, so there is no way to reach the stack's bitcoind or its "
+                + "Lightning nodes. Regenerate it with e2e/btcpay/up.sh.");
+        }
+
+        string Required(string name) =>
+            fixture.TryGetProperty(name, out var value) && value.GetString() is { Length: > 0 } text
+                ? text
+                : throw new InvalidOperationException($"{path}: the fixture block is missing {name}.");
+
+        string? Optional(string name) =>
+            fixture.TryGetProperty(name, out var value) ? value.GetString() : null;
+
+        return new LocalRegtestFixtureInfo(
+            Required("bitcoindContainer"),
+            Required("bitcoindRpcUser"),
+            Required("bitcoindRpcPassword"),
+            Required("lndContainer"),
+            Optional("clnContainer"),
+            Optional("sspContainer"),
+            Optional("sspAdminToken"));
+    }
+}
+
+/// <summary>
+/// The Greenfield calls this suite makes, and nothing else.
+/// </summary>
+/// <remarks>
+/// A deliberately thin wrapper over <see cref="HttpClient"/> rather than BTCPay's own generated client. Two
+/// reasons. The plugin's endpoints are not in that client at all — they are this plugin's, and driving them
+/// the way <c>docs/greenfield-api.md</c> tells a merchant to drive them is part of what is under test. And a
+/// failing call has to explain itself: every non-success answer here carries the method, the path, the status
+/// code and BTCPay's own response body, which is where the reason actually is.
+/// </remarks>
+public sealed class BtcpayGreenfield
+{
+    private readonly HttpClient _http;
+    private readonly string _storeId;
+
+    public BtcpayGreenfield(HttpClient http, string storeId)
+    {
+        _http = http;
+        _storeId = storeId;
+    }
+
+    /// <summary>A store-scoped path, e.g. <c>/spark/sweep</c> → <c>/api/v1/stores/{id}/spark/sweep</c>.</summary>
+    public string StorePath(string suffix) => $"/api/v1/stores/{_storeId}{suffix}";
+
+    public Task<JsonDocument> GetStoreAsync(string suffix, CancellationToken cancellationToken) =>
+        GetAsync(StorePath(suffix), cancellationToken);
+
+    public Task<JsonDocument> PostStoreAsync(
+        string suffix, string? json, CancellationToken cancellationToken) =>
+        PostAsync(StorePath(suffix), json, cancellationToken);
+
+    public Task<JsonDocument> PutStoreAsync(
+        string suffix, string json, CancellationToken cancellationToken) =>
+        SendAsync(HttpMethod.Put, StorePath(suffix), json, cancellationToken);
+
+    public Task<JsonDocument> GetAsync(string path, CancellationToken cancellationToken) =>
+        SendAsync(HttpMethod.Get, path, null, cancellationToken);
+
+    public Task<JsonDocument> PostAsync(string path, string? json, CancellationToken cancellationToken) =>
+        SendAsync(HttpMethod.Post, path, json, cancellationToken);
+
+    private async Task<JsonDocument> SendAsync(
+        HttpMethod method, string path, string? json, CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(method, path);
+        if (json is not null)
+            request.Content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        using var response = await _http.SendAsync(request, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new BtcpayGreenfieldException(
+                method, path, (int)response.StatusCode, body);
+        }
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            // 200 with no body — DELETE .../spark answers this way. Modelled as an empty object so callers
+            // do not have to special-case it.
+            return JsonDocument.Parse("{}");
+        }
+
+        try
+        {
+            return JsonDocument.Parse(body);
+        }
+        catch (JsonException ex)
+        {
+            throw new BtcpayGreenfieldException(
+                method, path, (int)response.StatusCode,
+                $"the response was not JSON ({ex.Message}): {Trim(body)}");
+        }
+    }
+
+    internal static string Trim(string value) =>
+        value.Length <= 4_000 ? value : value[..4_000] + "\n… (truncated)";
+}
+
+/// <summary>A Greenfield call that did not succeed, carrying BTCPay's own explanation.</summary>
+/// <remarks>
+/// The body is the whole point. A 403 from a missing API-key permission, a 422 from the plugin's own
+/// validation and a 404 from a plugin that failed to load are three completely different problems that read
+/// identically as a status code.
+/// </remarks>
+public sealed class BtcpayGreenfieldException : Exception
+{
+    public BtcpayGreenfieldException(HttpMethod method, string path, int statusCode, string body)
+        : base($"{method} {path} answered {statusCode}."
+               + (string.IsNullOrWhiteSpace(body) ? "" : $"\nbody:\n{BtcpayGreenfield.Trim(body).TrimEnd()}"))
+    {
+        Method = method;
+        Path = path;
+        StatusCode = statusCode;
+        Body = body;
+    }
+
+    public HttpMethod Method { get; }
+
+    public string Path { get; }
+
+    public int StatusCode { get; }
+
+    public string Body { get; }
+}
+
+/// <summary>
+/// The collection every BtcpayE2E test joins, so they share one store and one chain, one at a time.
+/// </summary>
+[CollectionDefinition(BtcpayE2EStack.CollectionName, DisableParallelization = true)]
+public sealed class BtcpayE2ECollection : ICollectionFixture<BtcpayE2EStack>;

--- a/BTCPayServer.Plugins.Flint.Tests/BtcpayE2E/BtcpayE2ETests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/BtcpayE2E/BtcpayE2ETests.cs
@@ -1,0 +1,466 @@
+using System.Globalization;
+using System.Text.Json;
+using BTCPayServer.Plugins.Flint.Tests.LocalRegtest;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests.BtcpayE2E;
+
+/// <summary>
+/// Flint doing its job inside a real BTCPay Server: an invoice a customer's node pays, a payout the store's
+/// Lightning API sends, and a cooperative exit that confirms on a chain this suite mines.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Why these three and not more.</b> Each one closes a gap that no other suite in this repository can
+/// reach, and every one of them is a gap between the plugin and its <em>host</em> rather than inside the
+/// plugin:
+/// </para>
+/// <list type="number">
+/// <item><description>
+/// <b>An invoice reaching <c>Settled</c>.</b> The LocalRegtest suite proves the plugin's reconciler settles
+/// its own invoice record from the Receive leg. It cannot prove that BTCPay hears about it — that is
+/// <c>SparkSettlementBroadcaster</c> waking a listening session, <c>SparkInvoiceCreditor</c> registering the
+/// payment through BTCPay's own gateway, and BTCPay then moving the invoice to <c>Settled</c>. Three
+/// components, all of them host-facing, none of them exercised by a test that owns the invoice store.
+/// </description></item>
+/// <item><description>
+/// <b>A payment through the store's Lightning API.</b> This is the payout path a merchant, a pull payment or
+/// a Lightning payout processor uses, and it goes through the connection string the provisioner wrote into
+/// the store's <c>BTC-LN</c> payment method — so it proves the wiring, the connection-string handler and
+/// BTCPay's resolution of a plugin-supplied <c>ILightningClient</c>, not just <c>SparkLightningClient</c>.
+/// </description></item>
+/// <item><description>
+/// <b>A sweep reaching <c>Confirmed</c>.</b> The engine's Sent → Confirmed transition is written by the
+/// reconciliation pass running as a hosted service on BTCPay's schedule and reading the store's real
+/// settings out of Postgres. Every unit test of it drives the pass by hand.
+/// </description></item>
+/// </list>
+/// <para>
+/// <b>Everything is asserted against the counterparty, not against the plugin.</b> Invoice settlement is
+/// confirmed by BTCPay's own invoice status and cross-checked against the hash LND paid; the payout is
+/// confirmed by LND's copy of its own invoice; the sweep is confirmed by a transaction the fixture's bitcoind
+/// mined. A plugin that reported success to itself would pass none of them.
+/// </para>
+/// <para>
+/// <b>Amounts.</b> One store, funded once, and no guaranteed test order — so each test is sized to leave the
+/// others enough, and the sweep sizes itself off a live fee quote to leave
+/// <see cref="BtcpayE2EStack.ReserveForOtherTestsSats"/> behind rather than draining.
+/// </para>
+/// <para>Gated on <c>FLINT_BTCPAY_E2E</c>. See <see cref="BtcpayE2EStack"/>.</para>
+/// </remarks>
+[Trait("Category", "BtcpayE2E")]
+[Collection(BtcpayE2EStack.CollectionName)]
+public class BtcpayE2ETests
+{
+    private readonly BtcpayE2EStack _stack;
+
+    public BtcpayE2ETests(BtcpayE2EStack stack) => _stack = stack;
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>What the external node pays the store's invoice, in satoshis.</summary>
+    private const long ReceiveAmountSats = 2_000;
+
+    /// <summary>What the store pays the external node, in satoshis.</summary>
+    private const long SendAmountSats = 3_000;
+
+    /// <summary>
+    /// How long an invoice may take to reach <c>Settled</c> after LND reports the payment succeeded.
+    /// </summary>
+    /// <remarks>
+    /// Bounded generously rather than tuned. The path is long — the SDK's event stream, the plugin's
+    /// reconciler, the credit gateway, BTCPay's invoice state machine — and the plugin also runs a periodic
+    /// reconciliation pass as a backstop for a missed event, which is measured in tens of seconds. Anything
+    /// inside this window is a pass; the ceiling exists so a genuinely stuck settlement fails with a message
+    /// instead of hanging until the CI job's own timeout kills the run.
+    /// </remarks>
+    private static readonly TimeSpan SettlementTimeout = TimeSpan.FromMinutes(4);
+
+    /// <summary>How long a sent cooperative exit may take to be recorded as confirmed.</summary>
+    private static readonly TimeSpan ConfirmationTimeout = TimeSpan.FromMinutes(6);
+
+    /// <summary>
+    /// An invoice created through Greenfield, paid by the fixture's LND, reaching <c>Settled</c> in BTCPay.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The BOLT11 is read off <c>GET /api/v1/stores/{id}/invoices/{id}/payment-methods</c> rather than
+    /// constructed: that endpoint's <c>destination</c> is what a checkout page shows a customer, so paying it
+    /// is paying what a customer would pay. The invoice is priced in <c>BTC</c> so no rate provider is
+    /// involved — a regtest server has no business asking an exchange what a bitcoin is worth, and a rate
+    /// fetch that failed would make this a test of network access.
+    /// </para>
+    /// <para>
+    /// <b>The cross-check matters more than the status.</b> An invoice can reach <c>Settled</c> because
+    /// something credited it with the wrong payment; so the payment hash BTCPay recorded is compared with the
+    /// hash LND says it paid, both normalised to lowercase hex.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task An_external_node_pays_a_store_invoice_and_BTCPay_settles_it()
+    {
+        Assert.SkipUnless(BtcpayE2EStack.IsEnabled, BtcpayE2EStack.SkipReason);
+
+        var amountBtc = (ReceiveAmountSats / 100_000_000m).ToString("0.00000000", CultureInfo.InvariantCulture);
+        string invoiceId;
+        using (var created = await _stack.Api.PostStoreAsync(
+                   "/invoices",
+                   $$"""
+                   {
+                     "amount": "{{amountBtc}}",
+                     "currency": "BTC",
+                     "checkout": { "paymentMethods": ["BTC-LN"], "expirationMinutes": 30 },
+                     "metadata": { "itemDesc": "flint btcpay e2e receive" }
+                   }
+                   """,
+                   Ct))
+        {
+            invoiceId = created.RootElement.GetProperty("id").GetString()!;
+            Assert.Equal("New", created.RootElement.GetProperty("status").GetString());
+        }
+
+        string bolt11;
+        using (var methods = await _stack.Api.GetStoreAsync($"/invoices/{invoiceId}/payment-methods", Ct))
+        {
+            // Named rather than taken as [0]: the store also has LNURL enabled, and the LNURL method's
+            // destination is an LNURL string, which lncli cannot pay.
+            var lightning = methods.RootElement.EnumerateArray().FirstOrDefault(
+                method => string.Equals(
+                    method.GetProperty("paymentMethodId").GetString(), "BTC-LN", StringComparison.Ordinal));
+
+            Assert.True(
+                lightning.ValueKind is JsonValueKind.Object,
+                "the invoice has no BTC-LN payment method, so the store's Lightning wiring is not in force. "
+                + $"Payment methods: {methods.RootElement}");
+
+            bolt11 = lightning.GetProperty("destination").GetString()!;
+            Assert.StartsWith("lnbcrt", bolt11, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // Decoded by LND rather than parsed here, so the hash being compared below is the one the payer
+        // committed to and not one this test derived from the same string twice.
+        string paymentHash;
+        using (var decoded = await _stack.Control.LncliJsonAsync(["decodepayreq", bolt11], Ct))
+        {
+            paymentHash = decoded.RootElement.GetProperty("payment_hash").GetString()!.ToLowerInvariant();
+            Assert.Equal(
+                ReceiveAmountSats,
+                RegtestControl.LongOf(decoded.RootElement.GetProperty("num_satoshis")));
+        }
+
+        var payment = await _stack.Control.LndPayInvoiceAsync(bolt11, paymentHash, cancellationToken: Ct);
+        Assert.True(
+            payment.Succeeded,
+            $"LND did not pay the store's invoice: status {payment.Status}. The route is LND → its channel "
+            + "to the SSP's LDK node → a Spark transfer, so a failure here is the fixture's topology rather "
+            + "than the plugin.");
+
+        // Settled and nothing weaker. `Processing` means BTCPay has seen a payment and is waiting on the
+        // speed policy; `New` means it has not heard about one at all — a plugin that settled its own record
+        // and never told BTCPay leaves the invoice on `New` indefinitely, which is precisely the gap this
+        // test exists to close. The last status seen is reported so the two failures are distinguishable.
+        var lastStatus = "unknown";
+        var settled = await PollAsync(
+            SettlementTimeout,
+            async () =>
+            {
+                using var invoice = await _stack.Api.GetStoreAsync($"/invoices/{invoiceId}", Ct);
+                lastStatus = invoice.RootElement.GetProperty("status").GetString() ?? "unknown";
+                return lastStatus == "Settled" ? lastStatus : null;
+            });
+
+        Assert.True(
+            settled == "Settled",
+            $"invoice {invoiceId} was paid by LND (hash {paymentHash}) but BTCPay still reports "
+            + $"{lastStatus} after {SettlementTimeout.TotalMinutes:0} minutes. `New` means the settlement "
+            + "never reached BTCPay at all — look at SparkSettlementBroadcaster and the credit gateway in "
+            + "the plugin's log; `Processing` means it arrived and the invoice is waiting on the store's "
+            + "speed policy.");
+
+        using var paid = await _stack.Api.GetStoreAsync($"/invoices/{invoiceId}/payment-methods", Ct);
+        var lnMethod = paid.RootElement.EnumerateArray().First(
+            method => string.Equals(
+                method.GetProperty("paymentMethodId").GetString(), "BTC-LN", StringComparison.Ordinal));
+
+        var payments = lnMethod.GetProperty("payments").EnumerateArray().ToList();
+        Assert.NotEmpty(payments);
+
+        // BTCPay records a Lightning payment's id as the payment hash. Compared with LND's, which is the
+        // whole cross-check: a plugin that credited the invoice from the wrong payment would settle it too.
+        var recorded = payments
+            .Select(p => p.GetProperty("id").GetString()?.ToLowerInvariant())
+            .ToList();
+        Assert.Contains(paymentHash, recorded);
+
+        Console.WriteLine(
+            $"btcpay-e2e: invoice {invoiceId} settled from an external {ReceiveAmountSats:N0} sat payment "
+            + $"(hash {paymentHash}, LND fee {payment.FeeSats?.ToString(CultureInfo.InvariantCulture) ?? "?"} "
+            + "sat)");
+    }
+
+    /// <summary>
+    /// The store's Lightning API pays an invoice minted by the fixture's LND, and LND agrees it was paid.
+    /// </summary>
+    /// <remarks>
+    /// <c>POST /api/v1/stores/{id}/lightning/BTC/invoices/pay</c> is the payout path, and it reaches the
+    /// plugin only through the connection string the provisioner wrote into the store's <c>BTC-LN</c>
+    /// configuration — so a green result here is also proof that <c>SparkConnectionStringHandler</c> claimed
+    /// that string and that BTCPay resolved a plugin-supplied client from it. The verdict is read from LND's
+    /// own copy of its invoice rather than from BTCPay's response.
+    /// </remarks>
+    [Fact]
+    public async Task The_stores_Lightning_API_pays_an_external_invoice()
+    {
+        Assert.SkipUnless(BtcpayE2EStack.IsEnabled, BtcpayE2EStack.SkipReason);
+
+        await _stack.RequireBalanceAsync(
+            SendAmountSats * 3, "paying an external Lightning invoice", Ct);
+
+        var invoice = await _stack.Control.LndAddInvoiceAsync(
+            SendAmountSats, "flint btcpay e2e send", Ct);
+
+        // maxFeePercent generous for a regtest topology whose channel policies nobody tuned; the point of the
+        // test is that the payment completes, not what it costs.
+        using var response = await _stack.Api.PostStoreAsync(
+            "/lightning/BTC/invoices/pay",
+            $$"""
+            { "BOLT11": "{{invoice.Bolt11}}", "maxFeePercent": "5.0", "sendTimeout": 120 }
+            """,
+            Ct);
+
+        // A 200 here says BTCPay accepted the send. Whether the money arrived is LND's to say — and on a
+        // 0-length route it can answer before BTCPay's response is even read, so this is polled either way.
+        var state = await PollAsync(
+            SettlementTimeout,
+            async () =>
+            {
+                var current = await _stack.Control.LndLookupInvoiceAsync(invoice.PaymentHash, Ct);
+                return current.Settled ? current : null;
+            });
+
+        Assert.NotNull(state);
+        Assert.Equal("SETTLED", state!.State);
+        Assert.Equal(SendAmountSats, state.AmountPaidSats);
+
+        Console.WriteLine(
+            $"btcpay-e2e: the store paid LND {SendAmountSats:N0} sats through its Lightning API "
+            + $"(hash {invoice.PaymentHash}); BTCPay reported "
+            + $"{response.RootElement.ToString()[..Math.Min(160, response.RootElement.ToString().Length)]}");
+    }
+
+    /// <summary>
+    /// A manual sweep through Greenfield reaches <c>Swept</c>, and the record reaches <c>Confirmed</c> once
+    /// the exit is mined.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The sweep is sized off a live quote, not fixed.</b> A cooperative exit's fee does not scale with
+    /// what it carries, but on this fixture it scales with the <em>chain</em>: every transaction the fixture
+    /// sends specifies <c>fee_rate=100</c>, and bitcoind's estimator eventually believes it, so the same exit
+    /// was quoted at a few hundred sats on a fresh chain and at ~20,000 an hour later. A fixed amount would
+    /// either be refused by the fee guard on an old chain or make the guard vacuous on a fresh one. So the
+    /// test previews first — which reserves no address and writes no record — and sets the store's reserve so
+    /// that the fee lands at a comfortable fraction of what the destination receives.
+    /// </para>
+    /// <para>
+    /// <b>The reserve is also what keeps the suite order-independent.</b> Draining would leave the other two
+    /// tests with nothing if this one ran first, and xunit guarantees no order within a collection.
+    /// </para>
+    /// <para>
+    /// <b>Confirmation is a claim about the chain.</b> The record's txid is looked up in the fixture's
+    /// bitcoind and its confirmations counted, so <c>Confirmed</c> is checked against a mined transaction and
+    /// not merely against the plugin's own status field.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task A_manual_sweep_exits_on_chain_and_is_recorded_as_confirmed()
+    {
+        Assert.SkipUnless(BtcpayE2EStack.IsEnabled, BtcpayE2EStack.SkipReason);
+
+        // Enough to cover the reserve the sweep leaves behind plus a sweep large enough to clear the fee.
+        await _stack.RequireBalanceAsync(
+            BtcpayE2EStack.ReserveForOtherTestsSats + 20_000, "a cooperative exit", Ct);
+
+        var settings = await ReadSweepSettingsAsync();
+        var destination = Text(settings, "staticAddress")
+            ?? throw new InvalidOperationException(
+                "the store's sweep configuration has no staticAddress, so this test has no destination to "
+                + "check on chain. e2e/btcpay/up.sh sets one; re-run it.");
+
+        // Quote with the reserve at zero, so the quote is for the largest exit the wallet could make and the
+        // fee it reports is the flat exit fee this chain is charging right now.
+        await WriteSweepSettingsAsync(destination, reserveSats: 0);
+        long balance;
+        long feeSats;
+        using (var preview = await _stack.Api.PostStoreAsync("/spark/sweep", "{\"preview\":true}", Ct))
+        {
+            Assert.True(
+                preview.RootElement.GetProperty("canSweep").GetBoolean(),
+                "the sweep preview refused before the reserve was even set: "
+                + $"{Text(preview.RootElement, "refusalReason")}");
+
+            balance = preview.RootElement.GetProperty("balanceSats").GetInt64();
+            feeSats = preview.RootElement.GetProperty("quote").GetProperty("feeSats").GetInt64();
+        }
+
+        Assert.True(feeSats > 0, "the exit quote reported no fee, which no cooperative exit costs.");
+
+        // Sweep everything above the reserve, and then require that the fee is at most a fifth of what the
+        // destination receives. Both halves matter. Sweeping the lot keeps the stranded remainder — see
+        // BtcpayE2EStack.ReserveForOtherTestsSats — down to the reserve rather than to whatever a fixed
+        // amount happened to leave. And a *checked* ratio keeps the fee guard a real assertion: at 20% the
+        // 40% ceiling the store is configured with, and the engine's 50% hard backstop, are both comfortably
+        // clear, so a sweep that gets through is getting through on its economics rather than on the fee
+        // market the fixture happens to be in today.
+        var reserve = BtcpayE2EStack.ReserveForOtherTestsSats;
+        var sweepable = balance - reserve;
+        Assert.True(
+            sweepable >= feeSats * 6,
+            $"this chain's exit fee ({feeSats:N0} sats) is too large a share of the {balance:N0} sat balance "
+            + $"to sweep {sweepable:N0} while leaving {reserve:N0} behind — the plugin's fee guard would "
+            + "refuse it, correctly. Re-run e2e/btcpay/up.sh, which funds the store afresh.");
+        await WriteSweepSettingsAsync(destination, reserve);
+
+        string txId;
+        string idempotencyKey;
+        using (var swept = await _stack.Api.PostStoreAsync("/spark/sweep", "{}", Ct))
+        {
+            var outcome = swept.RootElement.GetProperty("outcome").GetString();
+            Assert.True(
+                outcome == "Swept",
+                $"the sweep was not accepted: outcome {outcome}, refusalCode "
+                + $"{Text(swept.RootElement, "refusalCode")}, reason {Text(swept.RootElement, "reason")}. "
+                + $"(balance {balance:N0}, reserve {reserve:N0}, quoted fee {feeSats:N0})");
+
+            var record = swept.RootElement.GetProperty("record");
+            idempotencyKey = record.GetProperty("idempotencyKey").GetString()!;
+            Assert.Equal(destination, record.GetProperty("destinationAddress").GetString());
+            Assert.Equal("StaticAddress", record.GetProperty("destinationMode").GetString());
+            Assert.Equal("Manual", record.GetProperty("trigger").GetString());
+            txId = record.GetProperty("txId").GetString()
+                   ?? throw new InvalidOperationException(
+                       "the accepted sweep record carries no txId, so there is nothing to mine to.");
+        }
+
+        // Mined here rather than waited for: nothing else advances an idle regtest chain, and the plugin's
+        // reconciliation pass is what turns confirmations into Confirmed.
+        await _stack.Control.MineAsync(6, Ct);
+
+        var confirmed = await PollAsync(
+            ConfirmationTimeout,
+            async () =>
+            {
+                await _stack.Control.MineAsync(1, Ct);
+                using var configuration = await _stack.Api.GetStoreAsync("/spark/sweep", Ct);
+                var record = configuration.RootElement.GetProperty("history").EnumerateArray().FirstOrDefault(
+                    entry => string.Equals(
+                        entry.GetProperty("idempotencyKey").GetString(), idempotencyKey,
+                        StringComparison.Ordinal));
+
+                if (record.ValueKind is not JsonValueKind.Object)
+                    return null;
+
+                return record.GetProperty("status").GetString() == "Confirmed"
+                    ? record.GetProperty("feeSats").GetInt64().ToString(CultureInfo.InvariantCulture)
+                    : null;
+            });
+
+        Assert.NotNull(confirmed);
+
+        // And the chain agrees. The plugin's Confirmed is a claim about a transaction; this is the
+        // transaction.
+        using var tx = await _stack.Control.BitcoinCliJsonAsync(["getrawtransaction", txId, "true"], Ct);
+        var confirmations = tx.RootElement.TryGetProperty("confirmations", out var count)
+            ? count.GetInt32()
+            : 0;
+        Assert.True(
+            confirmations > 0,
+            $"the plugin recorded the sweep {txId} as Confirmed, but the fixture's bitcoind reports "
+            + $"{confirmations} confirmations for it.");
+
+        Console.WriteLine(
+            $"btcpay-e2e: swept {sweepable:N0} sats to {destination} in {txId} for {confirmed} sats of fee "
+            + $"(quoted {feeSats:N0}), confirmed at {confirmations} confirmations, leaving a "
+            + $"{reserve:N0} sat reserve");
+    }
+
+    private async Task<JsonElement> ReadSweepSettingsAsync()
+    {
+        using var configuration = await _stack.Api.GetStoreAsync("/spark/sweep", Ct);
+        return configuration.RootElement.GetProperty("settings").Clone();
+    }
+
+    /// <summary>
+    /// Replaces the store's sweep configuration, keeping every field this suite depends on.
+    /// </summary>
+    /// <remarks>
+    /// <c>PUT</c> is a full replacement — a field the body omits takes its default, it does not keep its
+    /// current value — so the whole configuration is sent every time. <c>enabled</c> stays false: every sweep
+    /// here is a manual trigger, and an automatic pass firing between two tests would move money nothing
+    /// asserted on.
+    /// </remarks>
+    private async Task WriteSweepSettingsAsync(string destination, long reserveSats)
+    {
+        using var applied = await _stack.Api.PutStoreAsync(
+            "/spark/sweep",
+            $$"""
+            {
+              "enabled": false,
+              "balanceThresholdSats": 10000,
+              "reserveSats": {{reserveSats.ToString(CultureInfo.InvariantCulture)}},
+              "minimumSweepSats": 10000,
+              "maxFeePercent": 40.0,
+              "drainWhenSweeping": true,
+              "confirmationSpeed": "Medium",
+              "destinationMode": "StaticAddress",
+              "staticAddress": "{{destination}}"
+            }
+            """,
+            Ct);
+
+        Assert.Equal(
+            reserveSats,
+            applied.RootElement.GetProperty("settings").GetProperty("reserveSats").GetInt64());
+    }
+
+    private static string? Text(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind is JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    /// <summary>
+    /// Polls <paramref name="probe"/> until it answers non-null, or returns null at the deadline.
+    /// </summary>
+    /// <remarks>
+    /// Returns rather than fails so the caller can assert with its own message: "the invoice never settled"
+    /// and "the sweep never confirmed" call for completely different next steps, and a shared helper that
+    /// failed here could say neither.
+    /// </remarks>
+    private static async Task<T?> PollAsync<T>(TimeSpan timeout, Func<Task<T?>> probe) where T : class
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        Exception? last = null;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            try
+            {
+                if (await probe() is { } answer)
+                    return answer;
+            }
+            catch (BtcpayGreenfieldException ex)
+            {
+                // A transient 5xx while BTCPay is busy is not a verdict; the deadline is the judge. Anything
+                // structural repeats until the deadline and is then reported by the caller's assertion.
+                last = ex;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(3), Ct);
+        }
+
+        if (last is not null)
+            Console.WriteLine($"btcpay-e2e: the last poll error was {last.Message}");
+
+        return null;
+    }
+}

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeSparkSdkClientFactory.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/FakeSparkSdkClientFactory.cs
@@ -33,6 +33,18 @@ public sealed class FakeSparkSdkClientFactory : ISparkSdkClientFactory
     /// <summary>Every store a connect was attempted for, in order.</summary>
     public List<string> Connects { get; } = [];
 
+    /// <summary>
+    /// The options each store's most recent connect was made with.
+    /// </summary>
+    /// <remarks>
+    /// Recorded because several of the connect options are decisions <see cref="Services.SparkService"/> makes
+    /// and nothing downstream would reveal — the custom-network descriptor most of all, whose whole point is
+    /// that it is null on mainnet whatever the environment says. Holding the object is safe here and nowhere
+    /// else: it carries the mnemonic, and <see cref="SparkConnectOptions.ToString"/> is suppressed for that
+    /// reason, so a test must never print one.
+    /// </remarks>
+    public ConcurrentDictionary<string, SparkConnectOptions> Options { get; } = new();
+
     /// <summary>The clients handed out, by store. A hung store appears only once it is released.</summary>
     public ConcurrentDictionary<string, FakeSparkSdkClient> Clients { get; } = new();
 
@@ -46,6 +58,7 @@ public sealed class FakeSparkSdkClientFactory : ISparkSdkClientFactory
     {
         lock (Connects)
             Connects.Add(options.StoreId);
+        Options[options.StoreId] = options;
         EventWriters[options.StoreId] = eventWriter;
 
         if (FailFor.TryGetValue(options.StoreId, out var failure))

--- a/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkServiceHarness.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/Fakes/SparkServiceHarness.cs
@@ -58,6 +58,16 @@ public sealed class SparkServiceHarness : IDisposable
         TimeSpan ConfirmStatus,
         TimeSpan AbandonedConnectGrace);
 
+    /// <summary>
+    /// The chain the service's network provider reports, carried across a <see cref="Restart"/>.
+    /// </summary>
+    /// <remarks>
+    /// Regtest for every test but the custom-network one, which has to prove that the environment variable
+    /// naming a local Spark stack is not read on mainnet. That is a property of the network, so the network
+    /// has to be a parameter rather than a constant.
+    /// </remarks>
+    private readonly ChainName _chain;
+
     private SparkServiceHarness(
         TestableSparkService service,
         FakeSparkSdkClientFactory sdk,
@@ -65,7 +75,8 @@ public sealed class SparkServiceHarness : IDisposable
         CapturingLogger<SparkService> log,
         string dataDir,
         Durable durable,
-        Deadlines deadlines)
+        Deadlines deadlines,
+        ChainName chain)
     {
         Service = service;
         Sdk = sdk;
@@ -74,6 +85,7 @@ public sealed class SparkServiceHarness : IDisposable
         _dataDir = dataDir;
         _durable = durable;
         _deadlines = deadlines;
+        _chain = chain;
     }
 
     public SparkService Service { get; }
@@ -128,11 +140,17 @@ public sealed class SparkServiceHarness : IDisposable
     /// moment it tries to adopt a connected wallet. The throw is production code's own argument check, not a
     /// fake standing in for it — the only thing this withholds is a real dependency.
     /// </param>
+    /// <param name="chain">
+    /// The chain the network provider reports. Regtest by default, which is what every test but the
+    /// custom-network one wants; <see cref="ChainName.Mainnet"/> is how the mainnet half of that test is
+    /// expressed.
+    /// </param>
     public static SparkServiceHarness Create(
         TimeSpan? connectDeadline = null,
         TimeSpan? confirmStatusDeadline = null,
         TimeSpan? abandonedConnectGrace = null,
-        bool failWalletAdoption = false)
+        bool failWalletAdoption = false,
+        ChainName? chain = null)
     {
         var dataDir = Path.Combine(
             Path.GetTempPath(), "spark-service-tests", Guid.NewGuid().ToString("N"));
@@ -153,6 +171,7 @@ public sealed class SparkServiceHarness : IDisposable
                 // Long by default so the existing abandon tests still observe a late connect being adopted and
                 // shut down; the release-the-lock test shortens it deliberately.
                 abandonedConnectGrace ?? TimeSpan.FromMinutes(5)),
+            chain ?? ChainName.Regtest,
             failWalletAdoption);
     }
 
@@ -174,11 +193,12 @@ public sealed class SparkServiceHarness : IDisposable
     {
         StopService();
         _ownsDataDir = false;
-        return Create(_dataDir, _durable, _deadlines);
+        return Create(_dataDir, _durable, _deadlines, _chain);
     }
 
     private static SparkServiceHarness Create(
-        string dataDir, Durable durable, Deadlines deadlines, bool failWalletAdoption = false)
+        string dataDir, Durable durable, Deadlines deadlines, ChainName chain,
+        bool failWalletAdoption = false)
     {
         var log = new CapturingLogger<SparkService>();
         var logs = new Logs();
@@ -218,7 +238,7 @@ public sealed class SparkServiceHarness : IDisposable
             new BTCPayServer.EventAggregator(logs),
             stores,
             Options.Create(new DataDirectories { DataDir = dataDir }),
-            new BTCPayNetworkProvider([], new NBXplorerNetworkProvider(ChainName.Regtest), logs),
+            new BTCPayNetworkProvider([], new NBXplorerNetworkProvider(chain), logs),
             sdk,
             invoices,
             new InMemoryOutgoingPaymentStore(),
@@ -238,7 +258,7 @@ public sealed class SparkServiceHarness : IDisposable
             service,
             NullLogger<SparkLightningConfigSweeper>.Instance);
 
-        return new SparkServiceHarness(service, sdk, broadcaster, log, dataDir, durable, deadlines);
+        return new SparkServiceHarness(service, sdk, broadcaster, log, dataDir, durable, deadlines, chain);
     }
 
     /// <summary>Stores a store's Spark settings the way a previous run would have left them.</summary>

--- a/BTCPayServer.Plugins.Flint.Tests/SparkCustomNetworkTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkCustomNetworkTests.cs
@@ -14,6 +14,10 @@ namespace BTCPayServer.Plugins.Flint.Tests;
 /// that succeeds and goes on talking to Lightspark's hosted regtest — which is the failure mode these tests
 /// exist to make impossible, because a green local-regtest run against the hosted network proves nothing.
 /// </remarks>
+// Joined to the environment-variable collection because An_unset_environment_variable_yields_no_network
+// clears SPARK_LOCAL_REGTEST_NETWORK, which is process-global: without this it can run in parallel with
+// SparkServiceCustomNetworkTests, which sets it, and either class can then see the other's value.
+[Collection(SparkNetworkEnvironmentCollection.Name)]
 public class SparkCustomNetworkTests
 {
     private const string FirstIdentifier =

--- a/BTCPayServer.Plugins.Flint.Tests/SparkServiceCustomNetworkTests.cs
+++ b/BTCPayServer.Plugins.Flint.Tests/SparkServiceCustomNetworkTests.cs
@@ -1,0 +1,232 @@
+using BTCPayServer.Plugins.Flint.Sdk;
+using BTCPayServer.Plugins.Flint.Tests.Fakes;
+using NBitcoin;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Flint.Tests;
+
+/// <summary>
+/// The one production read of <c>SPARK_LOCAL_REGTEST_NETWORK</c>: <c>SparkService</c> hands a locally hosted
+/// signing set to the SDK on regtest, and refuses to look at the variable anywhere else.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the seam the <c>BtcpayE2E</c> suite stands on. Without it, a BTCPay Server running beside the local
+/// Spark stack would connect every store to Spark's own hosted regtest, the wallet would never see the money
+/// the fixture sent it, and the whole suite would fail as an unexplained funding timeout. With it, the e2e
+/// tests observe the plugin's real store-connect path.
+/// </para>
+/// <para>
+/// The mainnet half is the one that matters for safety, and it is asserted against the environment variable
+/// <em>set</em>. Merely observing that mainnet passes null with the variable unset would prove nothing: it is
+/// null then either way. <see cref="SparkSdkClientFactory.ApplyCustomNetwork"/> refuses a custom network off
+/// regtest as a second, independent guard — <see cref="SparkCustomNetworkTests"/> holds that end — but a
+/// belt-and-braces pair is only worth having if both halves are actually tested.
+/// </para>
+/// </remarks>
+[Collection(SparkNetworkEnvironmentCollection.Name)]
+public class SparkServiceCustomNetworkTests
+{
+    private const string StoreId = "store-on-a-local-stack";
+
+    /// <summary>
+    /// A descriptor good enough for the loader, which validates every field it models.
+    /// </summary>
+    /// <remarks>
+    /// Two operators at a threshold of two rather than the fixture's three, because the loader's only rule
+    /// about the count is that the threshold fits inside it, and a shorter document is easier to read. The
+    /// certificate is a stub: nothing here performs a TLS handshake, and the loader asks only that the field is
+    /// non-blank.
+    /// </remarks>
+    private const string Descriptor = """
+        {
+          "coordinatorIdentifier": "0000000000000000000000000000000000000000000000000000000000000001",
+          "threshold": 2,
+          "operators": [
+            {
+              "id": 0,
+              "identifier": "0000000000000000000000000000000000000000000000000000000000000001",
+              "address": "https://localhost:8535",
+              "identityPublicKey": "03dfbdff4b6332c220f8fa2ba8ed496c698ceada563fa01b67d9983bfc5c95e763",
+              "caCertPem": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+            },
+            {
+              "id": 1,
+              "identifier": "0000000000000000000000000000000000000000000000000000000000000002",
+              "address": "https://localhost:8536",
+              "identityPublicKey": "03e625e9768651c9be268e287245cc33f96a68ce9141b0b4769205db027ee8ed77",
+              "caCertPem": "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+            }
+          ],
+          "ssp": {
+            "baseUrl": "http://127.0.0.1:5000",
+            "identityPublicKey": "0322ca18fc0f26c1a1e6e0f7a4a8f6f4c0e2c1a5b6d7e8f9a0b1c2d3e4f5a6b7c8",
+            "schemaEndpoint": "graphql/spark/rc"
+          },
+          "esploraUrl": "http://127.0.0.1:30000",
+          "fixture": {
+            "bitcoindContainer": "cashu-bitcoind-1",
+            "bitcoindRpcUser": "cashu",
+            "bitcoindRpcPassword": "cashu",
+            "lndContainer": "cashu-lnd-1-1"
+          }
+        }
+        """;
+
+    [Fact]
+    public async Task A_regtest_store_connects_to_the_network_the_descriptor_names()
+    {
+        using var descriptor = new TemporaryDescriptor(Descriptor);
+        using var scope = SparkNetworkEnvironment.PointedAt(descriptor.Path);
+
+        using var harness = SparkServiceHarness.Create();
+        harness.SeedStore(StoreId, SparkServiceHarness.MnemonicFor(1));
+
+        await harness.Service.StartAsync(TestContext.Current.CancellationToken);
+
+        var options = Assert.Contains(StoreId, harness.Sdk.Options);
+        var network = Assert.IsType<SparkCustomNetwork>(options.CustomNetwork);
+
+        // Asserted field by field rather than as "not null": the failure this guards against is a descriptor
+        // that was read and then not carried through, which a null check would catch, and one that was read
+        // from a *stale* file, which it would not.
+        Assert.Equal(
+            "0000000000000000000000000000000000000000000000000000000000000001",
+            network.CoordinatorIdentifier);
+        Assert.Equal(2u, network.Threshold);
+        Assert.Equal(2, network.Operators.Count);
+        Assert.Equal("https://localhost:8535", network.Operators[0].Address);
+        Assert.Equal("http://127.0.0.1:5000", network.Ssp.BaseUrl);
+        Assert.Equal("http://127.0.0.1:30000", network.EsploraUrl);
+
+        // Reported once, at Information, and naming the variable — so the log of a run that went wrong answers
+        // "which Spark network was this server actually on?" without anyone having to guess.
+        var reported = harness.Log.Lines
+            .Where(line => line.Contains(SparkCustomNetworkFile.EnvironmentVariable, StringComparison.Ordinal))
+            .ToList();
+        Assert.Single(reported);
+        Assert.Contains("http://127.0.0.1:5000", reported[0]);
+    }
+
+    /// <summary>
+    /// On mainnet the variable is not read at all, so a mainnet store gets the SDK's own network.
+    /// </summary>
+    /// <remarks>
+    /// The variable is deliberately set for the duration of this test, pointing at a descriptor that parses.
+    /// Everything a merchant's money depends on is on the other side of this assertion: a mainnet wallet
+    /// connected to somebody else's signing set is not a misconfiguration, it is a wallet whose keys are
+    /// shared with whoever runs that stack.
+    /// </remarks>
+    [Fact]
+    public async Task A_mainnet_store_ignores_the_descriptor_even_when_the_variable_is_set()
+    {
+        using var descriptor = new TemporaryDescriptor(Descriptor);
+        using var scope = SparkNetworkEnvironment.PointedAt(descriptor.Path);
+
+        using var harness = SparkServiceHarness.Create(chain: ChainName.Mainnet);
+        harness.SeedStore(StoreId, SparkServiceHarness.MnemonicFor(2));
+
+        await harness.Service.StartAsync(TestContext.Current.CancellationToken);
+
+        var options = Assert.Contains(StoreId, harness.Sdk.Options);
+        Assert.Null(options.CustomNetwork);
+        Assert.Equal(Breez.Sdk.Spark.Network.Mainnet, options.Network);
+
+        // And nothing was said about it either, because nothing looked.
+        Assert.DoesNotContain(
+            harness.Log.Lines,
+            line => line.Contains(SparkCustomNetworkFile.EnvironmentVariable, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A descriptor that cannot be read refuses to start the wallet rather than falling back silently.
+    /// </summary>
+    /// <remarks>
+    /// The silent fallback is the worse outcome by a distance: the store would come up healthy against Spark's
+    /// hosted regtest, and the e2e suite would spend ten minutes waiting for money that was sent to a wallet
+    /// on a different network. A refusal names the variable in the log and leaves the store visibly down.
+    /// </remarks>
+    [Fact]
+    public async Task An_unreadable_descriptor_stops_the_store_rather_than_falling_back()
+    {
+        using var descriptor = new TemporaryDescriptor("{ \"threshold\": 2 }");
+        using var scope = SparkNetworkEnvironment.PointedAt(descriptor.Path);
+
+        using var harness = SparkServiceHarness.Create();
+        harness.SeedStore(StoreId, SparkServiceHarness.MnemonicFor(3));
+
+        await harness.Service.StartAsync(TestContext.Current.CancellationToken);
+
+        // No connect was attempted at all: the descriptor is resolved before the storage claim is taken, so a
+        // broken one costs nothing and cannot leave a lock behind.
+        Assert.DoesNotContain(StoreId, harness.Sdk.Connects);
+        Assert.Contains(
+            harness.Log.Lines,
+            line => line.Contains(SparkCustomNetworkFile.EnvironmentVariable, StringComparison.Ordinal)
+                    && line.Contains("write-network.sh", StringComparison.Ordinal));
+    }
+
+    /// <summary>A descriptor on disk, deleted with the test.</summary>
+    private sealed class TemporaryDescriptor : IDisposable
+    {
+        public TemporaryDescriptor(string json)
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(), $"spark-network-{Guid.NewGuid():N}.json");
+            File.WriteAllText(Path, json);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                File.Delete(Path);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Sets <c>SPARK_LOCAL_REGTEST_NETWORK</c> for the life of a test and puts it back afterwards.
+/// </summary>
+/// <remarks>
+/// Environment variables are process-global, which is why every test that touches this one belongs to
+/// <see cref="SparkNetworkEnvironmentCollection"/> and runs alone. The restore is unconditional: a test that
+/// left the variable set would make the entire local-regtest suite stop skipping and then fail on a
+/// descriptor that no longer exists.
+/// </remarks>
+internal sealed class SparkNetworkEnvironment : IDisposable
+{
+    private readonly string? _original;
+
+    private SparkNetworkEnvironment(string? original) => _original = original;
+
+    public static SparkNetworkEnvironment PointedAt(string? path)
+    {
+        var original = Environment.GetEnvironmentVariable(SparkCustomNetworkFile.EnvironmentVariable);
+        Environment.SetEnvironmentVariable(SparkCustomNetworkFile.EnvironmentVariable, path);
+        return new SparkNetworkEnvironment(original);
+    }
+
+    public void Dispose() =>
+        Environment.SetEnvironmentVariable(SparkCustomNetworkFile.EnvironmentVariable, _original);
+}
+
+/// <summary>
+/// The collection every test that writes <c>SPARK_LOCAL_REGTEST_NETWORK</c> joins.
+/// </summary>
+/// <remarks>
+/// xunit runs separate test classes in parallel by default, and an environment variable is per process — so
+/// without this, a class that sets the variable and a class that clears it can and do interleave. The
+/// collection has no fixture: serialising the classes is the whole of what it is for.
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class SparkNetworkEnvironmentCollection
+{
+    public const string Name = "Spark network environment variable";
+}

--- a/BTCPayServer.Plugins.Flint/Services/SparkService.cs
+++ b/BTCPayServer.Plugins.Flint/Services/SparkService.cs
@@ -17,6 +17,7 @@ using BTCPayServer.Plugins.Flint.Sdk;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NBitcoin;
+using SdkNetwork = Breez.Sdk.Spark.Network;
 
 namespace BTCPayServer.Plugins.Flint.Services;
 
@@ -156,6 +157,17 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
     /// does not provide.
     /// </summary>
     private readonly SemaphoreSlim _instanceLock = new(1, 1);
+
+    /// <summary>
+    /// Set once the local-regtest network descriptor has been reported, so the line appears one time per
+    /// process rather than once per store and again on every wallet restart.
+    /// </summary>
+    /// <remarks>
+    /// An <c>int</c> driven by <see cref="Interlocked.Exchange(ref int, int)"/> rather than a
+    /// <c>bool</c>: stores are connected from the startup loop and from the provisioning path, so two
+    /// threads can reach this and a plain read-then-write would log twice.
+    /// </remarks>
+    private int _customNetworkReported;
 
     /// <summary>
     /// Startup gate. Everything that reads <see cref="_settings"/> or <see cref="_instances"/> waits on this
@@ -395,6 +407,12 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
             return networkError;
         }
 
+        // Resolved here — before the wallet-owner check, before the storage claim, before anything is
+        // allocated — so that a descriptor that cannot be read costs nothing and names itself.
+        var customNetwork = ResolveCustomNetwork(sdkNetwork, storeId, out var customNetworkError);
+        if (customNetworkError is not null)
+            return customNetworkError;
+
         // The SDK's hazard is per wallet, not per store: two instances on one seed corrupt one SQLite file
         // even though the storage directories differ. Two stores sharing a seed is not hypothetical — reusing
         // the BTCPay hot-wallet seed on two stores of the same server does it.
@@ -462,7 +480,10 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
                 // which is below the mainnet floor essentially always, and above it a deposit is never claimed and
                 // never surfaces anywhere the merchant looks.
                 maxDepositClaimFee: (settings.Deposits ?? new SparkDepositSettings()).ToMaxFee(),
-                stableBalance: BuildStableBalance(settings));
+                stableBalance: BuildStableBalance(settings),
+                // Null unless this process was pointed at a privately hosted regtest network; see
+                // ResolveCustomNetwork for why reading an environment variable here is safe.
+                customNetwork: customNetwork);
 
             // Created before the SDK because the factory registers the event listener against this writer, and
             // events can arrive the moment it does. The channel buffers until the consumer starts below.
@@ -552,6 +573,91 @@ public class SparkService : EventHostedServiceBase, ISparkClientResolver, ISpark
                 storageLock.Dispose();
             }
         }
+    }
+
+    /// <summary>
+    /// The privately hosted Spark network this process was pointed at, or null for the one the SDK ships.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>The one production read of <see cref="SparkCustomNetworkFile.EnvironmentVariable"/>.</b> It exists so
+    /// that a BTCPay Server running inside the local-regtest stack — the <c>BtcpayE2E</c> suite's whole point —
+    /// exercises the plugin's <em>real</em> store-connect path against local operators, instead of the suite
+    /// reaching around the plugin and connecting an SDK instance of its own. Everything the e2e suite observes
+    /// (invoice settlement, the reconciler, the sweep engine, the Greenfield surface) therefore runs on the
+    /// same code a mainnet store runs on, with only the signing set swapped.
+    /// </para>
+    /// <para>
+    /// <b>Why an environment variable is safe here.</b> Three independent reasons, and any one of them would do:
+    /// </para>
+    /// <list type="number">
+    /// <item><description>
+    /// The network check is first, and the variable is <em>not read at all</em> off regtest. A mainnet or
+    /// testnet server behaves exactly as it did before this method existed, whatever the environment says.
+    /// </description></item>
+    /// <item><description>
+    /// <c>SparkSdkClientFactory</c> refuses a custom network on any network but
+    /// <see cref="SdkNetwork.Regtest"/> anyway, so even a future caller that skipped the check above would get
+    /// a throw rather than a wallet on somebody else's signing set.
+    /// </description></item>
+    /// <item><description>
+    /// It is an environment variable of the BTCPay <em>process</em>, not a store setting and not anything a
+    /// merchant or an API key can reach. See <see cref="SparkCustomNetwork"/> for why that boundary matters:
+    /// whoever can set it can already replace the plugin.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// A descriptor that exists but cannot be read is a refusal to start the wallet rather than a silent
+    /// fallback to Spark's own regtest. The fallback is the worse failure: the store would come up healthy,
+    /// against the wrong network, and the e2e suite would report a wallet that never sees its own money.
+    /// </para>
+    /// </remarks>
+    private SparkCustomNetwork? ResolveCustomNetwork(SdkNetwork sdkNetwork, string storeId, out string? error)
+    {
+        error = null;
+
+        // First, and load-bearing: see reason 1 in the remarks. Nothing below runs off regtest.
+        if (sdkNetwork is not SdkNetwork.Regtest)
+            return null;
+
+        SparkCustomNetwork? network;
+        try
+        {
+            network = SparkCustomNetworkFile.TryLoadFromEnvironment();
+        }
+        catch (Exception ex) when (ex is FormatException or IOException or UnauthorizedAccessException)
+        {
+            _logger.LogError(
+                ex,
+                "Store {StoreId}: {EnvironmentVariable} names a Spark network descriptor that could not be "
+                + "read, so the store's wallet was not started. Regenerate it with "
+                + "e2e/local-regtest/write-network.sh, or unset the variable to use Spark's own regtest",
+                storeId, SparkCustomNetworkFile.EnvironmentVariable);
+
+            error = "This server is configured with a local Spark regtest network descriptor that could not "
+                    + "be read, so this store's wallet was not started. Check the server logs.";
+            return null;
+        }
+
+        if (network is null)
+            return null;
+
+        // Once per process. Enough to answer "which Spark network is this server actually on?" from the log of
+        // a run that has gone wrong, which is the question a locally hosted signing set makes worth asking.
+        if (Interlocked.Exchange(ref _customNetworkReported, 1) == 0)
+        {
+            _logger.LogInformation(
+                "Spark wallets on this server connect to the privately hosted regtest network described by "
+                + "{EnvironmentVariable}: {OperatorCount} operator(s) at a threshold of {Threshold}, SSP "
+                + "{SspBaseUrl}, chain source {EsploraUrl}. Spark's own regtest is not used",
+                SparkCustomNetworkFile.EnvironmentVariable,
+                network.Operators.Count,
+                network.Threshold,
+                network.Ssp.BaseUrl,
+                network.EsploraUrl);
+        }
+
+        return network;
     }
 
     /// <summary>

--- a/docs/ci-and-releases.md
+++ b/docs/ci-and-releases.md
@@ -16,24 +16,60 @@
   error-string re-wording, or a preimage reaching the log, shows as a failed job inside a green
   scheduled run. A drained wallet failing a PR is answered by funding the wallet and re-running, not by
   reading it as a code failure.
-- **`.github/workflows/local-regtest.yml`** runs the `LocalRegtest` suite against a Spark stack it
-  stands up itself — [callebtc/cashu-regtest](https://github.com/callebtc/cashu-regtest)'s `--spark`
-  profile, pinned by SHA in both the workflow and `e2e/local-regtest/up.sh`. It is the only job that
-  covers settlement end to end with **no third-party service and no secret**: real LND nodes on both
-  sides of an invoice, and blocks mined on demand. Daily, on PRs, and on manual dispatch.
+- **`.github/workflows/local-regtest.yml`** runs the `LocalRegtest` **and `BtcpayE2E`** suites against a
+  Spark stack it stands up itself — [callebtc/cashu-regtest](https://github.com/callebtc/cashu-regtest)'s
+  `--spark` profile, pinned by SHA in both the workflow and `e2e/local-regtest/up.sh`. It is the only job
+  that covers settlement end to end with **no third-party service and no secret**: real LND nodes on both
+  sides of an invoice, and blocks mined on demand. Daily, on PRs, on manual dispatch, and on
+  `workflow_call` from `package.yml`.
 
-  | job | gates a merge? | why |
+  Two layers against one stack. `LocalRegtest` drives the Breez SDK directly, so a failure there is the
+  plugin's SDK wiring. `BtcpayE2E` then stands up a real BTCPay Server in Docker with this plugin
+  side-loaded (`e2e/btcpay/up.sh`) and drives it over the Greenfield API — store Lightning method,
+  invoice lifecycle, sweep endpoint — so a failure there is the plugin *as BTCPay hosts it*, which is the
+  one thing no in-process test host can tell you.
+
+  | trigger | gates? | why |
   |---|---|---|
-  | `local-regtest` | no — `continue-on-error` | no measured flake rate yet, and the fixture is six services built from source with keyshare generation and channel gossip to wait on; a flaky fixture blocking merges would cost more than the gap it closes. Unlike `integration-test` the dependency is not a third-party service, so red here is likelier to be our bug — which is the argument for eventually gating it on PRs, once the daily schedule has accumulated a pass/fail record, exactly as `funded-regtest-test` earned its gate |
+  | `workflow_call` from `package.yml` (a `v*` tag) | **yes** — blocking | cutting a signed release over a stack that cannot settle a payment is indefensible, and a release is a moment a human is present to re-run a transient failure |
+  | a `release/*` PR | **yes** — blocking | this repository releases by merging a `release/vX.Y.Z` branch through a PR, so that PR is where a maintainer would rather learn about a broken stack than at tag time |
+  | ordinary PRs, schedule, dispatch | no — `continue-on-error` | no measured flake rate yet, and the fixture is six services with keyshare generation and channel gossip to wait on (plus a BTCPay container now); a flaky fixture blocking every merge would cost more than the gap it closes. Unlike `integration-test` the dependency is not a third-party service, so red here is likelier to be our bug — the argument for eventually promoting this case too, once the daily schedule has accumulated a pass/fail record, exactly as `funded-regtest-test` earned its gate |
 
-  It is also the slowest job in the repository by a wide margin: the fixture publishes no images, so
-  every run builds the Spark operators, Electrs, `open-ssp` and `ldk-server` from Rust and Go source
-  on a cache-less runner — around **40 minutes**, against a 90-minute timeout. Publishing those images
-  to `ghcr.io` once per pinned SHA is the noted follow-up, and is what would make the job cheap enough
-  to gate. On failure it uploads a `local-regtest-stack-logs` artifact with `docker compose ps -a` and
-  the tail of each service's log, because a failure here is usually "which of six services fell over"
-  rather than anything the .NET output shows. See
+  The gating is one job-level expression,
+  `continue-on-error: ${{ !(inputs.blocking || startsWith(github.head_ref, 'release/')) }}`. The
+  `blocking` input exists because **`github.event_name` cannot detect being called**: inside a reusable
+  workflow it reports the *caller's* triggering event (`push`, for a tag build), never `workflow_call`.
+  It defaults to `true`, so a caller has to opt *out* of the gate rather than remember to opt in; on
+  every other trigger the `inputs` context is empty and the term reads as falsy, and `github.head_ref`
+  is only set on `pull_request`, so the whole expression collapses to "advisory" everywhere else.
+
+  On failure it uploads a `local-regtest-stack-logs` artifact with `docker compose ps -a`, the tail of
+  each fixture service's log, and the BTCPay/NBXplorer container logs (matched by container name, since
+  those live in a different Compose project) — because a failure here is usually "which of seven
+  services fell over" rather than anything the .NET output shows, and a plugin that failed to load says
+  so in BTCPay's startup log and nowhere else. See
   ["Against a local Spark stack"](testing.md#against-a-local-spark-stack).
+- **`.github/workflows/local-regtest-images.yml`** is what makes the job above affordable enough to gate
+  a release. The fixture publishes no images, so compose built the Spark operators (Rust), `open-ssp`
+  (Go), Electrs (Rust) and `ldk-server` (Rust) from source on every run — around **40 minutes** on a
+  cache-less hosted runner, and the whole reason `local-regtest` was advisory on every trigger. This
+  workflow builds those four once per pinned fixture SHA and pushes them to
+  `ghcr.io/sethforprivacy/flint-regtest/<image>:<cashu-regtest-sha>`; `up.sh` pulls each one and
+  `docker tag`s it to the local name the pinned compose file expects, so compose finds it and skips the
+  build. That is the difference between ~40 minutes and **~10–15**.
+  - It runs on manual dispatch and on pushes to `main` touching `up.sh` or itself, so a merged pin bump
+    republishes the set. `CASHU_REGTEST_SHA` in `up.sh` is the single source of truth for the revision
+    (the workflow greps it out rather than carrying a copy), and
+    `docker compose --profile spark config` is the single source of truth for the image set — a
+    hardcoded list that drifted would not fail, it would just build again, and the only symptom would
+    be a "fast" run taking forty minutes.
+  - **`linux/amd64` only.** An arm64 variant means cross-building several large Rust projects under
+    QEMU, which is hours rather than minutes; Apple silicon developers build native images locally once
+    and keep the layers, and `up.sh` skips the pull entirely off amd64 rather than running the stack
+    emulated. Every pull failure is a warning, never fatal, so a fork with no images is slow, not broken.
+  - It builds with `docker buildx bake` over the fixture's own compose file, because that is the only
+    front end that consumes compose `build:` sections — one target's context is a git URL with an inline
+    Dockerfile, which no `build-push-action` invocation could express.
 - **`.github/workflows/spark-regtest-wallet.yml`** is manual-only. It prints the CI regtest wallet's
   static deposit address and balance so a maintainer can fund it — see
   ["A funded regtest wallet for CI"](testing.md#a-funded-regtest-wallet-for-ci). It never prints the seed, and
@@ -43,6 +79,16 @@
   and `SHA256SUMS`) as a workflow artifact, and attaches it to the corresponding GitHub Release when
   triggered by a tag. On a tag it also refuses to build if the tag disagrees with the version in the
   csproj, so a `v0.2.0` tag on a 0.1.0 tree fails rather than producing a mislabelled release.
+  - **A `v*` tag runs the local Spark stack first.** A `local-regtest` job calls
+    `local-regtest.yml` (taking `blocking`'s default of `true`) and `package` `needs` it, so no tag can
+    produce a signed release over a plugin that cannot settle a payment or that BTCPay cannot load. The
+    gate is scoped to tags on purpose: `workflow_dispatch` exists to inspect a packaged artifact
+    quickly, and making every dispatch pay a quarter-hour of Docker would defeat that, so the gate job
+    skips off-tag and `package`'s `if:` accepts a *skipped* need while refusing a failed or cancelled
+    one. The calling job grants only `contents: read` and `packages: read` — a job that calls a
+    reusable workflow takes its permissions from the call site, not from the called file, and nothing
+    in that stack should be able to attest or publish. No `secrets: inherit` either: every credential
+    in the fixture is a published regtest value.
   - **All four ELF/Mach-O native payloads are stripped at packaging time** by
     [`scripts/strip-native-payloads.sh`](../scripts/strip-native-payloads.sh): Breez ships its Rust
     libraries with DWARF debug info and fat symbol tables — never-mapped data that nonetheless
@@ -95,5 +141,14 @@
   (`integration-test` intentionally *not* required, since it is `continue-on-error` by design), plus
   "Require branches to be up to date before merging". `funded-regtest-test` blocks PRs since it is
   no longer `continue-on-error` there; requiring it in branch protection as well is a choice —
-  doing so means a drained CI wallet holds every merge until someone funds it. `local-regtest` is
-  `continue-on-error` on every trigger and should not be required either, for now.
+  doing so means a drained CI wallet holds every merge until someone funds it. `local-regtest` should
+  **not** be required: it is `continue-on-error` on ordinary PRs, and it blocks exactly where it needs
+  to — on `release/*` PRs and on the tag build — through its own job expression rather than through
+  branch protection. Making it a required check would extend a fixture's flake rate to every merge,
+  which is the thing that expression exists to avoid.
+- **GHCR package visibility**: `local-regtest-images.yml` creates four packages under
+  `ghcr.io/sethforprivacy/flint-regtest/`, and GitHub creates a package **private** on its first push.
+  Make each one public (Packages → the package → Package settings → Change visibility) so a fork's
+  `local-regtest` run can pull them; the same-repository case works either way, because that job logs
+  in to GHCR with `GITHUB_TOKEN`. A private package is a slow run, not a broken one — `up.sh` warns
+  and builds from source.

--- a/docs/greenfield-api.md
+++ b/docs/greenfield-api.md
@@ -27,7 +27,16 @@ engine with the same guards.
 A key scoped to a single store works; `btcpay.store.canmodifystoresettings` covers the read endpoints too.
 Basic authentication is accepted wherever an API key is, as everywhere in Greenfield.
 
-Three things are worth knowing before scripting against it.
+Four things are worth knowing before scripting against it.
+
+- **A key that generates or imports a seed needs `btcpay.server.canmodifyserversettings` as well**, even
+  when it belongs to an administrator. `seedSource` `generate`, `import` and `hotWallet` all create a hot
+  wallet on this server, and the plugin asks BTCPay's own `CanUseHotWallet` — which answers yes only when
+  the server policy *allow non-admins to create hot wallets* is switched on, or when **the caller** holds
+  the server-settings policy. An API key is judged on its own permissions and not on its owner's role, so a
+  store-scoped key made by an admin is refused with `403` and `hot-wallet-not-allowed`. Either add that
+  permission to the key or turn the server policy on; the refusal is a server policy rather than a bad
+  request, which is why it is a `403` and not a validation error.
 
 - **A generated recovery phrase is returned exactly once**, in the response to the `POST` that generated
   it, and never again. There is no endpoint that reads a seed back — the phrase is stored encrypted with

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -193,3 +193,89 @@ makes that wait time out with the SSP unfunded.
 Everything the stack holds — the `cashu`/`cashu` RPC credentials, the `regtest-spark-admin-token`, the
 operator keyshares — is a public fixture value, and the suite's wallet is random per run. Details, and how
 to bump the pin, are in [`e2e/local-regtest/README.md`](../e2e/local-regtest/README.md).
+
+### Through a real BTCPay Server
+
+The suite above drives the plugin's own collaborators and connects an SDK instance of its own. That is
+enough to prove the money paths, but it means the plugin has never been observed **inside a host**: no
+BTCPay invoice ever reached `Settled`, the Lightning payment method the provisioner writes was never
+resolved by BTCPay, the reconciliation and sweep tasks never ran on BTCPay's schedule against real store
+settings in Postgres, and the plugin was never once *loaded* the way an install loads it — as a directory
+under the data dir, out of the official image, with Breez's native library resolved by BTCPay's plugin load
+context. [`e2e/btcpay/`](../e2e/btcpay/) closes that gap.
+
+It brings up BTCPay Server, NBXplorer and Postgres **joined to the Spark stack's own docker network**, so
+NBXplorer uses the fixture's `bitcoind` and the plugin inside BTCPay reaches the fixture's operators, SSP
+and Esplora. One chain, one fee market, and a cooperative exit the tests can mine to confirmation.
+
+```bash
+e2e/local-regtest/up.sh                     # the Spark stack first; this needs it
+e2e/btcpay/up.sh                            # BTCPay + NBXplorer + Postgres, then provision and fund
+
+FLINT_BTCPAY_E2E=$PWD/e2e/btcpay/btcpay.json \
+  dotnet test --filter "Category=BtcpayE2E" --output Detailed
+
+e2e/btcpay/down.sh                          # BTCPay side only; then e2e/local-regtest/down.sh
+```
+
+`up.sh` takes about **20 seconds** on a warm machine — it starts three containers, waits for BTCPay's
+`/api/v1/health`, and then does everything a merchant would do, over Greenfield: create the first
+administrator, mint an API key, create a store, `POST /api/v1/stores/{id}/spark` with
+`seedSource: generate`, read the deposit address back, pay it from the fixture's `bitcoind`, mine, wait for
+the claim, and configure sweeping. It writes `e2e/btcpay/btcpay.json` — base URL, API key, store id and the
+same `fixture` block `network.json` carries — which is the only thing the tests read. The suite itself takes
+about **two minutes**, nearly all of it the cooperative exit.
+
+Two things about that provisioning are worth knowing before scripting anything similar.
+
+- **The API key needs `btcpay.server.canmodifyserversettings`**, even when it belongs to an administrator.
+  `seedSource: generate` creates a hot wallet, and BTCPay's own `CanUseHotWallet` check answers yes only
+  when the server policy *allow non-admins to create hot wallets* is on, or when **the caller** holds the
+  server-settings policy — and an API key is judged on its own permissions, not on its owner's role. Without
+  it the provisioning `POST` answers `403 hot-wallet-not-allowed`. See
+  [`greenfield-api.md`](greenfield-api.md).
+- **The image is pinned by digest** to `btcpayserver/btcpayserver:2.4.4`, matching the `btcpayserver`
+  submodule tag and therefore `Constants.BuiltAgainstBTCPayServerVersion`. The official image is a Release
+  build, so `DEBUG_PLUGINS` — the side-loading route [`development.md`](development.md) uses — does not
+  exist in it; `up.sh` instead stages the Release build output as
+  `<plugindir>/BTCPayServer.Plugins.Flint/`, which is the layout `PluginManager` scans and byte-for-byte
+  what `PluginPacker` would have zipped. `BTCPAY_PLUGINDIR` is set explicitly because BTCPay resolves the
+  plugin directory independently of `BTCPAY_DATADIR`.
+
+The three tests each close one host-facing gap, and each is checked against the counterparty rather than
+against the plugin:
+
+1. an invoice created through Greenfield, its BOLT11 read off the payment-methods endpoint, paid by `lnd-1`,
+   reaching `Settled` — with the payment hash BTCPay recorded compared against the hash LND says it paid;
+2. `POST /api/v1/stores/{id}/lightning/BTC/invoices/pay` paying an invoice `lnd-1` minted, with the verdict
+   read from LND's own copy of that invoice — which also proves BTCPay resolved a plugin-supplied
+   `ILightningClient` from the connection string the provisioner wrote;
+3. `POST /api/v1/stores/{id}/spark/sweep` reaching outcome `Swept`, then `Confirmed` after mining, with the
+   record's txid looked up in the fixture's `bitcoind` and its confirmations counted.
+
+**The fixture's SSP liquidity is the consumable, and the numbers are tight.** The wallet is funded with
+150,000 sats out of the SSP's own Spark leaves, and the deposit is only the first demand: every Spark payment
+out of the wallet needs the SSP to *split* a leaf it can back. Against a leaf set that is too small or too
+coarse, a wallet takes its deposit and then refuses both the first Lightning send and the exit quote with
+`Tree service error: insufficient funds` — a message that names the wallet and means the SSP. This is
+sequence-dependent: the fixture seeds one 500,000-sat leaf, the `LocalRegtest` suite that runs first in CI
+borrows ~140,000 of it and returns most through its cooperative exit, and this suite's deposit then left
+~360,000 — at which point a 3,000-sat send failed, while the same run against two leaves (857,000) passed.
+So `up.sh` **tops the SSP up itself** until it holds at least five times the funding amount, adding one
+500,000-sat leaf per round exactly as the fixture's `cashu-spark-fund-ssp` does (admin deposit address →
+`bitcoind` → three confirmations → admin claim). Regtest coins are free; the top-up costs about ten seconds.
+
+`down.sh` is what keeps that from being necessary often. It pays the store's remaining balance back to
+`lnd-1` over Lightning before removing the containers, which returns the leaves to the SSP: a full
+`up.sh` → suite → `down.sh` cycle was measured to cost the SSP **500 sats** net. The return leg is a
+Lightning payment and not a sweep on purpose — an exit on this chain costs around 20,000 sats, so the
+plugin's fee guard correctly refuses any remainder much smaller than that, which is exactly the amount left
+after the sweep test. Without it the leftover is stranded in a wallet whose storage `down.sh` destroys, and
+one measured pair of runs took the SSP from 500,000 to 382,000.
+
+Observed figures from a green run, for calibration: 150,000 sats deposited, **140,100 credited** (a
+9,900-sat claim fee at ~100 sat/vB, auto-claimed by the SDK's own worker), and a sweep of 125,100 delivering
+105,400 for a **19,700-sat exit fee** — 18.7% of what the destination received, inside the store's 40%
+ceiling and well inside the engine's 50% hard backstop. Every one of those numbers is set by the fixture's
+fee market, which drifts upward as the fixture sends more `fee_rate=100` transactions, so the sweep test
+quotes first and sizes itself off the quote rather than fixing an amount.

--- a/e2e/btcpay/README.md
+++ b/e2e/btcpay/README.md
@@ -1,0 +1,131 @@
+# Flint on a real BTCPay Server, against the local Spark stack
+
+This directory stands up **BTCPay Server 2.4.4 + NBXplorer + Postgres**, joined to the Spark fixture's own
+docker network, with the Flint plugin installed the way an install installs it. It exists so the plugin can
+be observed from *outside*: the [`BtcpayE2E`](../../BTCPayServer.Plugins.Flint.Tests/BtcpayE2E) suite drives
+it entirely over Greenfield HTTP, and every assertion is checked against the fixture's own bitcoind or LND
+rather than against anything the plugin says about itself.
+
+It is stage 2. Stage 1 — [`../local-regtest`](../local-regtest) plus the `LocalRegtest` suite — builds the
+plugin's collaborators by hand and connects an SDK instance of its own. That proves the money paths against
+real Spark operators, and proves nothing at all about the host: BTCPay's invoice lifecycle, the Lightning
+payment method the provisioner writes, the Greenfield surface's authorisation, the reconciliation and sweep
+tasks running on BTCPay's schedule against Postgres, or the plugin *loading* — out of the official image,
+as a directory under the data dir, with Breez's native library resolved by BTCPay's plugin load context.
+
+## Use
+
+The Spark stack has to be up first; nothing here starts a chain.
+
+```bash
+../local-regtest/up.sh          # tens of minutes cold, minutes warm
+./up.sh                         # ~20 s
+FLINT_BTCPAY_E2E=$PWD/btcpay.json \
+  ~/.dotnet/dotnet test ../../BTCPayServer.Plugins.Flint.Tests/BTCPayServer.Plugins.Flint.Tests.csproj \
+  -c Release --filter "Category=BtcpayE2E" --output Detailed
+./down.sh                       # this side only
+../local-regtest/down.sh
+```
+
+`up.sh` is idempotent against live containers: it reuses the store and leaves a running wallet alone. A
+clean slate is `down.sh` then `up.sh`, which gets a fresh Postgres and therefore a fresh store.
+
+BTCPay's UI is on <http://127.0.0.1:14142> (loopback only), and `up.sh` prints the throwaway
+administrator's credentials. `FLINT_BTCPAY_E2E_PORT` moves the port.
+
+## What `up.sh` does, and why in that order
+
+1. **Asserts the fixture is up and usable.** The in-network Spark descriptor is generated first, because
+   `../local-regtest/write-network.sh --docker` is also the stack's health check: it asserts every operator
+   is running, reads their live TLS certificates out of the compose volume, verifies the SAN the in-network
+   address needs, and reads the SSP's identity. Then the SSP's Spark liquidity is checked — see
+   [Liquidity](#liquidity-is-the-consumable).
+2. **Builds the plugin and stages it.** The official image is a Release build and `DEBUG_PLUGINS` is behind
+   `#if DEBUG` in `PluginManager`, so the side-loading route in
+   [`docs/development.md`](../../docs/development.md) does not exist here. What does exist is the directory
+   scan: `PluginManager` walks `<plugindir>/*/` and loads `<identifier>/<identifier>.dll`. An unpacked copy
+   of the Release build output under that name is byte-for-byte what `PluginPacker` would have zipped into a
+   `.btcpay`, minus the zip. Both `linux-x64` and `linux-arm64` copies of
+   `libbreez_sdk_spark_bindings.so` are asserted present — the images are multi-arch, so the same staged
+   directory serves an amd64 runner and an arm64 Mac.
+3. **Starts the containers** and waits for `/api/v1/health`, then reads
+   `Running plugin BTCPayServer.Plugins.Flint` off the log. Healthy and loaded are different questions: a
+   plugin that threw during `Execute` is disabled, BTCPay restarts *without* it, and every Flint route then
+   404s.
+4. **Provisions over Greenfield**, exactly as [`docs/greenfield-api.md`](../../docs/greenfield-api.md)
+   describes: the first administrator (`POST /api/v1/users`, which needs no authentication while no admin
+   exists), an API key, a store, and `POST /api/v1/stores/{id}/spark` with `seedSource: generate`.
+5. **Funds the wallet through the plugin's own endpoints** — `GET .../spark/deposit` for the address, then
+   bitcoind, then mining, then the SDK's own claim (with `POST .../spark/deposit/claim` as the fallback the
+   plugin provides for a claim the automatic worker priced too low). Deliberately not the SSP's admin API: a
+   deposit credited out of band would prove nothing about how the plugin configures the SDK.
+6. **Configures sweeping** with a static destination and a fee ceiling this chain's exit fee can actually
+   clear, and writes `btcpay.json`.
+
+The generated recovery phrase is never captured. It is regtest money out of a fixture `down.sh` destroys,
+and writing a seed into a file beside a checkout is not a habit worth forming.
+
+## The two descriptors are not interchangeable
+
+`network.json` names `https://localhost:8535` and `http://127.0.0.1:5000`, which is right for a client on
+the host. From inside the fixture's network `127.0.0.1` is *the BTCPay container* and `localhost:8535` is
+nothing at all, so this side needs `write-network.sh --docker`, which emits `spark-operator-N:8535`,
+`spark-ssp:5000` and `spark-electrs:3002`. Those hostnames are verifiable because `spark-cert-init` issues
+each operator certificate with `DNS:spark-operator-<i>` alongside `DNS:localhost`; the script asserts
+whichever SAN it is about to depend on rather than assuming both survive a fixture bump.
+
+The descriptor is mounted read-only at `/datadir/spark-network.json` and named by
+`SPARK_LOCAL_REGTEST_NETWORK`. That variable is the plugin's **one** production read of the environment, in
+`SparkService.ResolveCustomNetwork`, and it is not read at all off regtest — the comment there gives three
+independent reasons why that is safe.
+
+## Liquidity is the consumable
+
+The wallet is funded with 150,000 sats out of the SSP's own Spark leaves, and the deposit is only the first
+demand: every Spark payment out of the wallet needs the SSP to *split* a leaf it can back. Against a leaf set
+that is too small or too coarse the wallet takes its deposit and then refuses both the first Lightning send
+and the exit quote with `Tree service error: insufficient funds` — a message that names this wallet and means
+the SSP. Measured: with the fixture's single 500,000-sat leaf, running this suite right after `LocalRegtest`
+left ~360,000 and a 3,000-sat send failed; the same run against two leaves (857,000) passed. So `up.sh`
+**tops the SSP up itself** until it holds at least five times the funding amount, adding one 500,000-sat leaf
+per round the way the fixture's `cashu-spark-fund-ssp` does — admin deposit address, `bitcoind`, three
+confirmations, admin claim — about ten seconds per leaf. To do it by hand:
+
+```bash
+cd ../local-regtest/cashu-regtest
+export COMPOSE_PROJECT_NAME=cashu COMPOSE_PROFILES=spark
+. ./docker-scripts.sh && cashu-spark-fund-ssp
+```
+
+`down.sh` is what keeps that rare. Before removing the containers it pays the store's remaining balance
+back to `lnd-1` over Lightning, which returns the leaves to the SSP; a full `up.sh` → suite → `down.sh`
+cycle was measured to cost the SSP **500 sats** net. The return leg is a Lightning payment and not a sweep
+on purpose: an exit on this chain costs around 20,000 sats, so the plugin's fee guard correctly refuses any
+remainder much smaller than that — which is exactly the amount the sweep test leaves. Without the return,
+one measured pair of runs took the SSP from 500,000 to 382,000.
+
+`down.sh --volumes` is not optional either. BTCPay's data directory holds the plugin's per-store SDK
+storage, and a store's wallet is keyed by a seed that only ever existed there.
+
+## Pins
+
+| Image | Pin | Why that one |
+|---|---|---|
+| `btcpayserver/btcpayserver` | `2.4.4`, by index digest | The `btcpayserver` submodule tag, and therefore `Constants.BuiltAgainstBTCPayServerVersion`. Multi-arch index digest so one line works on amd64 and arm64. |
+| `nicolasdorier/nbxplorer` | `2.6.10`, by index digest | What BTCPay's own `BTCPayServer.Tests/docker-compose.yml` pairs with this tag. |
+| `postgres` | `17-alpine`, by digest | The same image and digest `ci.yml`'s store-test service uses, so the plugin's migrations run on a version CI already covers. |
+
+## Notes
+
+- `BTCPAY_PLUGINDIR` is set explicitly. `DataDirectories.Configure` reads `plugindir` independently of
+  `BTCPAY_DATADIR` and otherwise falls back to a path under `$HOME`, so without it the bind mount would not
+  be the directory `PluginManager` scans.
+- `ASPNETCORE_URLS` is set rather than BTCPay's `--bind`/`--port`: those are only honoured when an HTTPS
+  certificate is configured (see `Startup.cs`), and the image sets no `ASPNETCORE_URLS` of its own, so
+  Kestrel would listen on `127.0.0.1:5000` *inside* the container and the published port would answer
+  nothing.
+- Service names are prefixed `flint-e2e-` because they share a network namespace with about forty fixture
+  services, and a hostname collision on a shared network resolves silently to the wrong container.
+- BTCPay logs a warning that NBXplorer's cookie file is missing. Expected: NBXplorer runs with
+  `NBXPLORER_NOAUTH=1`, and BTCPay connects anyway — the log line to look for is
+  `Connected to WebSocket of NBXplorer (BTC)`.

--- a/e2e/btcpay/docker-compose.yml
+++ b/e2e/btcpay/docker-compose.yml
@@ -1,0 +1,121 @@
+# A BTCPay Server that runs the packaged Flint plugin against the local Spark stack.
+#
+# Three containers — Postgres, NBXplorer, BTCPay Server — joined to the *fixture's* docker network
+# (`cashu_default`) rather than one of their own. That is the whole trick of this file: NBXplorer then
+# talks to the fixture's bitcoind, and the Flint plugin inside BTCPay reaches the fixture's Spark
+# operators, SSP and Esplora by their compose hostnames. Nothing here starts a bitcoind of its own, so
+# BTCPay and the Spark stack share one chain and one fee market, which is what makes a cooperative exit
+# something the tests can mine to confirmation.
+#
+# Every image is pinned by digest, as ci.yml pins its Postgres service: an e2e run that quietly moved to
+# a different BTCPay Server would be reporting on a host the plugin was not built against.
+#
+# Service names are prefixed `flint-e2e-` because they share a network namespace with ~40 fixture
+# services. `postgres` and `nbxplorer` would both be plausible names for something the fixture adds
+# later, and a hostname collision on a shared network resolves silently to the wrong container.
+
+name: flint-btcpay-e2e
+
+services:
+  flint-e2e-postgres:
+    # Same image and digest as the store-test service in .github/workflows/ci.yml, so the plugin's
+    # migrations run on the version CI already covers. `trust` auth and the durability flags off: this
+    # database is destroyed by down.sh and nothing in it is worth an fsync.
+    image: postgres:17-alpine@sha256:18cfe3ef5e6815560c98237d6216d1e5119702fb0f3894c8785dd58b8bbe5d73
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: ["-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+    volumes:
+      - flint-e2e-postgres:/var/lib/postgresql/data
+
+  flint-e2e-nbxplorer:
+    # The version BTCPay's own BTCPayServer.Tests/docker-compose.yml pairs with this submodule tag.
+    image: nicolasdorier/nbxplorer:2.6.10@sha256:7d2ab1f6ce38e301cba98a4f85bfbfcf2912d5034bd88af056f9d60e5511f911
+    restart: unless-stopped
+    depends_on:
+      flint-e2e-postgres:
+        condition: service_healthy
+    environment:
+      NBXPLORER_NETWORK: regtest
+      NBXPLORER_CHAINS: btc
+      # The fixture's bitcoind, by its compose hostname. Its command line is
+      # `-regtest -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -rpcuser=cashu -rpcpassword=cashu -txindex`,
+      # so regtest's default RPC port 18443 is reachable from anywhere on this network and the
+      # credentials are the fixture's fixed pair. 18444 is regtest's P2P port, which is how NBXplorer
+      # follows new blocks; the fixture exposes both.
+      NBXPLORER_BTCRPCURL: http://bitcoind:18443/
+      NBXPLORER_BTCNODEENDPOINT: bitcoind:18444
+      NBXPLORER_BTCRPCUSER: cashu
+      NBXPLORER_BTCRPCPASSWORD: cashu
+      NBXPLORER_BIND: 0.0.0.0:32838
+      NBXPLORER_NOAUTH: 1
+      # Small gap sizes purely to keep the initial scan cheap; nothing here derives many addresses.
+      NBXPLORER_MINGAPSIZE: 5
+      NBXPLORER_MAXGAPSIZE: 10
+      NBXPLORER_POSTGRES: >-
+        User ID=postgres;Include Error Detail=true;Host=flint-e2e-postgres;Port=5432;Database=nbxplorer
+    volumes:
+      - flint-e2e-nbxplorer:/datadir
+
+  flint-e2e-btcpay:
+    # btcpayserver/btcpayserver:2.4.4 — the tag the `btcpayserver` submodule is pinned to, which is what
+    # Constants.BuiltAgainstBTCPayServerVersion says the plugin was compiled against. Pinned to the
+    # multi-arch index digest so the same line works on an amd64 runner and on an arm64 Mac; the plugin
+    # ships Breez's native library for both linux RIDs, so either resolves.
+    image: btcpayserver/btcpayserver:2.4.4@sha256:c264aa08cd32a469bd30d41978b73dc8bb2de1503ce67bdb0ab8fd5d934fb614
+    restart: unless-stopped
+    depends_on:
+      flint-e2e-postgres:
+        condition: service_healthy
+      flint-e2e-nbxplorer:
+        condition: service_started
+    environment:
+      BTCPAY_NETWORK: regtest
+      BTCPAY_CHAINS: btc
+      BTCPAY_BTCEXPLORERURL: http://flint-e2e-nbxplorer:32838/
+      BTCPAY_POSTGRES: >-
+        User ID=postgres;Include Error Detail=true;Host=flint-e2e-postgres;Port=5432;Database=btcpayserver
+      # BTCPAY_DATADIR is already /datadir in the image, but the plugin directory is *not* derived from
+      # it: DataDirectories.Configure reads `plugindir` independently and otherwise falls back to a
+      # path under $HOME. Set explicitly so the bind mount below is the directory PluginManager scans.
+      BTCPAY_PLUGINDIR: /datadir/Plugins
+      BTCPAY_DEBUGLOG: /datadir/btcpay.log
+      BTCPAY_DEBUGLOGLEVEL: information
+      # Kestrel's own URL setting, not BTCPay's --bind: `bind`/`port` are only honoured when an HTTPS
+      # certificate is configured (see Startup.cs), and the image sets no ASPNETCORE_URLS, so without
+      # this Kestrel listens on 127.0.0.1:5000 *inside* the container and the published port answers
+      # nothing.
+      ASPNETCORE_URLS: http://0.0.0.0:49392
+      # The one production read of this variable (SparkService.ResolveCustomNetwork): it points every
+      # store's wallet at the fixture's own Spark operators instead of Spark's hosted regtest. The file
+      # is the --docker descriptor, mounted below; it carries in-network addresses, so it is only
+      # meaningful to a process on this network.
+      SPARK_LOCAL_REGTEST_NETWORK: /datadir/spark-network.json
+    ports:
+      # Loopback only. The tests drive it from the host over this port.
+      - "127.0.0.1:${FLINT_BTCPAY_E2E_PORT:-14142}:49392"
+    volumes:
+      - flint-e2e-btcpay:/datadir
+      # Read-write on purpose: PluginManager creates the directory, drains a command queue in it, and
+      # writes a disable marker for a plugin that crashed at startup. Mounted read-only, a crash would
+      # present as a second, unrelated failure.
+      - ./data/plugins:/datadir/Plugins
+      - ./data/spark-network.json:/datadir/spark-network.json:ro
+
+volumes:
+  flint-e2e-postgres:
+  flint-e2e-nbxplorer:
+  flint-e2e-btcpay:
+
+networks:
+  # The fixture's network, joined rather than created. `external: true` means compose refuses to start
+  # if the stack is not up, which is the correct failure: without bitcoind there is no chain for either
+  # NBXplorer or the Spark operators.
+  default:
+    name: ${FLINT_REGTEST_NETWORK:-cashu_default}
+    external: true

--- a/e2e/btcpay/down.sh
+++ b/e2e/btcpay/down.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Remove the BTCPay Server, NBXplorer and Postgres containers this directory's compose file created,
+# and their volumes.
+#
+# It touches nothing of the Spark stack's. That is the point of it being a separate script: the
+# fixture takes tens of minutes to build and the BTCPay side takes seconds, so tearing the second
+# down and leaving the first up is the normal development loop — and in CI, this runs *before*
+# e2e/local-regtest/down.sh so BTCPay releases its Postgres and its plugin storage while the network
+# it is attached to still exists. (A compose `down` against a network that is already gone leaves
+# the containers behind.)
+#
+# `--volumes` is not optional. BTCPay's data directory holds the plugin's per-store SDK storage, and
+# a store's Spark wallet is keyed by a seed that only ever existed in that directory: a second `up.sh`
+# over a surviving volume would find settings for a store that no longer exists in a fresh Postgres,
+# and the plugin would refuse to start the wallet on a storage claim it cannot explain.
+#
+# Environment:
+#   FLINT_BTCPAY_E2E_PORT  only so compose can interpolate the same port mapping; unused otherwise
+#   FLINT_REGTEST_NETWORK  the fixture network the compose file declares as external
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+export FLINT_BTCPAY_E2E_PORT="${FLINT_BTCPAY_E2E_PORT:-14142}"
+export FLINT_REGTEST_NETWORK="${FLINT_REGTEST_NETWORK:-cashu_default}"
+
+# ---------------------------------------------------------------------------------------------
+# Give the SSP's liquidity back first, best effort.
+# ---------------------------------------------------------------------------------------------
+# Every up.sh funds a wallet with 150,000 sats out of the SSP's own Spark leaves, and a wallet that
+# is simply abandoned keeps whatever is left in it: the fixture's seed falls by the leftover per run
+# and never recovers. Measured directly — a run whose sweep was refused took the fixture's SSP from
+# 382,000 to 239,900 in one go, and up.sh's own liquidity floor then refused to start the next one.
+#
+# **The return leg is a Lightning payment, not a cooperative exit.** Both give the leaves back to the
+# SSP, but an exit on this chain costs around 20,000 sats and the plugin's fee guard therefore
+# refuses any remainder under roughly three times that — correctly, and the remainder after the sweep
+# test is deliberately much smaller than that. Paying an invoice on the fixture's own LND costs a few
+# sats of routing fee and moves the whole balance, so it works on exactly the amounts an exit cannot.
+#
+# Best effort throughout, and silent about failure beyond a line: this runs after the tests have
+# their verdicts, and in CI on the failure path too. A teardown that failed the job while tidying up
+# would be worse than a stack that needs a top-up (cashu-spark-fund-ssp, in the fixture's
+# docker-scripts.sh).
+handoff="$script_dir/btcpay.json"
+if [ -f "$handoff" ] && command -v jq >/dev/null && command -v curl >/dev/null \
+   && command -v docker >/dev/null; then
+  base_url="$(jq -r '.baseUrl // empty' "$handoff")"
+  api_key="$(jq -r '.apiKey // empty' "$handoff")"
+  store_id="$(jq -r '.storeId // empty' "$handoff")"
+  lnd="$(jq -r '.fixture.lndContainer // empty' "$handoff")"
+
+  if [ -n "$base_url" ] && [ -n "$api_key" ] && [ -n "$store_id" ] && [ -n "$lnd" ]; then
+    balance="$(curl --silent --max-time 60 "$base_url/api/v1/stores/$store_id/spark" \
+      -H "Authorization: token $api_key" 2>/dev/null \
+      | jq -r '.balanceSats // 0' 2>/dev/null || echo 0)"
+
+    # A floor rather than "> 0": below a couple of thousand sats there is nothing worth a round trip,
+    # and balanceSats is documented as indicative anyway (it lags settlement by ~20 s), so a small
+    # number here is not something to act precisely on.
+    if [ "${balance:-0}" -gt 2000 ]; then
+      # 500 sats of headroom for the routing fee, which the payer pays on top of the invoice amount.
+      amount=$((balance - 500))
+      echo "==> returning $amount of the store's $balance sats to the SSP over Lightning (best effort)"
+
+      # --rpcserver is required and cannot be localhost: the fixture starts lnd with
+      # `--rpclisten=<hostname>:10009`, so it is not listening on loopback at all. The hostname is
+      # read off the container rather than guessed from its name — the container is `cashu-lnd-1-1`
+      # and the hostname is `lnd-1`, and nothing derives one from the other reliably. Same
+      # invocation RegtestControl uses, for the same reason.
+      lnd_host="$(docker inspect -f '{{.Config.Hostname}}' "$lnd" 2>/dev/null || true)"
+      bolt11=""
+      if [ -n "$lnd_host" ]; then
+        bolt11="$(docker exec "$lnd" lncli --network regtest --rpcserver="$lnd_host:10009" \
+          addinvoice --amt "$amount" --memo flint-btcpay-e2e-return --expiry 600 2>/dev/null \
+          | jq -r '.payment_request // empty' 2>/dev/null || true)"
+      fi
+
+      if [ -n "$bolt11" ]; then
+        outcome="$(curl --silent --max-time 180 -X POST \
+          "$base_url/api/v1/stores/$store_id/lightning/BTC/invoices/pay" \
+          -H "Authorization: token $api_key" -H 'Content-Type: application/json' \
+          -d "$(jq -nc --arg b "$bolt11" '{BOLT11: $b, maxFeePercent: "5.0", sendTimeout: 120}')" \
+          2>/dev/null || true)"
+        echo "    $(printf '%s' "${outcome:-no response}" | head -c 200)"
+      else
+        echo "    could not mint an LND invoice to pay; leaving the balance where it is."
+      fi
+    fi
+  fi
+fi
+
+# The declared external network may already be gone (someone ran the fixture's down.sh first).
+# Compose refuses to resolve the file at all in that case, so fall back to removing the project's
+# containers and volumes by label — which is what `down` would have done.
+if docker network inspect "$FLINT_REGTEST_NETWORK" >/dev/null 2>&1; then
+  echo "==> docker compose down --volumes"
+  docker compose -f "$script_dir/docker-compose.yml" down --volumes --remove-orphans
+else
+  echo "==> the $FLINT_REGTEST_NETWORK network is gone; removing the project by label instead"
+  containers="$(docker ps -aq --filter label=com.docker.compose.project=flint-btcpay-e2e)"
+  if [ -n "$containers" ]; then
+    # shellcheck disable=SC2086  # deliberate word splitting of the id list
+    docker rm -f $containers >/dev/null
+  fi
+  for volume in flint-btcpay-e2e_flint-e2e-postgres \
+                flint-btcpay-e2e_flint-e2e-nbxplorer \
+                flint-btcpay-e2e_flint-e2e-btcpay; do
+    docker volume rm "$volume" >/dev/null 2>&1 || true
+  done
+fi
+
+# The handoff file names an API key for a server that no longer exists, and the staged plugin plus
+# the in-network descriptor are both per-run copies. Left behind, btcpay.json is the more dangerous
+# of the three: a later `dotnet test` would find FLINT_BTCPAY_E2E pointing at a dead host and fail on
+# a connection error rather than skipping.
+rm -f "$script_dir/btcpay.json"
+rm -rf "$script_dir/data"
+
+echo "==> BTCPay e2e stack removed. The Spark stack is untouched; e2e/local-regtest/down.sh stops that."

--- a/e2e/btcpay/up.sh
+++ b/e2e/btcpay/up.sh
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+# Bring up a BTCPay Server running the Flint plugin against the already-running local Spark stack,
+# provision a store through Greenfield, fund its wallet, and write e2e/btcpay/btcpay.json.
+#
+# This is stage 2 of the local-regtest work. Stage 1 (BTCPayServer.Plugins.Flint.Tests/LocalRegtest)
+# drives the SDK directly and proves the plugin's own collaborators against local Spark operators.
+# What it cannot see is everything that only exists inside a host: BTCPay's invoice lifecycle, the
+# Lightning payment method wiring, the Greenfield surface, the reconciler running as a hosted
+# service, and the sweep engine's guards reading real store settings. That is what this brings up.
+#
+# Prerequisites, all asserted below rather than assumed:
+#   * the fixture stack is up (e2e/local-regtest/up.sh) — this joins its docker network and uses its
+#     bitcoind, Spark operators, SSP and Esplora. Nothing here starts a chain.
+#   * docker, jq, curl, and a dotnet SDK on PATH (or DOTNET at its path).
+#
+# What it does NOT do: mine while the fixture is initialising, or restart anything of the fixture's.
+# It mines only to mature its own funding deposit, once the stack has already reported healthy.
+#
+# Environment:
+#   FLINT_BTCPAY_E2E_PORT   host port BTCPay is published on (default 14142, loopback only)
+#   FLINT_REGTEST_NETWORK   the fixture's docker network (default cashu_default)
+#   SPARK_NETWORK_DESCRIPTOR
+#                           an existing --docker descriptor to use instead of generating one
+#   DOTNET                  the dotnet binary (default: `dotnet` from PATH, else ~/.dotnet/dotnet)
+#   FLINT_BTCPAY_SKIP_BUILD if 1, reuse the plugin's existing Release build output
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/../.." && pwd)"
+data_dir="$script_dir/data"
+plugin_dir="$data_dir/plugins/BTCPayServer.Plugins.Flint"
+descriptor="$data_dir/spark-network.json"
+output="$script_dir/btcpay.json"
+
+port="${FLINT_BTCPAY_E2E_PORT:-14142}"
+network="${FLINT_REGTEST_NETWORK:-cashu_default}"
+base_url="http://127.0.0.1:$port"
+
+# A throwaway administrator on a throwaway regtest server. Fixed rather than generated so a run that
+# died halfway can be re-run against the same containers: creating the first admin twice answers 403
+# (registrations are disabled once one exists), and the script treats that as "already done" below.
+admin_email="flint-e2e@example.com"
+admin_password="Flint-e2e-regtest-1!"
+
+# How long BTCPay may take to answer /api/v1/health. Generous because the first start applies both
+# BTCPay's and the plugin's migrations against an empty database.
+health_timeout=300
+# The funding path: bitcoind -> deposit address -> 3 confirmations -> the SSP claims it. Stage 1
+# measured this at anywhere between 7 s and 305 s on the same stack, because it is the SDK's own
+# deposit worker deciding when to look. The ceiling is so a broken stack explains itself instead of
+# hanging until a CI job's timeout kills the run with nothing to read.
+funding_timeout=900
+
+# Sized for the whole suite exactly as LocalRegtestStack.FundingSats is, and for the same two
+# reasons. Below: a ~2,000-sat receive, a ~3,000-sat send, and a cooperative exit whose fee on this
+# chain (~100 sat/vB) runs to ~20,000 sats. Above: the fixture seeds open-ssp with a single
+# 500,000-sat leaf, and every Spark payment out of this wallet needs the SSP to split leaves it can
+# back — funding beyond a third of the SSP's balance was observed to succeed and then fail the first
+# Lightning send with "Tree service error: insufficient funds".
+funding_sats=150000
+
+# Ceiling for a manual deposit claim, in satoshi. The SDK's automatic claim is priced off the
+# chain's *recommended* fee plus the plugin's 2 sat/vB leeway, and on this fixture that is far below
+# what the SSP asks: every funding transaction the fixture sends specifies fee_rate=100, so a claim
+# is quoted near 100 sat/vB (~10,000 sats) and the automatic attempt is refused. The manual claim
+# endpoint exists for exactly that, and the plugin's own guards still apply — 25,000 sats is the
+# store's default manual ceiling and no configuration can authorise more than half a deposit.
+claim_fee_ceiling_sats=20000
+
+say() { printf '==> %s\n' "$*"; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+for tool in docker jq curl; do
+  command -v "$tool" >/dev/null || die "$tool is required"
+done
+
+dotnet_bin="${DOTNET:-}"
+if [ -z "$dotnet_bin" ]; then
+  if command -v dotnet >/dev/null; then dotnet_bin="dotnet"
+  elif [ -x "$HOME/.dotnet/dotnet" ]; then dotnet_bin="$HOME/.dotnet/dotnet"
+  else die "no dotnet on PATH and none at ~/.dotnet/dotnet; set DOTNET"; fi
+fi
+
+# ---------------------------------------------------------------------------------------------
+# 1. The fixture has to be up first, and it has to be *usable*, not merely present.
+# ---------------------------------------------------------------------------------------------
+docker network inspect "$network" >/dev/null 2>&1 \
+  || die "no docker network '$network'. Bring the Spark stack up first: e2e/local-regtest/up.sh"
+
+# The in-network Spark descriptor, generated first because it is also the stack's own health check:
+# write-network.sh asserts every operator is running, reads their live TLS certificates out of the
+# compose volume, verifies the SAN the in-network address needs, and reads the SSP's identity. A
+# half-started stack fails here, naming the service, rather than fifteen minutes later as a wallet
+# that will not connect.
+mkdir -p "$data_dir"
+if [ -n "${SPARK_NETWORK_DESCRIPTOR:-}" ]; then
+  say "using the descriptor at $SPARK_NETWORK_DESCRIPTOR"
+  cp "$SPARK_NETWORK_DESCRIPTOR" "$descriptor"
+else
+  say "writing an in-network Spark descriptor"
+  # --docker, not the host descriptor: from inside cashu_default, `127.0.0.1:5000` is the BTCPay
+  # container itself and `localhost:8535` is nothing. See write-network.sh's header.
+  "$repo_root/e2e/local-regtest/write-network.sh" --docker "$descriptor" >/dev/null
+fi
+jq -e '.operators[0].address | startswith("https://spark-operator-")' "$descriptor" >/dev/null \
+  || die "$descriptor does not carry in-network operator addresses. Regenerate it with
+       e2e/local-regtest/write-network.sh --docker."
+
+# The SSP's Spark liquidity is the real budget: this wallet is funded out of the SSP's own leaves,
+# and a claim against an SSP holding less than the funding amount fails as "insufficient funds"
+# naming this wallet rather than the SSP. Checked before anything is built, because the fix (top the
+# SSP up the way the fixture's cashu-spark-fund-ssp does) is a different job from anything below.
+#
+# /status is admin-authenticated — the token is the fixture's fixed one, recorded in the descriptor
+# — while /identity is not; write-network.sh already read /identity, so this call is only about the
+# balance.
+say "checking the fixture's Spark SSP"
+ssp_status="$(curl --fail --silent --max-time 15 \
+  -H "Authorization: Bearer $(jq -er '.fixture.sspAdminToken' "$descriptor")" \
+  http://127.0.0.1:5000/status || true)"
+[ -n "$ssp_status" ] || die "the fixture's SSP did not answer http://127.0.0.1:5000/status.
+       The stack is not ready; read e2e/local-regtest/up.log."
+
+# `.spark.available_sats` is where open-ssp reports its Spark leaves; the two fallbacks cover older
+# and flatter shapes of the same document rather than failing on a field move.
+available_sats="$(jq -r '.spark.available_sats // .available_sats // 0' <<<"$ssp_status")"
+# Topped up rather than refused. The SSP is funded out of *leaves*, and the demand is not the deposit
+# alone: every Spark payment out of this wallet needs the SSP to split a leaf it can back, and a leaf set
+# too small or too coarse answers the first Lightning send and the exit quote with "Tree service error:
+# insufficient funds" — a failure that names this wallet and means the SSP. It is sequence-dependent,
+# which is what makes it worth automating: the fixture seeds one 500,000-sat leaf, the LocalRegtest suite
+# that runs before this in CI takes ~140,000 of it for its own deposit and gives most back through its
+# cooperative exit, and this script's 150,000 deposit then left ~360,000 — at which point a 3,000-sat
+# send failed, while the same run against 857,000 (two leaves) passed. Five times the funding amount is
+# the floor here, and each top-up adds one 500,000-sat leaf exactly the way the fixture's own
+# cashu-spark-fund-ssp does: admin deposit address → bitcoind → three confirmations → admin claim.
+ssp_admin_token="$(jq -er '.fixture.sspAdminToken' "$descriptor")"
+bitcoind_container="$(jq -er '.fixture.bitcoindContainer' "$descriptor")"
+bitcoin_cli() {
+  docker exec "$bitcoind_container" bitcoin-cli -regtest \
+    -rpcuser="$(jq -er '.fixture.bitcoindRpcUser' "$descriptor")" \
+    -rpcpassword="$(jq -er '.fixture.bitcoindRpcPassword' "$descriptor")" \
+    -rpcwallet=cashu "$@"
+}
+mine() { bitcoin_cli generatetoaddress "$1" "$(bitcoin_cli getnewaddress)" >/dev/null; }
+ssp_available_sats() {
+  curl --fail --silent --max-time 15 -H "Authorization: Bearer $ssp_admin_token" \
+    http://127.0.0.1:5000/status | jq -r '.spark.available_sats // .available_sats // 0'
+}
+fund_ssp_leaf() {
+  local leaf_sats=500000 address txid vout tx_hex
+  address="$(curl --fail --silent --max-time 30 -X POST -H "Authorization: Bearer $ssp_admin_token" \
+    http://127.0.0.1:5000/admin/spark/deposit-address | jq -er '.address')" || return 1
+  txid="$(bitcoin_cli -named sendtoaddress "address=$address" amount=0.005 fee_rate=100 | tr -d '\r\n')" || return 1
+  mine 3
+  sleep 4
+  vout="$(bitcoin_cli getrawtransaction "$txid" true | jq -er --arg a "$address" \
+    '.vout[] | select(.scriptPubKey.address == $a) | .n')" || return 1
+  tx_hex="$(bitcoin_cli getrawtransaction "$txid" false | tr -d '\r\n')" || return 1
+  curl --fail --silent --max-time 60 -X POST -H "Authorization: Bearer $ssp_admin_token" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -nc --arg h "$tx_hex" --argjson v "$vout" '{transaction_hex: $h, vout: $v}')" \
+    http://127.0.0.1:5000/admin/spark/claim-deposit >/dev/null || return 1
+  say "added a $leaf_sats-sat leaf to the SSP"
+}
+ssp_floor=$((funding_sats * 5))
+for _ in 1 2 3; do
+  [ "$available_sats" -ge "$ssp_floor" ] && break
+  say "SSP has $available_sats sats of Spark liquidity, below the $ssp_floor floor: topping it up"
+  fund_ssp_leaf || die "could not add a leaf to the SSP; read docker logs of the spark-ssp container"
+  available_sats="$(ssp_available_sats)"
+done
+[ "$available_sats" -ge "$ssp_floor" ] \
+  || die "the SSP still reports only $available_sats sats of Spark liquidity after three top-ups."
+say "SSP has $available_sats sats of Spark liquidity"
+
+# ---------------------------------------------------------------------------------------------
+# 2. Build the plugin and stage it the way a real install is laid out.
+# ---------------------------------------------------------------------------------------------
+# The official btcpayserver image is a Release build, and DEBUG_PLUGINS is behind `#if DEBUG` in
+# PluginManager — so the side-loading route docs/development.md describes does not exist here. What
+# does exist is the directory scan: PluginManager walks <plugindir>/*/ and loads
+# <identifier>/<identifier>.dll. An unpacked copy of the Release build output under that name is
+# byte-for-byte what PluginPacker would have zipped into a .btcpay, minus the zip.
+if [ "${FLINT_BTCPAY_SKIP_BUILD:-0}" != "1" ]; then
+  say "building the plugin (Release)"
+  # -m:1 for the reason ci.yml gives: the Razor and BTCPayServer builds race on shared intermediate
+  # output under parallel MSBuild.
+  "$dotnet_bin" build "$repo_root/BTCPayServer.Plugins.Flint/BTCPayServer.Plugins.Flint.csproj" \
+    -c Release -m:1
+fi
+
+build_output="$repo_root/BTCPayServer.Plugins.Flint/bin/Release/net10.0"
+[ -f "$build_output/BTCPayServer.Plugins.Flint.dll" ] \
+  || die "no plugin assembly at $build_output. Run without FLINT_BTCPAY_SKIP_BUILD=1."
+
+say "staging the plugin into $plugin_dir"
+rm -rf "$plugin_dir"
+mkdir -p "$plugin_dir"
+cp -R "$build_output/." "$plugin_dir/"
+
+# Breez's SDK is a Rust library behind a C ABI, and the SDK's very first call P/Invokes it. The
+# plugin's load context resolves it out of runtimes/<rid>/native (AssemblyDependencyResolver over the
+# plugin's own deps.json), so the RID that matches the container has to be present. Both linux RIDs
+# are asserted rather than just the host's: the images are multi-arch, so the same staged directory
+# is used by an amd64 CI runner and an arm64 developer machine.
+for rid in linux-x64 linux-arm64; do
+  [ -f "$plugin_dir/runtimes/$rid/native/libbreez_sdk_spark_bindings.so" ] \
+    || die "the staged plugin has no $rid native library. The Breez.Sdk.Spark package ships both
+       linux RIDs; a build output missing one will fail inside the container as a
+       DllNotFoundException on the first SDK call."
+done
+
+# ---------------------------------------------------------------------------------------------
+# 3. Start the containers.
+# ---------------------------------------------------------------------------------------------
+compose() {
+  FLINT_BTCPAY_E2E_PORT="$port" FLINT_REGTEST_NETWORK="$network" \
+    docker compose -f "$script_dir/docker-compose.yml" "$@"
+}
+
+say "starting Postgres, NBXplorer and BTCPay Server on the $network network"
+compose up -d
+
+say "waiting for BTCPay Server on $base_url (up to ${health_timeout}s)"
+# /api/v1/health is unauthenticated and reports the database, which is the slow part of a first
+# start. Polled rather than waited on with a compose healthcheck so the failure message can name the
+# container whose log to read.
+deadline=$((SECONDS + health_timeout))
+until curl --fail --silent --max-time 5 "$base_url/api/v1/health" >/dev/null 2>&1; do
+  if [ "$SECONDS" -ge "$deadline" ]; then
+    compose logs --tail 80 flint-e2e-btcpay >&2 || true
+    die "BTCPay Server did not become healthy in ${health_timeout}s (log above)."
+  fi
+  sleep 3
+done
+
+# Loading the plugin is a separate question from being healthy: a plugin that threw during Execute is
+# disabled and BTCPay restarts *without* it, and every Flint route then 404s. Read it off the log
+# rather than inferring it from a later failure.
+#
+# The log is captured to a variable before being searched, not piped into `grep -q`. Under
+# `set -o pipefail` that pipeline fails even on a match: grep exits at the first hit, docker takes
+# SIGPIPE, and the pipeline's status becomes the failure — which read as "the plugin did not load"
+# against a server that had loaded it perfectly.
+btcpay_log="$(compose logs flint-e2e-btcpay 2>/dev/null || true)"
+if ! printf '%s' "$btcpay_log" | grep -F "Running plugin BTCPayServer.Plugins.Flint" >/dev/null; then
+  compose logs --tail 120 flint-e2e-btcpay >&2 || true
+  die "BTCPay Server started but never logged 'Running plugin BTCPayServer.Plugins.Flint'.
+       The plugin did not load; the log above says why (look for 'Error when executing plugin')."
+fi
+say "plugin loaded: $(printf '%s' "$btcpay_log" | grep -F 'Running plugin BTCPayServer.Plugins.Flint' \
+  | sed 's/.*Running plugin //' | tail -1)"
+
+# ---------------------------------------------------------------------------------------------
+# 4. Greenfield: an admin, an API key, a store, a Flint wallet.
+# ---------------------------------------------------------------------------------------------
+api() {
+  # $1 method, $2 path, $3 optional JSON body. Auth is supplied by the caller through $AUTH_HEADER.
+  local method="$1" path="$2" body="${3:-}"
+  if [ -n "$body" ]; then
+    curl --silent --show-error --max-time 120 -X "$method" "$base_url$path" \
+      -H "$AUTH_HEADER" -H 'Content-Type: application/json' -d "$body"
+  else
+    curl --silent --show-error --max-time 120 -X "$method" "$base_url$path" -H "$AUTH_HEADER"
+  fi
+}
+
+# POST /api/v1/users answers without authentication while the server has no administrator, and
+# disables registrations as soon as the first one is created. So this is the one call with no auth,
+# and a 403 on a re-run means the admin already exists — which is a success for our purposes.
+say "creating the first administrator"
+AUTH_HEADER="X-Flint-E2E: unauthenticated"
+create_user="$(api POST /api/v1/users \
+  "$(jq -nc --arg e "$admin_email" --arg p "$admin_password" \
+      '{email: $e, password: $p, isAdministrator: true}')")"
+if ! jq -e '.id' <<<"$create_user" >/dev/null 2>&1; then
+  # Not fatal on its own: an existing admin is the expected answer on a second run against live
+  # containers. Anything else is reported verbatim, because the body is BTCPay's own explanation.
+  echo "    (user not created; BTCPay said: $(jq -c . <<<"$create_user" 2>/dev/null || echo "$create_user"))"
+fi
+
+# Basic auth is accepted wherever an API key is, throughout Greenfield — which is how the key itself
+# is minted before any key exists.
+AUTH_HEADER="Authorization: Basic $(printf '%s:%s' "$admin_email" "$admin_password" | base64 | tr -d '\n')"
+
+say "creating an API key"
+# The explicit permission set the tests actually use, rather than `unrestricted`: an over-scoped key
+# would hide a missing permission on one of the plugin's own endpoints, and getting those right is
+# part of what docs/greenfield-api.md promises.
+#
+# `btcpay.server.canmodifyserversettings` is on the list for one reason, and it is not the plugin's
+# own endpoints. `seedSource: "generate"` creates a hot wallet, and SparkSeedResolver asks BTCPay's
+# own CanUseHotWallet — which answers yes only when the server policy AllowHotWalletForAll is on, or
+# when the *caller* holds the server-settings policy. An API key is judged on its own permissions and
+# not on its owner's role, so a key belonging to an administrator that lacks this one is refused with
+# `hot-wallet-not-allowed`. Found the hard way here; docs/greenfield-api.md now says so.
+api_key="$(api POST /api/v1/api-keys '{
+  "label": "flint-btcpay-e2e",
+  "permissions": [
+    "btcpay.store.canmodifystoresettings",
+    "btcpay.store.canviewstoresettings",
+    "btcpay.store.cancreateinvoice",
+    "btcpay.store.canviewinvoices",
+    "btcpay.store.cancreatelightninginvoice",
+    "btcpay.store.canviewlightninginvoice",
+    "btcpay.store.canuselightningnode",
+    "btcpay.server.canmodifyserversettings"
+  ]
+}' | jq -er '.apiKey')" || die "could not create an API key; check the admin credentials."
+
+AUTH_HEADER="Authorization: token $api_key"
+
+# Reused if it already exists, so re-running this script against live containers does not leave a
+# trail of stores each holding a wallet with money in it. A fresh `down.sh` + `up.sh` gets a fresh
+# Postgres and therefore a fresh store either way.
+store_id="$(api GET /api/v1/stores | jq -r '[.[] | select(.name == "Flint e2e")] | first | .id // empty')"
+if [ -n "$store_id" ]; then
+  say "reusing store $store_id"
+else
+  say "creating a store"
+  store_id="$(api POST /api/v1/stores \
+    '{"name": "Flint e2e", "defaultCurrency": "BTC"}' | jq -er '.id')" \
+    || die "could not create a store."
+  say "store $store_id"
+fi
+
+# The provisioning POST is the only call that ever hands out the recovery phrase, and it hands it out
+# once. It is deliberately NOT captured here: this wallet holds regtest sats out of a fixture that
+# down.sh destroys, and a seed written into a file next to a checkout is a habit worth not forming.
+# `| jq '.status'` also keeps the phrase out of the shell's own output.
+# Provisioning again would *replace* the store's seed, abandoning whatever the previous wallet held
+# — so a store that already has a running wallet is left alone.
+existing="$(api GET "/api/v1/stores/$store_id/spark" | jq -c '.')"
+if [ "$(jq -r '.walletRunning // false' <<<"$existing")" = "true" ]; then
+  say "the store already has a running Flint wallet"
+  provision_status="$existing"
+else
+  say "provisioning the store's Flint wallet"
+  provision_status="$(api POST "/api/v1/stores/$store_id/spark" '{"seedSource":"generate"}' \
+    | jq -c '.status // .')"
+fi
+jq -e '.walletRunning == true' <<<"$provision_status" >/dev/null \
+  || die "the wallet did not start. Status: $provision_status
+       Read \`docker compose -f e2e/btcpay/docker-compose.yml logs flint-e2e-btcpay\`: a wallet that
+       will not start against a custom network is almost always the descriptor (a TLS SAN, or an
+       operator that died during keyshare generation)."
+say "wallet running, Lightning wiring $(jq -r '.lightningWiring' <<<"$provision_status")"
+
+# ---------------------------------------------------------------------------------------------
+# 5. Fund it, through the plugin's own endpoints.
+# ---------------------------------------------------------------------------------------------
+# Deliberately the plugin's route and not the SSP's admin API: a deposit credited out of band would
+# prove nothing about how the plugin configures the SDK, and the claim-fee ceiling is one of the
+# things this is here to exercise.
+deposit_address="$(api GET "/api/v1/stores/$store_id/spark/deposit" | jq -er '.address')" \
+  || die "the store has no deposit address."
+say "funding $deposit_address with $funding_sats sats"
+
+# -named with an explicit fee_rate, as the fixture's own helpers do: on a chain whose estimator has
+# no data an unqualified sendtoaddress fails with "Fee estimation failed" rather than picking a floor.
+amount_btc="$(jq -nr --argjson s "$funding_sats" '$s / 100000000 | tostring')"
+txid="$(bitcoin_cli -named sendtoaddress "address=$deposit_address" "amount=$amount_btc" fee_rate=100 | tr -d '\r\n')"
+say "deposit $txid; mining 3 blocks to mature it"
+mine 3
+
+say "waiting for the deposit to be credited (up to ${funding_timeout}s)"
+deadline=$((SECONDS + funding_timeout))
+claimed=0
+balance=0
+while [ "$SECONDS" -lt "$deadline" ]; do
+  status="$(api GET "/api/v1/stores/$store_id/spark" || true)"
+  balance="$(jq -r '.balanceSats // 0' <<<"$status" 2>/dev/null || echo 0)"
+  if [ "${balance:-0}" -gt 0 ]; then break; fi
+
+  if [ "$claimed" = 0 ]; then
+    deposits="$(api GET "/api/v1/stores/$store_id/spark/deposit" || true)"
+    entry="$(jq -c --arg t "$txid" '.deposits // [] | map(select(.txId == $t)) | first // empty' \
+      <<<"$deposits" 2>/dev/null || true)"
+    if [ -n "$entry" ] && [ "$(jq -r '.isMature' <<<"$entry")" = "true" ]; then
+      vout="$(jq -r '.vout' <<<"$entry")"
+      # Omit maxFeeSats when Spark has already said what the claim needs — that is the documented
+      # ordinary case and the value the plugin will use. Otherwise name a ceiling, because on this
+      # chain the automatic claim is priced below what the SSP asks and would never fire.
+      if [ "$(jq -r '.requiredFeeSats // "null"' <<<"$entry")" != "null" ]; then
+        claim_body="$(jq -nc --arg t "$txid" --argjson v "$vout" '{txId: $t, vout: $v}')"
+      else
+        claim_body="$(jq -nc --arg t "$txid" --argjson v "$vout" --argjson f "$claim_fee_ceiling_sats" \
+          '{txId: $t, vout: $v, maxFeeSats: $f}')"
+      fi
+      claim="$(api POST "/api/v1/stores/$store_id/spark/deposit/claim" "$claim_body" || true)"
+      if [ "$(jq -r '.status // ""' <<<"$claim")" = "Claimed" ]; then
+        claimed=1
+        say "claimed the deposit for $(jq -r '.feeSats // "?"' <<<"$claim") sats of fee"
+      else
+        echo "    claim not accepted yet: $(jq -rc '.status, .message' <<<"$claim" | paste -sd' ' -)"
+      fi
+    fi
+  fi
+
+  # A block per pass. Electrs and the SDK's chain service both follow the tip, and nothing else
+  # advances an idle regtest chain.
+  mine 1
+  sleep 5
+done
+
+[ "${balance:-0}" -gt 0 ] || die "the store's wallet was never funded: $funding_sats sats went to
+       $deposit_address in $txid and were mined, but the balance is still 0 after
+       ${funding_timeout}s. Check that the SSP still reports Spark liquidity, and read the BTCPay
+       log for the plugin's own claim refusals."
+say "wallet funded: $balance sats"
+
+# ---------------------------------------------------------------------------------------------
+# 6. Sweep settings the third test can actually use.
+# ---------------------------------------------------------------------------------------------
+# A static destination rather than DestinationMode StoreWallet: the store has no on-chain BTCPay
+# wallet, and giving it one would mean deriving a scheme and waiting for NBXplorer to track it —
+# neither of which the sweep is about. StaticAddress exists for exactly this shape of store.
+#
+# The numbers are set by this chain's fee market, not by taste. A cooperative exit here quotes near
+# 20,000 sats against a ~150,000-sat balance, which is ~13% — over the plugin's 3% default and under
+# its 50% hard backstop. So: drain the whole balance, and set a ceiling that admits that fee
+# deliberately. `enabled: false` because every sweep in the tests is a manual trigger, and an
+# automatic pass firing mid-test would race the assertions.
+sweep_destination="$(bitcoin_cli getnewaddress flint-btcpay-e2e-sweep bech32 | tr -d '\r\n')"
+say "sweep destination $sweep_destination"
+api PUT "/api/v1/stores/$store_id/spark/sweep" "$(jq -nc --arg a "$sweep_destination" '{
+  enabled: false,
+  balanceThresholdSats: 10000,
+  minimumSweepSats: 10000,
+  maxFeePercent: 40.0,
+  drainWhenSweeping: true,
+  confirmationSpeed: "Medium",
+  destinationMode: "StaticAddress",
+  staticAddress: $a
+}')" | jq -e '.settings.destinationMode == "StaticAddress"' >/dev/null \
+  || die "the sweep configuration was refused."
+
+# ---------------------------------------------------------------------------------------------
+# 7. The handoff file.
+# ---------------------------------------------------------------------------------------------
+# Shape the BtcpayE2E fixture reads: baseUrl / apiKey / storeId plus the same `fixture` block network.json
+# carries, so the test suite can reuse RegtestControl unchanged to drive bitcoind and lnd-1.
+jq -n \
+  --arg baseUrl "$base_url" \
+  --arg apiKey "$api_key" \
+  --arg storeId "$store_id" \
+  --argjson fixture "$(jq '.fixture' "$descriptor")" \
+  '{baseUrl: $baseUrl, apiKey: $apiKey, storeId: $storeId, fixture: $fixture}' > "$output"
+chmod 600 "$output"
+
+echo ""
+echo "BTCPay e2e stack is up. Run the suite with:"
+echo ""
+echo "  export FLINT_BTCPAY_E2E=$output"
+echo "  $dotnet_bin test BTCPayServer.Plugins.Flint.Tests/BTCPayServer.Plugins.Flint.Tests.csproj \\"
+echo "      -c Release --filter \"Category=BtcpayE2E\" --output Detailed"
+echo ""
+echo "BTCPay UI: $base_url  ($admin_email / $admin_password)"
+echo "Tear it down with e2e/btcpay/down.sh (the Spark stack is left alone)."
+echo ""

--- a/e2e/local-regtest/README.md
+++ b/e2e/local-regtest/README.md
@@ -14,7 +14,7 @@ production is a command, and every credential is a published fixture value. See
 ## Running it
 
 ```bash
-e2e/local-regtest/up.sh                     # clone at the pin, then ./start.sh --spark
+e2e/local-regtest/up.sh                     # clone at the pin, pull images, init the stack
 e2e/local-regtest/write-network.sh          # discover the live stack, write network.json
 
 SPARK_LOCAL_REGTEST_NETWORK=$PWD/e2e/local-regtest/network.json \
@@ -26,12 +26,49 @@ e2e/local-regtest/down.sh                   # compose down --volumes, all profil
 `write-network.sh` prints the `export` line for the descriptor path when it finishes. Absent that
 variable the suite skips itself, exactly as the Postgres and Lightspark suites do.
 
+### What `up.sh` actually runs
+
+Not the fixture's `./start.sh --spark`. That is the fixture's init chain *plus* its own acceptance
+suites — seven nodes' channel and UTXO counts, an LNbits probe, `cashu-spark-e2e` (which rebuilds the
+fixture's Rust Breez SDK test client with `--build` and settles four payments through it), and the `ldk/`
+and `fees/` e2e scripts — all of which is the fixture proving itself, and which mines dozens of extra
+blocks on the way. `up.sh` runs the init chain itself (stop, `up -d`, bitcoind funding, the seven-node
+Lightning topology, the six LDK channels, then `cashu-spark-init`, the step that funds the SSP's Spark
+liquidity) with one step left out: `cashu-fees-init`, which funds a fee-charging hub and waits for its
+channel policies to gossip into three routing graphs. That wait is the fixture's flakiest step — its own
+CI timed out in it in two of the three runs before this pin, and so did this suite's first run on
+ubuntu-latest — and nothing here routes through the hub: `lnd-1` and the SSP's LDK node share a direct
+channel. `up.sh` then asserts the three properties the suites actually depend on:
+
+- `open-ssp` reports `ldk_mode: live` **and** non-zero `spark.available_sats`;
+- the SSP's LDK node has all six channels ready;
+- every Lightning node sits at `bitcoind`'s tip (the fixture's own `wait-for-ldk-height`).
+
+Set `FLINT_REGTEST_FULL=1` to run the fixture's full `start.sh --spark` instead — worth doing when
+you suspect the fixture rather than the plugin.
+
 ## What it costs
 
-The fixture builds the Spark operators (Rust and Go), Electrs, `open-ssp` and `ldk-server` **from
-source** — there are no published images. A cold first run is **tens of minutes** (the fixture's own
-CI allows 90, and its Spark job takes around 40) and wants several GB of disk for the image layers
-and build caches. Subsequent runs reuse those layers and come up in a few minutes.
+The fixture publishes no images: its compose file builds the Spark operators (Rust), `open-ssp` (Go),
+Electrs (Rust) and `ldk-server` (Rust) **from source**, which is tens of minutes and several GB of
+disk. So [`.github/workflows/local-regtest-images.yml`](../../.github/workflows/local-regtest-images.yml)
+builds that set once per pinned fixture SHA and pushes it to `ghcr.io`, and `up.sh` pulls each image
+and `docker tag`s it to the exact local name the pinned compose file expects — at which point compose
+finds the image already present and skips the build. Both sides read the names and the service list out
+of `docker compose --profile spark config` rather than hardcoding them, because a hardcoded list that
+drifted would not fail: compose would quietly build again, and the only symptom would be a "fast" run
+that takes forty minutes.
+
+| variable | effect |
+|---|---|
+| `FLINT_REGTEST_IMAGE_PREFIX` | registry path to pull from. Default `ghcr.io/sethforprivacy/flint-regtest`. Set it to the empty string to never pull. |
+| `FLINT_REGTEST_FULL=1` | run the fixture's own `./start.sh --spark` instead of the leaner path above. |
+
+Every pull failure is a warning, never fatal — a fork whose packages were never published, or a
+network blip, falls through to building from source, which still works. **The published images are
+`linux/amd64` only** (an arm64 variant would mean cross-building several large Rust projects under
+QEMU, which is hours rather than minutes), so on Apple silicon `up.sh` does not pull at all: it builds
+native images once, and every run after that reuses those layers and comes up in a few minutes.
 
 `up.sh` is idempotent about the *checkout*, not the *state*: the fixture's `start.sh` begins with
 `docker compose down --volumes`, so every run resets the chain, the operator databases, the SSP
@@ -74,6 +111,12 @@ To bump: update `CASHU_REGTEST_SHA` here **and** the `ref:` in
 [`.github/workflows/local-regtest.yml`](../../.github/workflows/local-regtest.yml), delete the local
 checkout, and run the flow above. Read the fixture's diff for moved ports or changed operator keys
 while you are at it; the assertions above will catch some of that, but not a port that moved.
+
+`up.sh` is the *only* copy of the pin that anything reads programmatically: the images workflow greps
+`CASHU_REGTEST_SHA` out of this file rather than carrying its own, and tags the images it publishes with
+it. So a merged bump republishes the image set automatically (that workflow triggers on pushes to `main`
+touching `up.sh`), and until it finishes, CI's pull misses and falls back to building from source —
+slow, not broken.
 
 ## Credentials
 

--- a/e2e/local-regtest/up.sh
+++ b/e2e/local-regtest/up.sh
@@ -17,6 +17,14 @@
 #   CASHU_REGTEST_DIR  where the fixture checkout lives. Defaults to a clone this script manages.
 #                      CI sets it to the path actions/checkout already wrote, so the workflow does
 #                      not clone twice.
+#   FLINT_REGTEST_IMAGE_PREFIX
+#                      registry path the prebuilt fixture images live under, published by
+#                      .github/workflows/local-regtest-images.yml. Defaults to this repository's
+#                      GHCR namespace. Set it to the empty string to never pull and always build.
+#   FLINT_REGTEST_FULL if 1, run the fixture's own ./start.sh --spark instead of the leaner path
+#                      below — that additionally runs the fixture's acceptance suites, which rebuild
+#                      its Rust Breez test client and mine dozens of extra blocks. Useful when you
+#                      suspect the fixture itself; not what CI needs.
 set -euo pipefail
 
 # Pinned so the descriptor write-network.sh emits, the operator keys it reads out of
@@ -97,20 +105,214 @@ fi
 echo "==> chmod -R 777 $checkout (the fixture's containers write into its bind mounts as several uids)"
 chmod -R 777 "$checkout"
 
-echo "==> ./start.sh --spark  (first run builds the Rust and Go images from source: tens of minutes)"
+# The Spark services are all behind a compose profile and the Spark half of the fixture's init is
+# gated on CASHU_SPARK_REGTEST. start.sh sets both from its --spark flag; the leaner path below calls
+# the fixture's functions directly, so it has to set them itself. Exported before anything reads the
+# compose file so `docker compose config`, `pull`, `ps` and `logs` all see the same service set.
+export COMPOSE_PROFILES="spark"
+export CASHU_SPARK_REGTEST="true"
+export CASHU_BARK_REGTEST="false"
+
+# --------------------------------------------------------------------------------------------------
+# Prebuilt images.
+#
+# The fixture publishes none, so compose would build the Spark operators (Rust), open-ssp (Go),
+# Electrs (Rust) and ldk-server (Rust) from source — tens of minutes locally and about forty on a
+# cache-less CI runner, which is the single reason the local-regtest job was too expensive to gate a
+# release on. .github/workflows/local-regtest-images.yml builds that set once per pinned fixture SHA
+# and pushes it to GHCR; this pulls it and retags each image to the exact local name the pinned
+# compose file names, at which point compose finds the image already present and skips the build.
+#
+# Both sides read the names out of `docker compose config` rather than hardcoding them, because a
+# hardcoded list that drifted from the compose file would not fail — compose would just quietly build
+# again, and the only symptom would be a "fast" path that takes forty minutes.
+#
+# Every failure here is a warning, never fatal: a fork whose packages were never published, a network
+# blip, or an arm64 host all fall through to building from source, which still works.
+image_prefix="${FLINT_REGTEST_IMAGE_PREFIX-ghcr.io/sethforprivacy/flint-regtest}"
+# Only amd64. The published images are linux/amd64 only (see that workflow's header for why: an arm64
+# variant means cross-building several large Rust projects under QEMU). Pulling them onto an Apple
+# silicon host would succeed and then run the whole stack emulated, which is far worse than building
+# native images once and keeping the layers — so on any other architecture, don't pull at all.
+docker_arch="$(docker version --format '{{.Server.Arch}}' 2>/dev/null || true)"
+if [ -z "$image_prefix" ]; then
+  echo "==> FLINT_REGTEST_IMAGE_PREFIX is empty: not pulling; compose will build anything missing."
+elif [ "$docker_arch" != "amd64" ]; then
+  echo "==> docker server arch is '${docker_arch:-unknown}', not amd64: not pulling."
+  echo "    The published fixture images are linux/amd64 only; compose will build native ones."
+else
+  echo "==> checking for prebuilt fixture images under $image_prefix"
+  # Same derivation as the images workflow: services carrying a `build:` section, deduplicated by
+  # image, since ldk/ldk-fee share one image and the three operators share another.
+  wanted="$(cd "$checkout" && docker compose config --format json \
+    | jq -r '[ .services | to_entries[] | select(.value.build != null) ]
+             | group_by(.value.image) | map(.[0].value.image) | .[]')"
+  if [ -z "$wanted" ]; then
+    echo "    warning: found no buildable services in the pinned compose file; skipping the pull." >&2
+  fi
+  while IFS= read -r local_image; do
+    [ -n "$local_image" ] || continue
+    # A locally built image wins. On a repeat run this is the common case and skipping the pull saves
+    # a registry round trip; on an arm64 host it is also what protects a native image from being
+    # replaced by an emulated one if this block is ever reached with the arch check relaxed.
+    if docker image inspect "$local_image" >/dev/null 2>&1; then
+      echo "    $local_image is already present locally"
+      continue
+    fi
+    remote="$image_prefix/${local_image%%:*}:$CASHU_REGTEST_SHA"
+    echo "    pulling $remote"
+    if docker pull --quiet --platform linux/amd64 "$remote" >/dev/null 2>&1 \
+      && docker tag "$remote" "$local_image"; then
+      echo "      -> tagged as $local_image"
+    else
+      echo "      warning: could not pull $remote; compose will build $local_image from source." >&2
+      echo "               (Expected in a fork whose packages are private or unpublished.)" >&2
+    fi
+  done <<< "$wanted"
+fi
+# --------------------------------------------------------------------------------------------------
+
+# The fixture's own start.sh is `cashu-regtest-start` plus its acceptance suites: seven Lightning
+# nodes' channel and UTXO counts, an LNbits probe, `cashu-spark-e2e` (which rebuilds the fixture's
+# Rust Breez SDK test client with --build — another long compile on a cold runner — and settles four
+# payments through it), and the ldk/ and fees/ e2e scripts. All of that is the *fixture* proving
+# itself, and it mines dozens of extra blocks doing so. We want the stack, not the audit, so the
+# default path runs the fixture's init chain itself — stop, `compose up -d`, then every init step
+# except the fee-hub one (see flint_start_stack for why), including `cashu-spark-init`, the step that
+# funds the SSP's Spark liquidity — and then asserts the three properties the LocalRegtest suite actually depends on. Set FLINT_REGTEST_FULL=1 to run the
+# fixture's full path instead when you suspect the fixture rather than the plugin.
+flint_start_stack() {
+  # No `set -e` in here, on purpose: start.sh does not run under it either, and the fixture's
+  # functions are written to return non-zero rather than to be safe under errexit — several of their
+  # steps (a `docker run` that deletes node data, a `psql` poll) fail benignly. Every call below is
+  # therefore checked explicitly.
+  set +e
+  # docker-scripts.sh sources ./bark/scripts.sh, ./ldk/scripts.sh and ./fees/scripts.sh by relative
+  # path, and is also what exports COMPOSE_PROJECT_NAME=cashu — the name every container and volume
+  # in the stack is created under. Sourcing it from anywhere but the checkout root silently does
+  # nothing useful.
+  cd "$checkout" || return 1
+  # shellcheck disable=SC1091  # a file in the pinned foreign checkout, not in this repository
+  . ./docker-scripts.sh
+
+  if [ "${FLINT_REGTEST_FULL:-0}" = "1" ]; then
+    echo "==> FLINT_REGTEST_FULL=1: running the fixture's own ./start.sh --spark"
+    ./start.sh --spark || return 1
+    return 0
+  fi
+
+  # The fixture's `cashu-regtest-start` is stop + `compose up -d` + `cashu-regtest-init`, and that init
+  # chain is reproduced here step by step so that ONE of its steps can be left out: `cashu-fees-init`,
+  # which funds a fee-charging hub and three leaf nodes and then waits for their channel *policies* to
+  # appear in three separate routing graphs. That gossip wait is the flakiest thing in the fixture — its
+  # own CI timed out in it ("Timed out: fee-policies-ready") in two of the three runs preceding this
+  # pin, and so did this workflow's first run on ubuntu-latest — and nothing this plugin tests routes
+  # through the hub: lnd-1 and the SSP's LDK node share a direct channel. The fee containers still
+  # start (they are in the default profile), they are simply never waited on or funded. Everything the
+  # suites do depend on — bitcoind funds, the seven-node topology, the six LDK channels, and
+  # `cashu-spark-init` funding the SSP — runs exactly as the fixture's own init runs it.
+  # Two attempts, each from a clean stop. The fixture's init is a chain of bounded waits on things that
+  # are asynchronous by nature — LDK's BDK wallet noticing its own funding spend, seven nodes reaching one
+  # exact height, channel gossip — and any one of them can time out on a slow or busy host with nothing
+  # actually wrong ("LDK wallet funding sync timed out" was seen once in five local starts). A second
+  # attempt from `compose down --volumes` costs a few minutes with cached images; a red release gate on a
+  # fixture wait costs a human an afternoon. Two rather than more, so a genuinely broken stack still
+  # fails inside the job's timeout with the fixture's own message intact.
+  local attempt
+  for attempt in 1 2; do
+    if flint_init_chain; then
+      echo "==> asserting the stack is ready for the LocalRegtest suite"
+      flint_assert_ready || return 1
+      return 0
+    fi
+    if [ "$attempt" = 1 ]; then
+      echo "==> the fixture's init chain failed; retrying once from a clean stop (its waits are known to flake)" >&2
+    fi
+  done
+  return 1
+}
+
+flint_init_chain() {
+  echo "==> compose down --volumes, up -d, then the fixture's init chain minus the fee-hub topology"
+  cashu-regtest-stop || return 1
+  docker compose up -d --remove-orphans || return 1
+  cashu-bitcoin-init || return 1
+  cashu-lightning-sync || return 1
+  cashu-lightning-init || return 1
+  cashu-ldk-init || return 1
+  cashu-spark-init || return 1
+}
+
+# The three properties the suite depends on, each polled with a bounded wait. The init chain already
+# asserts stronger versions of all three; re-checking here is cheap and turns "the stack came up but
+# the SSP has no liquidity" into a failure of up.sh with a legible message, rather than a test
+# failing on a Spark error deep inside the SDK.
+flint_assert_ready() {
+  local attempt status ldk_mode available channels
+
+  # 1. open-ssp is live and actually holds Spark liquidity. `ldk_mode: live` means its LDK node is
+  #    reachable, and available_sats > 0 means cashu-spark-fund-ssp's deposit claim landed — without
+  #    it the SSP cannot pay or be paid and every Lightning test fails on an opaque service error.
+  #    That liquidity is one 500,000-sat leaf and is the suite's whole budget.
+  for attempt in $(seq 1 60); do
+    status="$(curl --fail --silent --max-time 15 \
+      -H "Authorization: Bearer $SPARK_ADMIN_TOKEN" http://127.0.0.1:5000/status 2>/dev/null)"
+    ldk_mode="$(printf '%s' "$status" | jq -r '.ldk_mode // empty' 2>/dev/null)"
+    available="$(printf '%s' "$status" | jq -r '.spark.available_sats // 0' 2>/dev/null)"
+    case "$available" in ''|*[!0-9]*) available=0 ;; esac
+    if [ "$ldk_mode" = "live" ] && [ "$available" -gt 0 ]; then
+      echo "    open-ssp: ldk_mode=live, ${available} sats of Spark liquidity"
+      break
+    fi
+    [ "$attempt" -eq 60 ] && {
+      echo "error: open-ssp never reported a live LDK mode with liquidity" >&2
+      echo "       (last ldk_mode='${ldk_mode:-none}', available_sats=$available)" >&2
+      return 1
+    }
+    sleep 5
+  done
+
+  # 2. The SSP's LDK node has all six of its channels ready. Anything less and a payment to or from
+  #    one of the fixture's LND/CLN nodes may have no route — which surfaces as a payment timeout,
+  #    not as a topology error.
+  for attempt in $(seq 1 60); do
+    channels="$(ldk-cli-sim list-channels 2>/dev/null \
+      | jq -r '[.channels[]? | select(.is_channel_ready == true)] | length' 2>/dev/null)"
+    if [ "$channels" = "6" ]; then
+      echo "    LDK: 6 ready channels"
+      break
+    fi
+    [ "$attempt" -eq 60 ] && {
+      echo "error: LDK reported ${channels:-no} ready channels, expected 6" >&2
+      return 1
+    }
+    sleep 5
+  done
+
+  # 3. Every Lightning node sits at bitcoind's tip. wait-for-ldk-height is the fixture's own bounded
+  #    check and covers the LDK node plus all three LND and all three CLN nodes at once, which is
+  #    strictly stronger than the `lnd-1 synced_to_chain` the suite needs — and it is the property
+  #    that breaks if anything mines a block while the stack is still initialising.
+  wait-for-ldk-height || {
+    echo "error: the Lightning nodes never converged on bitcoind's block height" >&2
+    return 1
+  }
+  echo "    all seven Lightning nodes are at bitcoind's tip"
+}
+
+echo "==> starting the stack (a first run with no prebuilt images compiles from source: ~40 min)"
 echo "    full output is also being written to $log"
-# `start.sh` sources docker-scripts.sh with relative paths, so it only works from its own directory.
 # `set -e` is suspended around the pipeline so the tail-of-log diagnostic below actually runs; the
 # exit status comes from PIPESTATUS[0] rather than the pipeline, so `tee` cannot mask a failure.
 set +e
-( cd "$checkout" && ./start.sh --spark ) 2>&1 | tee "$log"
+( flint_start_stack ) 2>&1 | tee "$log"
 start_status="${PIPESTATUS[0]}"
 set -e
 
 if [ "$start_status" -ne 0 ]; then
   echo "" >&2
-  echo "error: the fixture's ./start.sh --spark failed (exit $start_status)." >&2
-  echo "       Last 80 lines; start.sh's own EXIT trap has already dumped container logs above." >&2
+  echo "error: bringing the fixture's Spark stack up failed (exit $start_status)." >&2
+  echo "       Last 80 lines follow; see also \`docker compose ps -a\` in $checkout." >&2
   echo "---------------------------------------------------------------------------" >&2
   tail -n 80 "$log" >&2
   echo "---------------------------------------------------------------------------" >&2
@@ -118,5 +320,5 @@ if [ "$start_status" -ne 0 ]; then
 fi
 
 echo ""
-echo "==> stack is up and the fixture's own acceptance tests passed."
+echo "==> stack is up and ready."
 echo "    Next: $script_dir/write-network.sh"

--- a/e2e/local-regtest/write-network.sh
+++ b/e2e/local-regtest/write-network.sh
@@ -8,7 +8,18 @@
 # identity keys, published host ports, the admin token — are read out of the pinned checkout's own
 # files where possible, so a bump that changes them shows up here instead of silently disagreeing.
 #
-# Usage:  write-network.sh [output-path]
+# Usage:  write-network.sh [--docker] [output-path]
+#
+#   --docker   emit IN-NETWORK addresses instead of published loopback ports, for a client that runs
+#              inside the fixture's own docker network (`cashu_default`) rather than on the host. That
+#              is the BTCPay Server container the BtcpayE2E suite drives: from inside the network,
+#              `127.0.0.1:5000` is the BTCPay container itself and `localhost:8535` is nothing at all,
+#              so the descriptor has to name the compose services — `spark-operator-N:8535`,
+#              `spark-ssp:5000`, `spark-electrs:3002`. The default output path changes to
+#              network.docker.json so a --docker run cannot quietly replace the host descriptor the
+#              LocalRegtest suite is pointed at; the two are not interchangeable, and a wallet
+#              connected through the wrong one fails as a TLS or timeout error naming neither.
+#
 # Environment:
 #   CASHU_REGTEST_DIR      the fixture checkout (default: the one up.sh manages, alongside this script)
 #   COMPOSE_PROJECT_NAME   defaults to `cashu`, which is what the fixture's docker-scripts.sh exports
@@ -17,7 +28,42 @@ set -euo pipefail
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 checkout="${CASHU_REGTEST_DIR:-$script_dir/cashu-regtest}"
-output="${1:-$script_dir/network.json}"
+
+in_docker=0
+output=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --docker) in_docker=1 ;;
+    -h|--help) sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    -*) echo "error: unknown option $1" >&2; exit 1 ;;
+    *) output="$1" ;;
+  esac
+  shift
+done
+
+if [ -z "$output" ]; then
+  if [ "$in_docker" = 1 ]; then output="$script_dir/network.docker.json"; else output="$script_dir/network.json"; fi
+fi
+
+# The two address sets. Everything else in the descriptor is identical between them: the operators'
+# certificates, their identity keys, the SSP's identity and the whole fixture block are properties of
+# the stack, not of where the client sits.
+if [ "$in_docker" = 1 ]; then
+  # `spark-operator-<i>` is both the compose service name and the SAN the certificate carries, which is
+  # what makes this address verifiable at all; asserted per operator below rather than assumed.
+  operator_host_for() { printf 'spark-operator-%s' "$1"; }
+  operator_port_for() { printf '8535'; }
+  operator_san_for()  { printf 'DNS:spark-operator-%s' "$1"; }
+  ssp_base_url="http://spark-ssp:5000"
+  esplora_url="http://spark-electrs:3002"
+else
+  operator_host_for() { printf 'localhost'; }
+  # Every operator listens on 8535 inside the network; the compose file publishes them as 8535/8536/8537.
+  operator_port_for() { printf '%s' "$((8535 + $1))"; }
+  operator_san_for()  { printf 'DNS:localhost'; }
+  ssp_base_url="http://127.0.0.1:5000"
+  esplora_url="http://127.0.0.1:30000"
+fi
 
 # The fixture pins its compose project name in docker-scripts.sh (`export COMPOSE_PROJECT_NAME=cashu`)
 # rather than letting Compose derive it from the directory name. That is what makes the containers
@@ -121,14 +167,15 @@ for id in 0 1 2; do
   printf '%s' "$cert" | grep -q 'BEGIN CERTIFICATE' \
     || { echo "error: server_$id.crt does not look like a PEM certificate" >&2; exit 1; }
 
-  # The client connects to https://localhost:<port> from the host, so `localhost` has to be a name
-  # the certificate covers or the SDK's TLS handshake fails on hostname verification — and the
-  # certificate is the only thing pinned, since there is no CA to fall back on. spark-cert-init
-  # issues each cert with `subjectAltName = DNS:spark-operator-<i>,DNS:spark-operator-<i>.minikube
-  # .local,DNS:localhost`, so it does; this asserts it rather than assuming, because that SAN list
-  # is a line in the fixture's compose file and a bump could drop the localhost entry.
-  if ! printf '%s' "$cert" | openssl x509 -noout -ext subjectAltName 2>/dev/null | grep -q 'DNS:localhost'; then
-    echo "error: server_$id.crt has no DNS:localhost SAN, so a host client cannot verify it." >&2
+  # Whichever hostname the client will use has to be a name the certificate covers, or the SDK's TLS
+  # handshake fails on hostname verification — and the certificate is the only thing pinned, since
+  # there is no CA to fall back on. spark-cert-init issues each cert with
+  # `subjectAltName = DNS:spark-operator-<i>,DNS:spark-operator-<i>.minikube.local,DNS:localhost`, so
+  # both address sets are covered; this asserts the one actually being written rather than assuming,
+  # because that SAN list is a line in the fixture's compose file and a bump could drop either entry.
+  required_san="$(operator_san_for "$id")"
+  if ! printf '%s' "$cert" | openssl x509 -noout -ext subjectAltName 2>/dev/null | grep -q "$required_san"; then
+    echo "error: server_$id.crt has no $required_san SAN, so this client cannot verify it." >&2
     echo "       Check spark-cert-init's -addext subjectAltName in the fixture's docker-compose.yml." >&2
     exit 1
   fi
@@ -144,7 +191,7 @@ for id in 0 1 2; do
   operators_json="$(jq \
     --argjson id "$id" \
     --arg identifier "$(printf '%064x' $((id + 1)))" \
-    --arg address "https://localhost:$((8535 + id))" \
+    --arg address "https://$(operator_host_for "$id"):$(operator_port_for "$id")" \
     --arg identityPublicKey "$identity_public_key" \
     --arg caCertPem "$cert" \
     '. + [{id: $id, identifier: $identifier, address: $address,
@@ -158,6 +205,8 @@ mkdir -p "$(dirname -- "$output")"
 # newlines is the classic way this file ends up unparseable.
 jq -n \
   --argjson operators "$operators_json" \
+  --arg sspBaseUrl "$ssp_base_url" \
+  --arg esploraUrl "$esplora_url" \
   --arg sspIdentityPublicKey "$ssp_identity" \
   --arg bitcoindContainer "$bitcoind_container" \
   --arg lndContainer "$lnd_container" \
@@ -168,11 +217,11 @@ jq -n \
     threshold: 2,
     operators: $operators,
     ssp: {
-      baseUrl: "http://127.0.0.1:5000",
+      baseUrl: $sspBaseUrl,
       identityPublicKey: $sspIdentityPublicKey,
       schemaEndpoint: "graphql/spark/rc"
     },
-    esploraUrl: "http://127.0.0.1:30000",
+    esploraUrl: $esploraUrl,
     fixture: {
       bitcoindContainer: $bitcoindContainer,
       bitcoindRpcUser: "cashu",
@@ -186,7 +235,13 @@ jq -n \
 
 output_abs="$(cd -- "$(dirname -- "$output")" && pwd)/$(basename -- "$output")"
 echo ""
-echo "Descriptor written. Point the suite at it with:"
-echo ""
-echo "  export SPARK_LOCAL_REGTEST_NETWORK=$output_abs"
+if [ "$in_docker" = 1 ]; then
+  echo "In-network descriptor written ($output_abs)."
+  echo "It is only usable from inside the ${COMPOSE_PROJECT_NAME}_default docker network; e2e/btcpay/up.sh"
+  echo "mounts it into the BTCPay container and sets SPARK_LOCAL_REGTEST_NETWORK to the mounted path."
+else
+  echo "Descriptor written. Point the suite at it with:"
+  echo ""
+  echo "  export SPARK_LOCAL_REGTEST_NETWORK=$output_abs"
+fi
 echo ""


### PR DESCRIPTION
Stacked on #70. Three follow-ups, wired so **every `v*` tag build runs the whole local stack before packaging**.

## Release gate
- `local-regtest.yml` gains `workflow_call` with a `blocking` input (default true). The job is blocking when called or when the PR head is `release/*`; advisory on ordinary PRs, schedule and dispatch until there is a flake rate.
- `package.yml` calls it on every tag and `package` `needs` it. A release cannot be built over a red stack. Manual dispatch of `package.yml` (artifact inspection) is unaffected.

## Prebuilt fixture images
- `local-regtest-images.yml` builds the four source-built images (Spark operator, open-ssp, Electrs, ldk-server; linux/amd64) with `buildx bake` over the fixture's own compose file and pushes `ghcr.io/sethforprivacy/flint-regtest/<image>:<fixture-sha>`.
- `up.sh` pulls and retags them so compose skips the ~40 min source build; falls back to building on any pull failure (forks, arm64).

## Leaner, steadier init
`up.sh` runs the fixture's init chain itself: no acceptance suites, and **no `cashu-fees-init`**, whose fee-hub gossip wait timed out on this job's first ubuntu-latest run (and in 2 of the fixture's own 3 preceding CI runs). Nothing here routes through that hub. One retry from a clean stop covers the fixture's other asynchronous waits.

## BTCPay e2e layer (`Category=BtcpayE2E`)
`e2e/btcpay/up.sh` starts the official `btcpayserver:2.4.4` image + NBXplorer + Postgres on the fixture's network, side-loads the Release build as a plugin directory, provisions admin/store/API key/Flint wallet over Greenfield, funds the wallet, writes `btcpay.json`. Three tests over the Greenfield API: LND pays a store invoice → Settled; the store's Lightning API pays an LND invoice → LND SETTLED; manual sweep → Swept → Confirmed on-chain. SSP leaf liquidity is topped up automatically to 5× funding.

**Plugin change:** `SparkService` passes `SparkCustomNetworkFile.TryLoadFromEnvironment()` on regtest only, so a BTCPay inside the stack connects through the plugin's real store-connect path. Not read off regtest; the factory refuses it off regtest regardless; an unreadable descriptor stops the wallet rather than falling back.

Found on the way and documented: Greenfield wallet provisioning needs `btcpay.server.canmodifyserversettings` on the API key — BTCPay's hot-wallet check judges the key, not its owner.

## Verified (Apple Silicon)
| check | result |
|---|---|
| full cycle: down → up → descriptor → LocalRegtest → BTCPay up → BtcpayE2E | green, **4 m 32 s** with cached images (3/3 + 3/3) |
| unit suite | 1253 passed, 0 failed |
| actionlint, shellcheck | clean |

## Left open
- One unreproduced BtcpayE2E receive timeout (LND paid, BTCPay stayed `New` for 4 min; 1 of 4 cycles, no logs captured). The workflow now uploads BTCPay's logs on failure.
- Linux/amd64 path of `e2e/btcpay/up.sh` and the `blocking` gate are exercised only by CI. Watch this PR's run and the first tag build.

## After merge
1. `local-regtest-images.yml` is dispatched on this branch; until it finishes, runs fall back to the source build.
2. Make the four GHCR packages public so forks can pull them.
3. Do **not** add `local-regtest` as a required branch-protection check; it blocks where it should through its own expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
