### PR TITLE
Fix the image-publish workflow's bake source

### DIFF
--- a/.github/workflows/local-regtest-images.yml
+++ b/.github/workflows/local-regtest-images.yml
@@ -166,6 +166,11 @@ jobs:
       - name: Build and push
         uses: docker/bake-action@d3418bd7d0e9324001bca92fa8ba175ea7e6dc9b # v7.3.0
         with:
+          # `source: .` is load-bearing. Without it bake-action builds from its default *git* context —
+          # this repository at the triggering commit — where there is no docker-compose.yml, and the
+          # first run on main failed with "lstat docker-compose.yml: no such file or directory". With it,
+          # the definition and every build context resolve inside the fixture checkout under `workdir`.
+          source: .
           workdir: cashu-regtest
           files: |
             docker-compose.yml


### PR DESCRIPTION
The first run of `local-regtest-images.yml` on main failed at bake with `lstat docker-compose.yml: no such file or directory`: docker/bake-action defaults `source` to this repository's git context rather than the checked-out fixture directory. `source: .` fixes that. On merge the workflow re-triggers itself (its push trigger watches its own path) and should publish the four images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)