### PR TITLE
Restore the NuGet cache without a post-save step in local-regtest

### DIFF
--- a/.github/workflows/local-regtest.yml
+++ b/.github/workflows/local-regtest.yml
@@ -132,17 +132,17 @@ jobs:
       # Same key as every job in ci.yml, exact on the csproj hashes with no `restore-keys` prefix
       # fallback, so a warm cache from a different dependency set is never adopted.
       #
-      # `!e2e/**` is not in ci.yml's key and does not change it: e2e/ holds no csproj, so the hashed file
-      # set is identical. It is here because hashFiles is evaluated TWICE — once at restore, once in the
-      # action's post step at the end of the job — and by then e2e/ contains the fixture checkout and
-      # the BTCPay data directory, with files the containers wrote as root that the runner user cannot
-      # read. Walking into them made the post-step hash fail ("Fail to hash files under directory") on
-      # this workflow's first green run, which lost the cache save and put a red step on a passing job.
-      - name: Cache NuGet packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # RESTORE ONLY, deliberately. The full `actions/cache` adds a post step that re-evaluates
+      # hashFiles at the end of the job, and by then e2e/ holds the fixture checkout and BTCPay data
+      # written by containers as root; the walk fails on those ("Fail to hash files under directory"),
+      # and it does so even with a `!e2e/**` exclusion, because the walker descends before it filters.
+      # Two green runs carried a red post step for that. This job never needs to save: ci.yml writes
+      # this exact key on every push and PR, so a miss here only means one network restore.
+      - name: Restore NuGet packages
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
-          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', '!e2e/**') }}
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj') }}
 
       - name: Build (plugin + tests)
         # -m:1 serialises MSBuild project scheduling. Not for speed obviously, but for correctness:


### PR DESCRIPTION
Two green runs of `local-regtest.yml` on main carried a failed `Post Cache NuGet packages` step: the cache action re-evaluates `hashFiles` at the end of the job, when `e2e/` holds root-owned files the fixture's containers wrote, and the walk fails even with a `!e2e/**` exclusion (it descends before filtering). This job never needs to save the cache — ci.yml writes the same key on every push and PR — so it now uses `actions/cache/restore`, same pinned SHA, same key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)